### PR TITLE
Version 3.1.0: Rimworld v1.5 support + a lot more

### DIFF
--- a/CryoRegenesis/About/About.xml
+++ b/CryoRegenesis/About/About.xml
@@ -7,6 +7,7 @@
 		<li>1.2</li>
 		<li>1.3</li>
 		<li>1.4</li>
+		<li>1.5</li>
 	</supportedVersions>
 	<description>Adds a new Cryo Casket which reverses aging and related illnesses.\n\nCredit to cat2002 for the original project and Allet for the art</description>
 </ModMetaData>

--- a/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
+++ b/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
@@ -61,6 +61,7 @@
 				</fuelFilter>
 				<destroyOnNoFuel>false</destroyOnNoFuel>
 			</li>
+			<li Class="CompProperties_Flickable"/>
 		</comps>
 		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<staticSunShadowHeight>0.4</staticSunShadowHeight>

--- a/README.md
+++ b/README.md
@@ -24,45 +24,58 @@ on more Rimworlds than most humans!
 ## Changelog
 
 **Version 1.0: 2020-08-11**
- * All of the core functionality.
- * Added support for Rimworld v1.2.
+* **[2020-08-10 22:11:40 CDT]** All of the core functionality.
+* **[2020-08-11 09:11:17 CDT]** Added support for Rimworld v1.2.
 
 **Version 1.1: 2021-06-17**
- * Ignore "missing body parts" for more efficient handling of bionics.
- * Reset the pawn's rest, joy and comfort levels on reawakening.
+* **[2021-06-17 23:38:02 CDT]** Ignore "missing body parts" for more efficient handling of bionics.
+* **[2021-06-17 23:39:56 CDT]** Reset the pawn's rest, joy and comfort levels on reawakening.
 
 **Version 2.0: 2021-10-28**
- * Show the Contents tab with the pawn inside.
- * Added the "Time To Heal" to the casket display.
- * Added support for compiling for both Rimworld v1.2 and v1.3.
- * Don't heal over bionics, but do heal peg legs, etc.
- * Added Linux build support.
+* **[2021-10-28 00:35:43 CDT]** Added Linux build support.
+* **[2021-10-28 01:00:32 CDT]** [m] Don't copy over all of the assemblies.
+* **[2021-10-28 02:52:26 CDT]** Don't heal over bionics, but do heal peg legs, etc.
+* **[2021-10-28 06:26:09 CDT]** Added support for compiling for both Rimworld v1.2 and v1.3.
+* **[2021-10-28 06:57:34 CDT]** [m] Added a deploy script.
+* **[2021-10-28 07:59:53 CDT]** Added the "Time To Heal" to the casket display.
+* **[2021-10-28 08:31:10 CDT]** Show the Contents tab with the pawn inside.
 
 **Version 2.5: 2022-01-29**
- * Heal the pawn no matter what.
- * Eject the pawn when there are no more injuries. origin/master
- * Increased the cost to build by 250 Gold.
- * Reverse age any pawn that enters healthy.
- * Completely ignore missing body parts due to bionics.
- * Properly count Old Age disabilities.
- * Properly determine healing frequency for species with lower life expenctancies.
- * [2022-01-29] - Now the chamber reanalyzes for new injuries after each healing.
+* **[2021-10-29 02:51:52 CDT]** FIXED: Age is shown when there are no injuries. origin/v2.0
+* **[2022-01-28 17:10:00 CDT]** Heal the pawn no matter what.
+* **[2022-01-28 17:11:00 CDT]** Eject the pawn when there are no more injuries.
+* **[2022-01-29 11:51:07 CDT]** Increased the cost to build by 250 Gold.
+* **[2022-01-29 11:59:46 CDT]** Reverse age any pawn that enters healthy.
+* **[2022-01-29 12:00:53 CDT]** Completely ignore missing body parts due to bionics.
+* **[2022-01-29 12:01:15 CDT]** Properly count Old Age disabilities.
+* **[2022-01-29 12:02:11 CDT]** Properly determine healing frequency for species with lower life expenctancies.
+* **[2022-01-29 12:10:02 CDT]** Now the chamber reanalyzes for new injuries after each healing.
 
 **Version 2.6: 2023-01-13**
- * [2022-05-26] - Reverse the age of animals completely.
- * [2023-01-13] - Moved the Defs into the standard location.
- * [2023-01-13] - Automatically package all of the supported versions DLLs into the v1.2 Mod directory.
- * [2023-01-13] - Upgraded to Rimworld v1.4.3580.
-<
+* **[2022-05-26 06:13:10 CDT]** Reverse the age of animals completely.
+* **[2023-01-13 05:12:40 CDT]** Moved the Defs into the standard location.
+* **[2023-01-13 05:15:43 CDT]** Automatically package all of the supported versions DLLs into the v1.2 Mod directory.
+* **[2023-01-13 05:16:45 CDT]** Upgraded to Rimworld v1.4.3580.
+
 **Version 3.0: 2023-05-22**
- * Re-added more hair colors.
- * Added Mod Settings.
- * Enabled the new optional debug messaging system.
- * Added a new option to only regen until the pawn is healed.
- * Added a new option for the target age of Human pawns.
- * Added an option to not try to heal anything that isn't tendable.
- * Added functionality to never heal implants.
- * Block non-colonist humans from being placed in the casket.
+* **[2023-03-26 06:41:29 CDT]** Re-added more hair colors.
+* **[2023-05-21 10:41:18 CDT]** [m] Update README.md: Added info about Cargo.
+* **[2023-05-22 00:30:13 CDT]** [m] Added a proper Mod class.
+* **[2023-05-22 00:32:17 CDT]** Added Mod Settings.
+* **[2023-05-22 00:38:56 CDT]** [m] Rearranged the SpawnSetup method.
+* **[2023-05-22 00:42:55 CDT]** Enabled the new optional debug messaging system.
+* **[2023-05-22 00:43:34 CDT]** Added a new option to only regen until the pawn is healed.
+* **[2023-05-22 00:44:19 CDT]** Added a new option for the target age of Human pawns.
+* **[2023-05-22 00:47:24 CDT]** Added an option to not try to heal anything that isn't tendable.
+* **[2023-05-22 00:47:45 CDT]** Added functionality to never heal implants.
+* **[2023-05-22 01:31:53 CDT]** Block non-colonist humans from being placed in the casket to avoid CryoRegenesis Quantum Anomaly (Bug #6).
 
 **Version 3.0.1: 2023-07-28**
- * Fixed a bug that prohibited animals from being put in the cryocasket.
+* **[2023-07-28 16:43:18 CDT]** Fixed a bug that prohibited animals from being put in the cryocasket.
+
+**Version 3.1.0: 2024-03-15**
+* **[2024-03-15 01:44:12 CDT]** [m] Majorly refactored the deploy script.
+* **[2024-03-15 01:44:32 CDT]** Upgraded to Rimworld v1.5. master
+* **[2024-03-15 01:46:43 CDT]** Made the CryoRegenesis flickable (turns it into a normal cryocasket).
+* **[2024-03-15 01:47:43 CDT]** Added optional code (enabled by default) to not heal any hediffs that are not marked as "bad".
+* **[2024-03-15 02:16:24 CDT]** Cured the CyroRegenesis Quantum Anomaly that broke when guests were put in.

--- a/Source/CryoRegenesis/CryoRegenesis.cs
+++ b/Source/CryoRegenesis/CryoRegenesis.cs
@@ -133,7 +133,7 @@ namespace BetterRimworlds.CryoRegenesis
             };
             this.hediffsToHeal = new List<Hediff>();
 
-            #if RIMWORLD14
+            #if RIMWORLD14 || RIMWORLD15
             var hediffsOfPawn = new List<Hediff>();
             pawn.health.hediffSet.GetHediffs<Hediff>(ref hediffsOfPawn);
             foreach (Hediff hediff in hediffsOfPawn.ToList())
@@ -401,7 +401,7 @@ namespace BetterRimworlds.CryoRegenesis
 
                 if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * targetAge)
                 {
-                    #if RIMWORLD14
+                    #if RIMWORLD14 || RIMWORLD15
                     power.PowerOutput = -props.PowerConsumption;
                     #else
                     power.PowerOutput = -props.basePowerConsumption;
@@ -481,17 +481,21 @@ namespace BetterRimworlds.CryoRegenesis
 
         protected void rerenderPawn(Pawn pawn)
         {
+            #if !RIMWORLD15
             // Tell the pawn's Drawer that the Person has had a hair-change makeover.
             // This code is from https://github.com/KiameV/rimworld-changedresser/blob/f0b8fcf9073cd1c232fcd26b0b083cb3137924a3/Source/UI/DresserUI.cs
             // Copyright (c) 2017 Travis Offtermatt
             // MIT License
             pawn.Drawer.renderer.graphics.ResolveAllGraphics();
+            #else
+            pawn.Drawer.renderer.renderTree.SetDirty();
+            #endif
             PortraitsCache.SetDirty(pawn);
         }
 
         protected void changeHairColor(Pawn pawn, Color hairColor)
         {
-            #if RIMWORLD14
+            #if RIMWORLD14 || RIMWORLD15
             pawn.story.HairColor = hairColor;
             #else
             pawn.story.hairColor = hairColor;
@@ -517,7 +521,7 @@ namespace BetterRimworlds.CryoRegenesis
         protected bool hasWhiteOrGrayHair(Pawn pawn)
         {
             string hsv;
-            #if RIMWORLD14
+            #if RIMWORLD14 || RIMWORLD15
             Color hairColor = pawn.story.HairColor;
             #else
             Color hairColor = pawn.story.hairColor;
@@ -622,7 +626,7 @@ namespace BetterRimworlds.CryoRegenesis
                 restoreCoolDown = -1000;
                 enterTime = Find.TickManager.TicksGame;
 
-                #if RIMWORLD14
+                #if RIMWORLD14 || RIMWORLD15
                 power.PowerOutput = -props.PowerConsumption;
                 #else
                 power.PowerOutput = -props.basePowerConsumption;

--- a/Source/CryoRegenesis/CryoRegenesis.cs
+++ b/Source/CryoRegenesis/CryoRegenesis.cs
@@ -195,6 +195,12 @@ namespace BetterRimworlds.CryoRegenesis
                     }
                 }
 
+                // Ignore a hediff not marked as bad...
+                if (CryoRegenesis.Settings.healNotBad == false && hediff.def.isBad == false)
+                {
+                    continue;
+                }
+
                 this.hediffsToHeal.Add(hediff);
                 if (CryoRegenesis.Settings.debugMode) Log.Message(hediff.def.description + " ( " + hediff.def.hediffClass + ") = " + hediff.def.causesNeed + ", " + hediff.GetType().Name);
             }

--- a/Source/CryoRegenesis/CryoRegenesis.cs
+++ b/Source/CryoRegenesis/CryoRegenesis.cs
@@ -432,7 +432,7 @@ namespace BetterRimworlds.CryoRegenesis
             Pawn pawn = ContainedThing as Pawn;
             pawn.health.AddHediff(cryosickness);
 
-            if (pawn.def.defName == "Human")
+            if (pawn.IsColonist == true && pawn.NonHumanlikeOrWildMan() == false)
             {
                 // Remove negative and now-irrelevant thoughts:
                 pawn.needs.mood.thoughts.memories.RemoveMemoriesOfDef(ThoughtDefOf.MyOrganHarvested);
@@ -449,13 +449,6 @@ namespace BetterRimworlds.CryoRegenesis
                 pawn.needs.comfort.SetInitialLevel();
 
                 this.possiblyChangeHairColor(pawn);
-
-                // if (pawn.IsColonist == false)
-                // {
-                //     // Remove the guest from the Forcefully Kept WorldPawns.
-                //     RimWorld.Planet.WorldPawns worldPawns = Find.WorldPawns;
-                //     worldPawns.ForcefullyKeptPawns.Remove(pawn);
-                // }
             }
 
             pawn.needs.rest.SetInitialLevel();
@@ -463,6 +456,13 @@ namespace BetterRimworlds.CryoRegenesis
 
             power.PowerOutput = 0;
             base.EjectContents();
+
+            // if (pawn.IsColonist == false)
+            // {
+            //     // Remove the guest from the Forcefully Kept WorldPawns.
+            //     RimWorld.Planet.WorldPawns worldPawns = Find.WorldPawns;
+            //     worldPawns.ForcefullyKeptPawns.Remove(pawn);
+            // }
         }
 
         protected List<Color> getHairColors()
@@ -621,11 +621,6 @@ namespace BetterRimworlds.CryoRegenesis
             }
 
             var pawn = thing as Pawn;
-            if (thing is Pawn && pawn.RaceProps.Humanlike && pawn.IsColonist == false)
-            {
-                // Reject to avoid the bad bug.
-                return false;
-            }
 
             if (base.TryAcceptThing(thing, allowSpecialEffects))
             {

--- a/Source/CryoRegenesis/CryoRegenesis.csproj
+++ b/Source/CryoRegenesis/CryoRegenesis.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release v1.2|AnyCPU' ">
     <Optimize>true</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>RIMWORLD12</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>/rimworld/1.2/Mods/CryoRegenesis/1.2/Assemblies</OutputPath>
@@ -40,6 +40,11 @@
     <DefineConstants>RIMWORLD14</DefineConstants>
     <OutputPath>/rimworld/1.4/Mods/CryoRegenesis/1.4/Assemblies</OutputPath>
     <MainPath>/rimworld/1.2/Mods/CryoRegenesis/1.4/Assemblies</MainPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release v1.5|AnyCPU' ">
+    <DefineConstants>RIMWORLD15</DefineConstants>
+    <OutputPath>/rimworld/1.5/Mods/CryoRegenesis/1.5/Assemblies</OutputPath>
+    <MainPath>/rimworld/1.2/Mods/CryoRegenesis/1.5/Assemblies</MainPath>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release v1.2|AnyCPU' ">
@@ -129,6 +134,29 @@
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\..\rimworld\1.4\RimWorldLinux_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release v1.5|AnyCPU' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Assembly-CSharp">
+      <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/CryoRegenesis/CryoRegenesis.sln
+++ b/Source/CryoRegenesis/CryoRegenesis.sln
@@ -8,19 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Release v1.2|Any CPU = Release v1.2|Any CPU
-		Debug v1.2|Any CPU = Debug v1.2|Any CPU
 		Release v1.3|Any CPU = Release v1.3|Any CPU
 		Release v1.4|Any CPU = Release v1.4|Any CPU
+		Release v1.5|Any CPU = Release v1.5|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.2|Any CPU.ActiveCfg = Release v1.2|Any CPU
-		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.2|Any CPU.Build.0 = Release v1.2|Any CPU
-		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Debug v1.2|Any CPU.ActiveCfg = Debug v1.2|Any CPU
-		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Debug v1.2|Any CPU.Build.0 = Debug v1.2|Any CPU
+		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.2|Any CPU.Build.0   = Release v1.2|Any CPU
 		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.3|Any CPU.ActiveCfg = Release v1.3|Any CPU
-		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.3|Any CPU.Build.0 = Release v1.3|Any CPU
-		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.4|Any CPU.Build.0 = Release v1.4|Any CPU
+		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.3|Any CPU.Build.0   = Release v1.3|Any CPU
+		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.4|Any CPU.Build.0   = Release v1.4|Any CPU
 		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.4|Any CPU.ActiveCfg = Release v1.4|Any CPU
+		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.5|Any CPU.Build.0   = Release v1.5|Any CPU
+		{675CE9D5-460C-496A-A6A9-8D3873EDEE87}.Release v1.5|Any CPU.ActiveCfg = Release v1.5|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/CryoRegenesis/Settings.cs
+++ b/Source/CryoRegenesis/Settings.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using UnityEngine;
 using Verse;
 
@@ -9,6 +8,7 @@ namespace BetterRimworlds.CryoRegenesis
         public int targetAge = 21;
         public bool regenUntilHealed = true;
         public bool healSimpleProsthetics = true;
+        public bool healNotBad = false;
 
         public bool debugMode = false;
 
@@ -17,6 +17,7 @@ namespace BetterRimworlds.CryoRegenesis
             Scribe_Values.Look(ref targetAge,             "brw.cryoregenesis.targetAge", 21);
             Scribe_Values.Look(ref regenUntilHealed,      "brw.cryoregenesis.regenUntilHealed", true);
             Scribe_Values.Look(ref healSimpleProsthetics, "brw.cryoregenesis.healSimpleProsthetics", true);
+            Scribe_Values.Look(ref healNotBad,            "brw.cryoregenesis.healNotBad", false);
             Scribe_Values.Look(ref debugMode,             "brw.cryoregenesis.debugMode", false);
         }
 
@@ -29,6 +30,7 @@ namespace BetterRimworlds.CryoRegenesis
                 "Target age for regening Humans:",
                 "Stop regenerating when a Human is fully healed? ",
                 "Heal simple and wooden prosthetics?",
+                "Heal non-bad body mods?",
                 "Print debug messages?",
             };
 
@@ -38,7 +40,8 @@ namespace BetterRimworlds.CryoRegenesis
 
             listing_Standard.CheckboxLabeled(labels[1],  ref regenUntilHealed);
             listing_Standard.CheckboxLabeled(labels[2],  ref healSimpleProsthetics);
-            listing_Standard.CheckboxLabeled(labels[3],  ref debugMode);
+            listing_Standard.CheckboxLabeled(labels[3],  ref healNotBad);
+            listing_Standard.CheckboxLabeled(labels[4],  ref debugMode);
 
             listing_Standard.End();
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 
-IS_WINDOWS=0
-RIMWORLD1_2=/rimworld/1.2
-RIMWORLD1_3=/rimworld/1.3
-
-# Assume Windows (and NOT WSL2)...
-if [ ! -z $WINDIR ]; then
-    IS_WINDOWS=1
-    RIMWORLD1_2=/c/RimWorld1-2-2900Win64
-    RIMWORLD1_3=/c/RimWorld1-3-3162Win64
+if [ ! $1 ]; then
+    echo "Error: The mod version is required."
+    exit
 fi
 
-for RIMHOME in $RIMWORLD1_2 $RIMWORLD1_3; do
-	rsync -rcv --delete-after README.md About Defs Textures $RIMHOME/Mods/CryoRegenesis/
-	unix2dos $RIMHOME/Mods/CryoRegenesis/README.md
+rm -rf /rimworld/1.2/Mods/CryoRegenesis
 
-    if [[ $IS_WINDOWS -eq 1 ]]; then
-	    rsync -rcv --delete-after $RIMHOME/Mods/CryoRegenesis "/c/Program Files (x86)/Steam/steamapps/common/RimWorld/Mods/"
-	fi
-done
+unix2dos README.md
+rsync -rcv --delete-after README.md CryoRegenesis/About CryoRegenesis/Defs CryoRegenesis/Textures  /rimworld/1.2/Mods/CryoRegenesis/
+rsync -rcv --delete-after README.md CryoRegenesis/About CryoRegenesis/Defs CryoRegenesis/Textures  /rimworld/1.3/Mods/CryoRegenesis/
+rsync -rcv --delete-after README.md CryoRegenesis/About CryoRegenesis/Defs CryoRegenesis/Textures  /rimworld/1.4/Mods/CryoRegenesis/
+rsync -rcv --delete-after README.md CryoRegenesis/About CryoRegenesis/Defs CryoRegenesis/Textures  /rimworld/1.5/Mods/CryoRegenesis/
+rsync -rcv --delete-after README.md CryoRegenesis/About CryoRegenesis/Defs CryoRegenesis/Textures  $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis/
+rsync -rcv /rimworld/1.2/Mods/CryoRegenesis/1.2 $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis/
+rsync -rcv /rimworld/1.3/Mods/CryoRegenesis/1.3 $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis/
+rsync -rcv /rimworld/1.4/Mods/CryoRegenesis/1.4 $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis/
+rsync -rcv /rimworld/1.4/Mods/CryoRegenesis/1.5 $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis/
 
+rsync -rcv --delete-after $HOME/.steam/steam/steamapps/common/RimWorld/Mods/CryoRegenesis /rimworld/1.2/Mods
+dos2unix README.md
+(cd /rimworld/1.2/Mods && zip -r CryoRegenesis-$1.zip CryoRegenesis && cp CryoRegenesis-$1.zip /tmp)
 


### PR DESCRIPTION
**Version 3.1.0: 2024-03-15**
* **[2024-03-15 01:44:12 CDT]** [m] Majorly refactored the deploy script.
* **[2024-03-15 01:44:32 CDT]** Upgraded to Rimworld v1.5. master
* **[2024-03-15 01:46:43 CDT]** Made the CryoRegenesis flickable (turns it into a normal cryocasket).
* **[2024-03-15 01:47:43 CDT]** Added optional code (enabled by default) to not heal any hediffs that are not marked as "bad".
* **[2024-03-15 02:16:24 CDT]** Cured the CyroRegenesis Quantum Anomaly that broke when guests were put in (Issue #6).
