### PR TITLE
Version 5.1.0

### DIFF
--- a/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
+++ b/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
@@ -2,14 +2,13 @@
 <Defs>
     <ThoughtDef>
         <defName>CryoRegenesis_LuciferiumSideEffect</defName>
-        <thoughtClass>Thought_Memory</thoughtClass>
-        <durationDays>60</durationDays>
+        <thoughtClass>BetterRimworlds.CryoRegenesis.Thought_CryoRegenesis_LuciferiumSideEffect</thoughtClass>
         <stackLimit>1</stackLimit>
         <stages>
             <li>
                 <label>grateful to be alive</label>
                 <description>I'm so happy to be alive. A little luci forever is worth it!</description>
-                <baseMoodEffect>28</baseMoodEffect>
+                <baseMoodEffect>45</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>

--- a/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
+++ b/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
@@ -15,37 +15,21 @@
     <ThoughtDef>
         <defName>CryoRegenesis_BodyPositivity</defName>
         <thoughtClass>BetterRimworlds.CryoRegenesis.Thought_RegenesisBodyPositivity</thoughtClass>
-        <durationDays>30</durationDays>
         <stages>
             <li>
                 <label>Regenerated</label>
-                <description>I feel a few years younger.</description>
-                <baseMoodEffect>15</baseMoodEffect>
-                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
                 <label>Mildly regenerated</label>
-                <description>I feel 10 years younger! The weight of time has been lifted from my body.</description>
-                <baseMoodEffect>20</baseMoodEffect>
-                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
                 <label>Substantially regenerated</label>
-                <description>20 years erased! My joints move smoothly again and my energy is returning.</description>
-                <baseMoodEffect>25</baseMoodEffect>
-                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
                 <label>Majorly regenerated</label>
-                <description>40 years gone! I recognize my younger self in the mirror.</description>
-                <baseMoodEffect>35</baseMoodEffect>
-                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
                 <label>Fully regenerated</label>
-                <description>My body feels like it did in my earliest adulthood - fresh, strong, and full of potential!</description>
-                <baseMoodEffect>40</baseMoodEffect>
-                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
         </stages>
     </ThoughtDef>

--- a/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
+++ b/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
@@ -13,30 +13,39 @@
         </stages>
     </ThoughtDef>
     <ThoughtDef>
-        <defName>CryoRegenesis_LifeStageReversed</defName>
-        <thoughtClass>Thought_Memory</thoughtClass>
-        <durationDays>60</durationDays>
-        <stackLimit>1</stackLimit>
+        <defName>CryoRegenesis_BodyPositivity</defName>
+        <thoughtClass>BetterRimworlds.CryoRegenesis.Thought_RegenesisBodyPositivity</thoughtClass>
+        <durationDays>30</durationDays>
         <stages>
             <li>
-                <label>[Regenesis] I feel younger.</label>
-                <description>I feel 20 years younger! The weight of time has been lifted from my body.</description>
+                <label>Regenerated</label>
+                <description>I feel a few years younger.</description>
                 <baseMoodEffect>15</baseMoodEffect>
+                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
-                <label>[Regenesis] Substantially regenerated</label>
-                <description>40 years erased! My joints move smoothly again and my energy is returning.</description>
+                <label>Mildly regenerated</label>
+                <description>I feel 10 years younger! The weight of time has been lifted from my body.</description>
+                <baseMoodEffect>20</baseMoodEffect>
+                <visibleInNeedsTab>true</visibleInNeedsTab>
+            </li>
+            <li>
+                <label>Substantially regenerated</label>
+                <description>20 years erased! My joints move smoothly again and my energy is returning.</description>
                 <baseMoodEffect>25</baseMoodEffect>
+                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
-                <label>[Regenesis] Majorly regenerated</label>
-                <description>60 years gone! I recognize my younger self in the mirror - the vigor of my prime is returning!</description>
+                <label>Majorly regenerated</label>
+                <description>40 years gone! I recognize my younger self in the mirror.</description>
                 <baseMoodEffect>35</baseMoodEffect>
+                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
             <li>
-                <label>[Regenesis] Fully regenerated</label>
+                <label>Fully regenerated</label>
                 <description>My body feels like it did in my earliest adulthood - fresh, strong, and full of potential!</description>
                 <baseMoodEffect>40</baseMoodEffect>
+                <visibleInNeedsTab>true</visibleInNeedsTab>
             </li>
         </stages>
     </ThoughtDef>

--- a/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
+++ b/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>نقل الجثة إلى تابوت التجديد البارد</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>نقل الجثة إلى تابوت التجديد البارد</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>يجب تحديد جثة</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>لا توجد جثات لنقلها إلى تابوت التجديد البارد</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>تجدد بالكامل</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>تجدد بشكل كبير</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>تجدد جوهري</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>تجدد طفيف</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>متجدد</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>يشعر جسدي كما في شبابي المبكر: منتعش وقوي ومليء بالإمكانيات!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>تم محو {0} عامًا! أتعرف على ذاتي الأصغر في المرآة: حيوية شبابي تعود!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>تم محو {0} عامًا! مفاصلي تتحرك بسلاسة مرة أخرى وطاقتي تعود.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>أشعر بأنني أصغر بـ {0} عامًا! ثقل الزمن قد أُزيل من جسدي.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>أشعر بأنني أصغر ببضع سنوات.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
+++ b/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportar cadàver a un sarcòfag de crioregeneració</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportar cadàver a un sarcòfag de crioregeneració</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Cal designar un cadàver</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>No hi ha cadàvers per transportar al sarcòfag de crioregeneració</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completament regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Majoritàriament regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substancialment regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Lleugerament regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>El meu cos se sent com a la meva joventut primerenca: fresc, fort i ple de potencial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} anys esborrats! Reconec el meu jo més jove al mirall: el vigor de la meva joventut està tornant!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anys esborrats! Les meves articulacions tornen a moure's amb suavitat i la meva energia està tornant.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Em sento {0} anys més jove! El pes del temps ha estat alliberat del meu cos.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Em sento uns anys més jove.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
+++ b/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>将尸体运送至低温再生棺</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>将尸体运送至低温再生棺</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>必须指定一具尸体</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>没有可运送至低温再生棺的尸体</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>完全再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>大幅再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>显著再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>轻微再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>已再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>我的身体感觉像是回到了青春初期：清新、强壮、充满潜力！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>抹去了{0}年！我在镜中认出了年轻的自己：青春的活力正在回归！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>抹去了{0}年！我的关节重新灵活转动，精力正在恢复。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>我感觉年轻了{0}岁！时间的重负已从我的身上卸下。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感觉年轻了几岁。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
+++ b/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>將屍體運送至低溫再生棺</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>將屍體運送至低溫再生棺</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>必須指定一具屍體</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>沒有可運送至低溫再生棺的屍體</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>完全再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>大幅再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>顯著再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>輕微再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>已再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>我的身體感覺像是回到了青春初期：清新、強壯、充滿潛力！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>抹去了{0}年！我在鏡中認出了年輕的自己：青春的活力正在回歸！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>抹去了{0}年！我的關節重新靈活轉動，精力正在恢復。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>我感覺年輕了{0}歲！時間的重負已從我的身上卸下。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感覺年輕了幾歲。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
+++ b/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Czech/Keyed/Czech.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Přenést mrtvolu do kryoregeneračního sarkofágu</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Přenést mrtvolu do kryoregeneračního sarkofágu</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Je nutné označit mrtvolu</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Žádné mrtvoly k přenesení do kryoregeneračního sarkofágu</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Plně regenerován</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Výrazně regenerován</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Významně regenerován</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Mírně regenerován</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerován</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Mé tělo se cítí jako v raném mládí: svěží, silné a plné potenciálu!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>Smazáno {0} let! V zrcadle vidím své mladší já: vitalita mého mládí se vrací!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>Smazáno {0} let! Mé klouby se opět hladce pohybují a má energie se vrací.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Cítím se o {0} let mladší! Břímě času bylo sejmuto z mého těla.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítím se o několik let mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
+++ b/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Danish/Keyed/Danish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transporter lig til kryptekammer med kryoregenerering</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transporter lig til kryptekammer med kryoregenerering</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Der skal udpeges et lig</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Der er ingen lig at transportere til kryptekammeret med kryoregenerering</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Helt regenereret</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Overvejende regenereret</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substantielt regenereret</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Let regenereret</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenereret</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Min krop føles som i min tidlige ungdom: frisk, stærk og fuld af potentiale!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} år slettet! Jeg genkender mit yngre jeg i spejlet: min ungdoms kraft vender tilbage!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år slettet! Mine led bevæger sig igen smidigt, og min energi vender tilbage.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jeg føler mig {0} år yngre! Tidens byrde er blevet fjernet fra min krop.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler mig nogle år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
+++ b/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transporteer lijk naar cryoregeneratiesarcofaag</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transporteer lijk naar cryoregeneratiesarcofaag</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Er moet een lijk worden aangewezen</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Er zijn geen lijken om naar de cryoregeneratiesarcofaag te transporteren</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Volledig geregenereerd</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Grotendeels geregenereerd</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Wezenlijk geregenereerd</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Licht geregenereerd</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Geregenereerd</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Mijn lichaam voelt als in mijn vroege jeugd: fris, sterk en vol potentieel!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} jaar gewist! Ik herken mijn jongere ik in de spiegel: de vitaliteit van mijn jeugd keert terug!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} jaar gewist! Mijn gewrichten bewegen weer soepel en mijn energie keert terug.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Ik voel me {0} jaar jonger! De last van de tijd is van mijn lichaam genomen.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ik voel me een paar jaar jonger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -5,4 +5,16 @@
 
     <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Must designate a corpse</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
     <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>No corpses to haul to cryoregenesis casket</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Fully regenerated</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Majorly regenerated</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substantially regenerated</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Mildly regenerated</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerated</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>My body feels like it did in my earliest adulthood - fresh, strong, and full of potential!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} years gone! I recognize my younger self in the mirror - the vigor of my prime is returning!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} years erased! My joints move smoothly again and my energy is returning.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>I feel {0} years younger! The weight of time has been lifted from my body.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>I feel a few years younger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 </LanguageData>

--- a/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
+++ b/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportida laip krüoregeneratsiooni sarkofaagi</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportida laip krüoregeneratsiooni sarkofaagi</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Tuleb määrata laip</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Pole laipu, mida krüoregeneratsiooni sarkofaagi transportida</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Täielikult regenereritud</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Suures osas regenereritud</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Märkimisväärselt regenereritud</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Veidi regenereritud</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenereritud</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Mu keha tunneb end nagu varases nooruses: värske, tugev ja potentsiaali täis!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} aastat kustutatud! Tunnen peeglist oma nooremat mina: mu nooruslik elujõud naaseb!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} aastat kustutatud! Mu liigesed liiguvad jälle sujuvalt ja mu energia naaseb.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tunnen end {0} aastat nooremalt! Aja koorem on mu kehast eemaldatud.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen end mõne aasta nooremalt.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
+++ b/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Kuljeta ruumis krioregeneraatio-sarkofagiin</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Kuljeta ruumis krioregeneraatio-sarkofagiin</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Täytyy osoittaa ruumis</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Ei ruumiita kuljetettavaksi krioregeneraatio-sarkofagiin</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Täysin regeneroitunut</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Pääosin regeneroitunut</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Olennaisesti regeneroitunut</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Hieman regeneroitunut</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regeneroitunut</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Kehoni tuntuu kuin varhaisessa nuoruudessani: raikas, vahva ja täynnä potentiaalia!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} vuotta pyyhitty pois! Tunnistan nuoremman minäni peilistä: nuoruuteni vilkas voima palaa!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} vuotta pyyhitty pois! Niveleni liikkuvat taas sujuvasti ja energiani palaa.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tunnen oloni {0} vuotta nuoremmaksi! Ajan taakka on poistettu kehostani.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen oloni muutaman vuoden nuoremmaksi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/French/Keyed/French.xml
+++ b/CryoRegenesis/Languages/French/Keyed/French.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/French/Keyed/French.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transporter le cadavre vers un cercueil de cryorégénération</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transporter le cadavre vers un cercueil de cryorégénération</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Doit désigner un cadavre</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Aucun cadavre à transporter vers le cercueil de cryorégénération</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Complètement régénéré</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Majoritairement régénéré</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substantiellement régénéré</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Légèrement régénéré</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Régénéré</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Mon corps se sent comme au début de ma jeunesse : frais, fort et plein de potentiel !</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} années effacées ! Je reconnais mon moi plus jeune dans le miroir : la vigueur de ma jeunesse revient !</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} années effacées ! Mes articulations bougent à nouveau avec souplesse et mon énergie revient.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Je me sens {0} ans plus jeune ! Le poids du temps a été retiré de mon corps.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Je me sens quelques années plus jeune.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/German/Keyed/German.xml
+++ b/CryoRegenesis/Languages/German/Keyed/German.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/German/Keyed/German.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Leiche in Kryoregenerierungssarkophag transportieren</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Leiche in Kryoregenerierungssarkophag transportieren</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Es muss eine Leiche ausgewählt werden</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Keine Leichen zum Transport in den Kryoregenerierungssarkophag vorhanden</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Vollständig regeneriert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Größtenteils regeneriert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Erheblich regeneriert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Leicht regeneriert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regeneriert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Mein Körper fühlt sich an wie in meiner frühen Jugend: frisch, stark und voller Potenzial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} Jahre ausgelöscht! Ich erkenne mein jüngeres Ich im Spiegel wieder: Die Kraft meiner Jugend kehrt zurück!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} Jahre ausgelöscht! Meine Gelenke bewegen sich wieder geschmeidig und meine Energie kehrt zurück.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Ich fühle mich um {0} Jahre jünger! Die Last der Zeit wurde von meinem Körper genommen.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ich fühle mich um einige Jahre jünger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
+++ b/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Greek/Keyed/Greek.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Μεταφορά πτώματος σε σαρκοφάγο κρυογενικής αναγέννησης</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Μεταφορά πτώματος σε σαρκοφάγο κρυογενικής αναγέννησης</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Πρέπει να ορίσετε ένα πτώμα</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Δεν υπάρχουν πτώματα για μεταφορά στο σαρκοφάγο κρυογενικής αναγέννησης</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Πλήρως αναγεννημένο</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Σε μεγάλο βαθμό αναγεννημένο</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Ουσιαστικά αναγεννημένο</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Ελαφρώς αναγεννημένο</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Αναγεννημένο</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Το σώμα μου νιώθει σαν στα πρώιμα νιάτα μου: φρέσκο, δυνατό και γεμάτο δυνατότητες!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} χρόνια σβησμένα! Αναγνωρίζω τον νεότερο εαυτό μου στον καθρέφτη: η ζωντάνια της νιότης μου επιστρέφει!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} χρόνια σβησμένα! Οι αρθρώσεις μου κινούνται ξανά ομαλά και η ενέργειά μου επιστρέφει.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Νιώθω {0} χρόνια νεότερος! Το βάρος του χρόνου έχει αφαιρεθεί από το σώμα μου.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Νιώθω μερικά χρόνια νεότερος.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
+++ b/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>शव को क्रायो-रिजेनेरेशन सरकोफैगस में ले जाएं</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>शव को क्रायो-रिजेनेरेशन सरकोफैगस में ले जाएं</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>एक शव निर्दिष्ट करना आवश्यक है</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>क्रायो-रिजेनेरेशन सरकोफैगस में ले जाने के लिए कोई शव नहीं है</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>पूरी तरह से पुनर्जीवित</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>अधिकतर पुनर्जीवित</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>काफी हद तक पुनर्जीवित</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>थोड़ा पुनर्जीवित</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>पुनर्जीवित</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>मेरा शरीर अपनी प्रारंभिक युवावस्था की तरह महसूस कर रहा है: तरोताजा, मजबूत और संभावनाओं से भरपूर!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} साल मिटा दिए गए! मैं आईने में अपने युवा स्व को पहचानता हूं: मेरी युवावस्था का उत्साह वापस आ रहा है!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} साल मिटा दिए गए! मेरे जोड़ फिर से सहजता से चल रहे हैं और मेरी ऊर्जा वापस आ रही है।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>मैं अपने आपको {0} साल युवा महसूस कर रहा हूं! समय का बोझ मेरे शरीर से हटा दिया गया है।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>मैं अपने आपको कुछ साल युवा महसूस कर रहा हूं।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
+++ b/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Holttest szállítása krioregenerációs szarkofágba</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Holttest szállítása krioregenerációs szarkofágba</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Holttestet kell kijelölni</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Nincs holttest a krioregenerációs szarkofágba szállításra</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Teljesen regenerálódott</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Nagyrészt regenerálódott</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Jelentősen regenerálódott</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Kissé regenerálódott</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerálódott</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>A testem olyan, mint a korai ifjúságomban: friss, erős és tele potenciállal!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} év törölve! Felismerem a tükörben a fiatalabb énem: az ifjúságom élénk ereje visszatér!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} év törölve! Az ízületeim újra simán mozognak, és az energiám visszatér.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0} évvel fiatalabbnak érzem magam! Az idő terhe eltávolítódott a testemből.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Néhány évvel fiatalabbnak érzem magam.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
+++ b/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Italian/Keyed/Italian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Trasporta cadavere nel sarcofago di criorigenerazione</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Trasporta cadavere nel sarcofago di criorigenerazione</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Devi designare un cadavere</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Nessun cadavere da trasportare nel sarcofago di criorigenerazione</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completamente rigenerato</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>In gran parte rigenerato</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Sostanzialmente rigenerato</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Leggermente rigenerato</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Rigenerato</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Il mio corpo si sente come nella mia giovinezza: fresco, forte e pieno di potenziale!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} anni cancellati! Riconosco il mio io più giovane nello specchio: il vigore della mia giovinezza sta tornando!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anni cancellati! Le mie articolazioni si muovono di nuovo con fluidità e la mia energia sta tornando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Mi sento {0} anni più giovane! Il peso del tempo è stato rimosso dal mio corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mi sento qualche anno più giovane.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
+++ b/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>死体をクライオ再生棺に運ぶ</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>死体をクライオ再生棺に運ぶ</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>死体を指定する必要があります</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>クライオ再生棺に運ぶ死体がありません</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>完全に再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>大部分が再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>かなり再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>わずかに再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>再生</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>体が若い頃のように感じる：新鮮で、強く、可能性に満ちている！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0}年が消え去った！鏡の中に若い頃の自分を認める：青春の活力が戻ってきている！</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0}年が消え去った！関節が再び滑らかに動き、活力が戻ってきている。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0}年若くなった気分だ！時間の重みが体から取り除かれた。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>数年若くなった気分だ。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
+++ b/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Korean/Keyed/Korean.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>시체를 저온 재생 관으로 운반</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>시체를 저온 재생 관으로 운반</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>시체를 지정해야 합니다</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>저온 재생 관으로 운반할 시체가 없습니다</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>완전히 재생됨</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>대부분 재생됨</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>상당히 재생됨</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>약간 재생됨</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>재생됨</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>내 몸이 젊은 시절처럼 느껴진다: 상쾌하고, 강하며, 잠재력이 가득하다!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0}년이 지워졌다! 거울 속에서 젊은 시절의 내 모습을 본다: 젊음의 활력이 돌아오고 있다!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0}년이 지워졌다! 관절이 다시 부드럽게 움직이고 에너지가 돌아오고 있다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0}년 젊어진 기분이다! 시간의 무게가 내 몸에서 사라졌다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>몇 년 젊어진 기분이다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
+++ b/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transporter lik til kryoregenerasjonssarkofag</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transporter lik til kryoregenerasjonssarkofag</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Det må angis et lik</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Det er ingen lik å transportere til kryoregenerasjonssarkofagen</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Fullstendig regenerert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>I stor grad regenerert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substansielt regenerert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Lett regenerert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerert</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Kroppen min føles som i min tidlige ungdom: frisk, sterk og full av potensial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} år visket ut! Jeg kjenner igjen mitt yngre jeg i speilet: min ungdoms kraft vender tilbake!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år visket ut! Leddene mine beveger seg igjen smidig, og energien min vender tilbake.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jeg føler meg {0} år yngre! Tidens byrde er fjernet fra kroppen min.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler meg noen år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
+++ b/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Polish/Keyed/Polish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Przenieś zwłoki do kriogenicznego sarkofagu regeneracji</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Przenieś zwłoki do kriogenicznego sarkofagu regeneracji</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Należy wyznaczyć zwłoki</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Brak zwłok do przeniesienia do kriogenicznego sarkofagu regeneracji</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>W pełni zregenerowany</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>W znacznym stopniu zregenerowany</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Istotnie zregenerowany</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Lekko zregenerowany</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Zregenerowany</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Moje ciało czuje się jak we wczesnej młodości: świeże, silne i pełne potencjału!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>Wymazano {0} lat! Widzę w lustrze młodszą wersję siebie: wigor mojej młodości powraca!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>Wymazano {0} lat! Moje stawy znów poruszają się płynnie, a moja energia powraca.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Czuję się o {0} lat młodszy! Ciężar czasu został zdjęty z mojego ciała.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Czuję się o kilka lat młodszy.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
+++ b/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportar cadáver para um caixão de criorregeneração</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportar cadáver para um caixão de criorregeneração</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Deve designar um cadáver</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Não há cadáveres para transportar ao caixão de criorregeneração</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completamente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Principalmente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substancialmente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Levemente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Meu corpo se sente como na minha juventude inicial: fresco, forte e cheio de potencial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} anos apagados! Reconheço meu eu mais jovem no espelho: a vigor da minha juventude está voltando!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anos apagados! Minhas articulações voltam a se mover com suavidade e minha energia está voltando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Sinto-me {0} anos mais jovem! O peso do tempo foi tirado do meu corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
+++ b/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportar cadáver para um sarcófago de crioregeneração</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportar cadáver para um sarcófago de crioregeneração</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Deve-se designar um cadáver</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Não há cadáveres para transportar ao sarcófago de crioregeneração</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completamente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Em grande parte regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substancialmente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Levemente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Meu corpo se sente como na minha juventude inicial: fresco, forte e cheio de potencial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} anos apagados! Reconheço meu eu mais jovem no espelho: o vigor da minha juventude está voltando!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anos apagados! Minhas articulações voltam a se mover com suavidade e minha energia está retornando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Sinto-me {0} anos mais jovem! O peso do tempo foi removido do meu corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
+++ b/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportă cadavrul la un sarcofag de crioregenerare</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportă cadavrul la un sarcofag de crioregenerare</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Trebuie să desemnezi un cadavru</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Nu există cadavre de transportat la sarcofagul de crioregenerare</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Complet regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>În mare parte regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Substanțial regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Ușor regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerat</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Corpul meu se simte ca în tinerețea timpurie: proaspăt, puternic și plin de potențial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} ani șterși! Îmi recunosc eu mai tânăr în oglindă: vigoarea tinereții mele se întoarce!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} ani șterși! Articulațiile mele se mișcă din nou cu ușurință și energia mea revine.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Mă simt cu {0} ani mai tânăr! Greutatea timpului a fost îndepărtată din corpul meu.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mă simt cu câțiva ani mai tânăr.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
+++ b/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Russian/Keyed/Russian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Перевезти труп в криорегенерационный саркофаг</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Перевезти труп в криорегенерационный саркофаг</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Необходимо выбрать труп</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Нет трупов для перевозки в криорегенерационный саркофаг</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Полностью регенерирован</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>В основном регенерирован</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Существенно регенерирован</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Слегка регенерирован</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Регенерирован</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Моё тело чувствует себя так же, как в ранней молодости: свежее, сильное и полное потенциала!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} лет стёрто! Я узнаю своё более молодое я в зеркале: энергия моей молодости возвращается!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} лет стёрто! Мои суставы снова двигаются плавно, и моя энергия возвращается.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Я чувствую себя на {0} лет моложе! Бремя времени было снято с моего тела.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я чувствую себя на несколько лет моложе.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
+++ b/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Preniesť mŕtvolu do kryoregeneračného sarkofágu</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Preniesť mŕtvolu do kryoregeneračného sarkofágu</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Je potrebné označiť mŕtvolu</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Žiadne mŕtvoly na prenesenie do kryoregeneračného sarkofágu</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Úplne regenerovaný</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Do veľkej miery regenerovaný</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Výrazne regenerovaný</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Mierne regenerovaný</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerovaný</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Moje telo sa cíti ako v mojej rannej mladosti: svieže, silné a plné potenciálu!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} rokov vymazaných! Spoznávam v zrkadle svoje mladšie ja: vitalita mojej mladosti sa vracia!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} rokov vymazaných! Moje kĺby sa opäť hýbu plynulo a moja energia sa vracia.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Cítim sa o {0} rokov mladší! Bremeno času bolo odstránené z môjho tela.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítim sa o niekoľko rokov mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportar cadáver a un ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportar cadáver a un ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Debe designar un cadáver</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>No hay cadáveres para transportar al ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completamente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Mayormente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Sustancialmente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Levemente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>¡Mi cuerpo se siente como en mi juventud temprana: fresco, fuerte y lleno de potencial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>¡{0} años borrados! Reconozco a mi yo más joven en el espejo: ¡el vigor de mi juventud está regresando!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>¡{0} años borrados! Mis articulaciones vuelven a moverse con suavidad y mi energía está regresando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>¡Me siento {0} años más joven! El peso del tiempo ha sido quitado de mi cuerpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportar cadáver a un ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportar cadáver a un ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Debe designar un cadáver</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>No hay cadáveres para transportar al ataúd de crioregénesis</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Completamente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Mayormente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Sustancialmente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Levemente regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Regenerado</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>¡Mi cuerpo se siente como en mi juventud temprana: fresco, fuerte y lleno de potencial!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>¡{0} años borrados! Reconozco a mi yo más joven en el espejo: ¡el vigor de mi juventud está regresando!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>¡{0} años borrados! Mis articulaciones vuelven a moverse con suavidad y mi energía está regresando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>¡Me siento {0} años más joven! El peso del tiempo ha sido quitado de mi cuerpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
+++ b/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Transportera lik till kryoregenereringssarkofag</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Transportera lik till kryoregenereringssarkofag</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>En lik måste markeras</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Det finns inga lik att transportera till kryoregenereringssarkofagen</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Fullständigt återgenererad</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Till största delen återgenererad</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Väsentligt återgenererad</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Lätt återgenererad</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Återgenererad</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Min kropp känns som i min tidiga ungdom: frisk, stark och full av potential!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} år utraderade! Jag känner igen mitt yngre jag i spegeln: min ungdoms kraft återvänder!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år utraderade! Mina leder rör sig åter smidigt och min energi återvänder.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jag känner mig {0} år yngre! Tidens börda har avlägsnats från min kropp.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jag känner mig några år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
+++ b/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Cesedi kriyojenik rejenerasyon lahdiine taşı</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Cesedi kriyojenik rejenerasyon lahdiine taşı</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Bir ceset işaretlenmelidir</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Kriyojenik rejenerasyon lahdiine taşınacak ceset yok</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Tamamen rejenerasyon geçirmiş</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Büyük ölçüde rejenerasyon geçirmiş</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Önemli ölçüde rejenerasyon geçirmiş</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Hafifçe rejenerasyon geçirmiş</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Rejenerasyon geçirmiş</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Vücudum erken gençliğimdeki gibi hissediyor: taze, güçlü ve potansiyel dolu!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} yıl silindi! Aynada genç halimi tanıyorum: gençliğimin enerjisi geri dönüyor!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} yıl silindi! Eklemlerim tekrar pürüzsüz hareket ediyor ve enerjim geri dönüyor.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Kendimi {0} yıl daha genç hissediyorum! Zamanın yükü bedenimden kaldırıldı.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Kendimi birkaç yıl daha genç hissediyorum.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
+++ b/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Перевезти труп у кріорегенераційний саркофаг</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Перевезти труп у кріорегенераційний саркофаг</BetterRimworlds.CryoRegenesis.Designator.Label>
+
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Необхідно вибрати труп</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Немає трупів для перевезення у кріорегенераційний саркофаг</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Повністю регенерований</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Переважно регенерований</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Суттєво регенерований</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Легко регенерований</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Регенерований</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Моє тіло відчувається так само, як у ранній молодості: свіже, сильне і повне потенціалу!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} років стерто! Я впізнаю своє молодше я в дзеркалі: енергія моєї молодості повертається!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} років стерто! Мої суглоби знову рухаються плавно, і моя енергія повертається.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Я відчуваю себе на {0} років молодшим! Тягар часу було знято з мого тіла.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я відчуваю себе на кілька років молодшим.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
+++ b/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ==== ./CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml ==== -->
+<LanguageData>
+    <BetterRimworlds.CryoRegenesis.Designator.Desc>Vận chuyển thi thể đến quan tài tái sinh lạnh</BetterRimworlds.CryoRegenesis.Designator.Desc>
+    <BetterRimworlds.CryoRegenesis.Designator.Label>Vận chuyển thi thể đến quan tài tái sinh lạnh</BetterRimworlds.CryoRegenesis.Designator.Label>
+ 
+    <BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>Phải chỉ định một thi thể</BetterRimworlds.CryoRegenesis.Designator.MustBeCorpse>
+    <BetterRimworlds.CryoRegenesis.Designator.NoCorpses>Không có thi thể nào để vận chuyển đến quan tài tái sinh lạnh</BetterRimworlds.CryoRegenesis.Designator.NoCorpses>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>Đã tái sinh hoàn toàn</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>Đã tái sinh phần lớn</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>Đã tái sinh đáng kể</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>Đã tái sinh nhẹ</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>Đã tái sinh</BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some>
+
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>Cơ thể tôi cảm thấy như thời trẻ mới lớn: tươi mới, khỏe mạnh và đầy tiềm năng!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>{0} năm đã bị xóa sổ! Tôi nhận ra bản thân trẻ tuổi hơn trong gương: sức sống của tuổi trẻ đang trở lại!</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} năm đã bị xóa sổ! Các khớp của tôi lại cử động trơn tru và năng lượng đang trở lại.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tôi cảm thấy trẻ hơn {0} tuổi! Gánh nặng của thời gian đã được gỡ bỏ khỏi cơ thể tôi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
+    <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tôi cảm thấy trẻ hơn vài năm.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+</LanguageData>

--- a/README.md
+++ b/README.md
@@ -121,13 +121,21 @@ The combination of resource costs and permanent Luciferium addiction ensures res
 * **[2025-03-15 03:11:00 CDT]** [m] Tiny code cleanups.
 
 **Version 5.0.0: 2025-07-22**
-* **[2025-07-22 21:47:41 CDT]** Added happy thoughts about being regenerated.
-* **[2025-07-22 04:45:26 CDT]** Added a "Grateful to be a alive!" thought when pawns are resurrected.
-* **[2025-07-22 04:28:00 CDT]** Added Luciferium addiction to resurrected pawns.
-* **[2025-07-22 04:05:47 CDT]** Cause resurrected pawns to be under anesthetic on revival.
-* **[2025-07-22 03:58:41 CDT]** Store the pawn's original age for use later.
-* **[2025-07-22 03:45:45 CDT]** Fixed the resurrection system.
-* **[2025-07-14 07:00:11 CDT]** Fixed the requirements gathering for resurrection.
-* **[2025-07-11 18:25:25 CDT]** Added support for Rimworld v1.6.
 * **[2025-07-11 18:01:11 CDT]** Migrated to a modern dotnet SDK project.
+* **[2025-07-11 18:25:25 CDT]** Added support for Rimworld v1.6.
+* **[2025-07-14 07:00:11 CDT]** Fixed the requirements gathering for resurrection.
+* **[2025-07-22 03:45:45 CDT]** Fixed the resurrection system.
+* **[2025-07-22 03:58:41 CDT]** Store the pawn's original age for use later.
+* **[2025-07-22 04:05:47 CDT]** Cause resurrected pawns to be under anesthetic on revival.
+* **[2025-07-22 04:28:00 CDT]** Added Luciferium addiction to resurrected pawns.
+* **[2025-07-22 04:45:26 CDT]** Added a "Grateful to be a alive!" thought when pawns are resurrected.
+* **[2025-07-22 21:47:41 CDT]** Added happy thoughts about being regenerated.
+
+**Version 5.1.0: 2026-04-29**
+* **[2026-04-29 06:52:14 CDT]** Added BetterRandom utility class for deterministic random number generation
+* **[2026-04-29 06:55:59 CDT]** Fixed Ejection to properly handle prisoners
+* **[2026-04-29 07:00:49 CDT]** Now freezes the corpse's rotting state preservation during resurrection.
+* **[2026-04-29 07:04:03 CDT]** Fixed the thought stage calculation for the age regression mood boost.
+* **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
+* **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.
 

--- a/Source/BetterRandom.cs
+++ b/Source/BetterRandom.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace BetterRimworlds.ThermoVoltaicGenerator;
+namespace BetterRimworlds;
 
 public class BetterRandom
 {

--- a/Source/BetterRandom.cs
+++ b/Source/BetterRandom.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace BetterRimworlds.ThermoVoltaicGenerator;
+
+public class BetterRandom
+{
+    private static readonly Random random = new Random();
+
+    public static int pick(int min, int max)
+    {
+        if (min > max)
+        {
+            throw new ArgumentException("min value should not be greater than max value.");
+        }
+
+        // The upper bound in Random.Next is exclusive, so we add 1 to include max
+        return random.Next(min, max + 1);
+    }
+}

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -132,10 +132,17 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 
         if (HasAnyContents)
         {
-            Pawn pawn = ContainedThing as Pawn;
-            this.configTargetAge(pawn);
-            this.enteredHealthy = this.determineCurableInjuries(pawn) == 0;
-        }
+            if (ContainedThing is Pawn pawn)
+            {
+                this.configTargetAge(pawn);
+                this.enteredHealthy = this.determineCurableInjuries(pawn) == 0;
+            }
+            else if (ContainedThing is Corpse corpse)
+            {
+                var rotProgress = corpse.GetComp<CompRottable>().RotProgress;
+                this.InitialRot = rotProgress;
+            }
+    }
 
         this.contentsKnown = true;
     }
@@ -638,10 +645,16 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
     }
     public override void EjectContents()
     {
+        if (ContainedThing is not Pawn)
+        {
+            power.PowerOutput = 0;
+            base.EjectContents();
+        }
+
         Pawn pawn = ContainedThing as Pawn;
         pawn.health.AddHediff(cryosickness);
 
-        if (pawn.IsColonist == true && pawn.NonHumanlikeOrWildMan() == false)
+        if ((pawn.IsPrisoner == true || pawn.IsColonist) && pawn.NonHumanlikeOrWildMan() == false)
         {
             // Remove negative and now-irrelevant thoughts:
             pawn.needs.mood.thoughts.memories.RemoveMemoriesOfDef(ThoughtDefOf.MyOrganHarvested);
@@ -654,8 +667,11 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             pawn.needs.mood.thoughts.memories.TryGainMemory(ThoughtDefOf.ArtifactMoodBoost);
             pawn.needs.mood.thoughts.memories.TryGainMemory(ThoughtDefOf.Catharsis);
 
-            pawn.needs.joy.SetInitialLevel();
-            pawn.needs.comfort.SetInitialLevel();
+            if (pawn.IsPrisoner == false)
+            {
+                pawn.needs.joy.SetInitialLevel();
+                pawn.needs.comfort.SetInitialLevel();
+            }
 
             this.possiblyChangeHairColor(pawn);
 

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -653,6 +653,8 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         {
             power.PowerOutput = 0;
             base.EjectContents();
+
+            return;
         }
 
         Pawn pawn = ContainedThing as Pawn;

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -1020,15 +1020,35 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         // Special case: Young adult regressed to minimum age (20)
         if (origAge >= 75 && newAge <= 25)
         {
-            stageIndex = 4; // Use stage 3 (index 3) for max boost
+            stageIndex = 3; // Use stage 3 (index 3) for max boost
+        }
+        else
+        {
+            stageIndex = (int)Math.Round((double)((origAge - newAge) / 20)) + 1;
+            stageIndex = Math.Min(stageIndex, 3);
         }
 
-        stageIndex = (int) Math.Round((double)((origAge - newAge) / 20)) + 1;
         if (CryoRegenesis.Settings.debugMode)
             Log.Warning($"Old age {origAge} | New age: {newAge} | Stage:  {stageIndex}");
+
         ThoughtDef thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_LifeStageReversed");
         Thought_Memory thought = (Thought_Memory)ThoughtMaker.MakeThought(thoughtDef);
         thought.SetForcedStage(stageIndex);
-        pawn.needs.mood.thoughts.memories.TryGainMemory(thought);
+        pawn.needs.mood?.thoughts.memories.TryGainMemory(thought);
+
+        #if !RIMWORLD12 && !RIMWORLD13
+        if (stageIndex >= 2)
+        {
+            if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
+            {
+                pawn.guest.Recruitable = true;
+                Messages.Message("Grateful to be so much younger, " + pawn.Name + " is now recruitable.", pawn, MessageTypeDefOf.PositiveEvent);
+            }
+        }
+        #endif
+
+        // pawn.needs.mood?.thoughts.memories.TryGainMemory(
+        //     ThoughtDef.Named("Thought_RegenesisBodyPositivity"), null);
+
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -1006,9 +1006,9 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             drugNeed.CurLevel = drugNeed.MaxLevel; // Start them off satisfied
         }
 
-        // Optional: Add a custom thought about the resurrection side effect
-        pawn.needs.mood?.thoughts.memories.TryGainMemory(
-            ThoughtDef.Named("CryoRegenesis_LuciferiumSideEffect"), null);
+        pawn.needs?.mood?.thoughts?.memories?.TryGainMemory(
+            DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_LuciferiumSideEffect")
+        );
     }
 
     public static void AddCryoregenesisThought(Pawn pawn, int origAge, int newAge)

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -1016,28 +1016,25 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         int yearsRegressed = origAge - newAge;
         if (yearsRegressed <= 0) return;
 
-        int stageIndex;
-        // Special case: Young adult regressed to minimum age (20)
-        if (origAge >= 75 && newAge <= 25)
-        {
-            stageIndex = 3; // Use stage 3 (index 3) for max boost
-        }
-        else
-        {
-            stageIndex = (int)Math.Round((double)((origAge - newAge) / 20)) + 1;
-            stageIndex = Math.Min(stageIndex, 3);
-        }
+        // Get the def
+        var thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_BodyPositivity");
 
-        if (CryoRegenesis.Settings.debugMode)
-            Log.Warning($"Old age {origAge} | New age: {newAge} | Stage:  {stageIndex}");
+        // Create the thought instance manually so we can initialize it
+        var thought = ThoughtMaker.MakeThought(thoughtDef) as Thought_RegenesisBodyPositivity;
+        if (thought == null) return;
 
-        ThoughtDef thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_LifeStageReversed");
-        Thought_Memory thought = (Thought_Memory)ThoughtMaker.MakeThought(thoughtDef);
-        thought.SetForcedStage(stageIndex);
+        // Set the years BEFORE adding it to the pawn
+        thought.SetYearsReversed(yearsRegressed);
+
+        // Add the initialized thought instance (not the def)
         pawn.needs.mood?.thoughts.memories.TryGainMemory(thought);
 
+        if (CryoRegenesis.Settings.debugMode)
+            Log.Warning($"Old age {origAge} | New age: {newAge} | Years reversed: {yearsRegressed} | Stage: {thought.CurStageIndex}");
+
+        // Use the thought's actual stage for the prisoner check
         #if !RIMWORLD12 && !RIMWORLD13
-        if (stageIndex >= 2)
+        if (thought.CurStageIndex >= 2)
         {
             if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
             {
@@ -1046,9 +1043,5 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             }
         }
         #endif
-
-        // pawn.needs.mood?.thoughts.memories.TryGainMemory(
-        //     ThoughtDef.Named("Thought_RegenesisBodyPositivity"), null);
-
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -336,6 +336,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
     private const int REQ_URANIUM = 150;
     private const int REQ_LUCIFERIUM = 50;
     private int[] ResurrectionFuelReqs = new int[3]{REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM};
+    private float InitialRot = -1;
 
     private void ResetFuelRequirement()
     {
@@ -363,7 +364,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         // If they've been dead and unfrozen for more than 1 day, the CryoRegenesis casket cannot resurrect them.
         if (rottable != null && rottable.RotProgress > 60_000)
         {
-            Messages.Message("[CryoRegenesis] Pawn rejected: More than 1 day unfrozen. Their brain is too degraded.", MessageTypeDefOf.RejectInput);
+            Messages.Message("[CryoRegenesis] Pawn rejected: More than 1 day unfrozen ("  + rottable.RotProgress +"). Their brain is too degraded.", MessageTypeDefOf.RejectInput);
             base.EjectContents();
             return;
         }
@@ -483,7 +484,6 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             resurrectedPawn.health.AddHediff(HediffDefOf.Anesthetic, null, null);
             this.AddLuciferiumAsResurrectionSideEffect(resurrectedPawn);
 
-
             // Reset fuel requirements for the next pawn
             this.ResetFuelRequirement();
         }
@@ -511,7 +511,11 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         {
             if (Find.TickManager.TicksGame % 180 == 0)
             {
-                this.Resurrect(this.ContainedThing as Corpse);
+                // Turn off / pause rotting once inside.
+                var corpse = ContainedThing as Corpse;
+                var rottable = corpse.GetComp<CompRottable>();
+                rottable.RotProgress = this.InitialRot;
+                this.Resurrect(corpse);
             }
 
             return;
@@ -855,12 +859,23 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             return false;
         }
 
+        this.InitialRot = -1;
+
         if (thing.def.defName.StartsWith("Corpse_"))
         {
             this.ResurrectionProgress = 0f;
             this.ResurrectionFuelReqs = new int[3]{REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM};
 
-            return base.TryAcceptThing(thing, allowSpecialEffects);
+            bool status = base.TryAcceptThing(thing, allowSpecialEffects);
+            if (status)
+            {
+                // Record the initial rot level.
+                var corpse = ContainedThing as Corpse;
+                var rottable = corpse.GetComp<CompRottable>();
+                this.InitialRot = rottable.RotProgress;
+            }
+
+            return status;
         }
 
         var pawn = thing as Pawn;
@@ -910,7 +925,15 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         {
             if (ContainedThing.def.defName.StartsWith("Corpse_"))
             {
-                string status = $"Dead (Resurrecting: {this.ResurrectionProgress * 100:F1}%)\n";
+                string debugString = "";
+                if (CryoRegenesis.Settings.debugMode)
+                {
+                    var corpse = ContainedThing as Corpse;
+                    var rotProgress = corpse.GetComp<CompRottable>().RotProgress;
+                    debugString = $"; Rotting: {rotProgress}";
+                }
+
+                string status = $"Dead (Resurrecting: {this.ResurrectionProgress * 100:F1}%{debugString})\n";
                 if (this.ResurrectionFuelReqs[2] > 0)
                 {
                     status += "Needed Luciferium: " + this.ResurrectionFuelReqs[2] + "\n";

--- a/Source/DeadCryoSleep/Designator_HaulCryoRegenesis.cs
+++ b/Source/DeadCryoSleep/Designator_HaulCryoRegenesis.cs
@@ -64,8 +64,7 @@ public class Designator_HaulCryoRegenesis : Designator
         }
         catch (InvalidOperationException)
         {
-            // return "BetterRimworlds.CryoRegenesis.Designator.NoCorpses".Translate();
-            return "No corpses to haul to cryoregenesis casket";
+            return "BetterRimworlds.CryoRegenesis.Designator.NoCorpses".Translate();
         }
     }
 

--- a/Source/Thought_DurationBased.cs
+++ b/Source/Thought_DurationBased.cs
@@ -1,0 +1,53 @@
+// ==== ./Source/Thought_DurationBased.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public abstract class Thought_DurationBased : Thought_Memory
+{
+    protected const int TicksPerDay = 60_000;
+
+    protected int DurationDays;
+    protected int ExtraDurationTicks;
+
+    protected int TotalDurationTicks => DurationDays * TicksPerDay + ExtraDurationTicks;
+
+    protected int TicksRemaining => TotalDurationTicks - age;
+
+    public override bool ShouldDiscard => age > TotalDurationTicks;
+
+    public abstract string BaseDescription { get; }
+
+    public override string Description
+    {
+        get
+        {
+            if (TicksRemaining <= 0)
+            {
+                return BaseDescription;
+            }
+
+            string expiresIn = TicksRemaining.ToStringTicksToPeriod();
+
+            return BaseDescription + "\n\nExpires in: " + $"<color=#00FFFF>{expiresIn}</color>";
+        }
+    }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+
+        Scribe_Values.Look(ref DurationDays, "durationDays");
+        Scribe_Values.Look(ref ExtraDurationTicks, "extraDurationTicks");
+    }
+
+    public abstract void CalculateDuration();
+
+    public override void Init()
+    {
+        base.Init();
+        CalculateDuration();
+        ExtraDurationTicks = BetterRandom.pick(1200, 60000);
+    }
+}

--- a/Source/Thought_LuciferiumSideEffect.cs
+++ b/Source/Thought_LuciferiumSideEffect.cs
@@ -1,0 +1,64 @@
+// ==== Source/CryoRegenesis/Thought_CryoRegenesis_LuciferiumSideEffect.cs ====
+using BetterRimworlds.ThermoVoltaicGenerator;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class Thought_CryoRegenesis_LuciferiumSideEffect : Thought_Memory
+{
+    private const int TicksPerDay = 60_000;
+    private const int DaysPerYear = 60;
+
+    private int durationDays;
+    private int extraDurationTicks;
+
+    private int TotalDurationTicks =>
+        durationDays * TicksPerDay + extraDurationTicks;
+
+    private int TicksRemaining =>
+        TotalDurationTicks - age;
+
+    public override int CurStageIndex => 0;
+
+    public override string LabelCap => "Grateful to be alive";
+
+    public override string Description
+    {
+        get
+        {
+            string baseDescription =
+                "I'm so happy to be alive. A little luci forever is worth it!";
+
+            if (TicksRemaining <= 0)
+            {
+                return baseDescription;
+            }
+
+            string expiresIn = TicksRemaining.ToStringTicksToPeriod();
+
+            return baseDescription + "\n\nExpires in: " + $"<color=#00FFFF>{expiresIn}</color>";
+        }
+    }
+
+    public override float MoodOffset() => 45f;
+
+    public override bool ShouldDiscard =>
+        age > TotalDurationTicks;
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+
+        Scribe_Values.Look(ref durationDays, "durationDays");
+        Scribe_Values.Look(ref extraDurationTicks, "extraDurationTicks");
+    }
+
+    public override void Init()
+    {
+        base.Init();
+
+        durationDays = BetterRandom.pick(1 * DaysPerYear, 10 * DaysPerYear);
+        extraDurationTicks = BetterRandom.pick(1200, 60000);
+    }
+}

--- a/Source/Thought_LuciferiumSideEffect.cs
+++ b/Source/Thought_LuciferiumSideEffect.cs
@@ -1,64 +1,24 @@
 // ==== Source/CryoRegenesis/Thought_CryoRegenesis_LuciferiumSideEffect.cs ====
-using BetterRimworlds.ThermoVoltaicGenerator;
 using RimWorld;
 using Verse;
 
 namespace BetterRimworlds.CryoRegenesis;
 
-public class Thought_CryoRegenesis_LuciferiumSideEffect : Thought_Memory
+public class Thought_CryoRegenesis_LuciferiumSideEffect : Thought_DurationBased
 {
-    private const int TicksPerDay = 60_000;
     private const int DaysPerYear = 60;
-
-    private int durationDays;
-    private int extraDurationTicks;
-
-    private int TotalDurationTicks =>
-        durationDays * TicksPerDay + extraDurationTicks;
-
-    private int TicksRemaining =>
-        TotalDurationTicks - age;
 
     public override int CurStageIndex => 0;
 
     public override string LabelCap => "Grateful to be alive";
 
-    public override string Description
-    {
-        get
-        {
-            string baseDescription =
-                "I'm so happy to be alive. A little luci forever is worth it!";
-
-            if (TicksRemaining <= 0)
-            {
-                return baseDescription;
-            }
-
-            string expiresIn = TicksRemaining.ToStringTicksToPeriod();
-
-            return baseDescription + "\n\nExpires in: " + $"<color=#00FFFF>{expiresIn}</color>";
-        }
-    }
+    public override string BaseDescription =>
+        "I'm so happy to be alive. A little luci forever is worth it!";
 
     public override float MoodOffset() => 45f;
 
-    public override bool ShouldDiscard =>
-        age > TotalDurationTicks;
-
-    public override void ExposeData()
+    public override void CalculateDuration()
     {
-        base.ExposeData();
-
-        Scribe_Values.Look(ref durationDays, "durationDays");
-        Scribe_Values.Look(ref extraDurationTicks, "extraDurationTicks");
-    }
-
-    public override void Init()
-    {
-        base.Init();
-
-        durationDays = BetterRandom.pick(1 * DaysPerYear, 10 * DaysPerYear);
-        extraDurationTicks = BetterRandom.pick(1200, 60000);
+        DurationDays = BetterRandom.pick(1 * DaysPerYear, 10 * DaysPerYear);
     }
 }

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -80,7 +80,7 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
         else if (isBodyPurist)
         {
             DurationDays = BetterRandom.pick(30, 300) * BetterRandom.pick(1, 3);
-            this._moodBonus = BetterRandom.pick(1, 2);
+            this._moodBonus *= BetterRandom.pick(1, 2);
         }
         else
         {
@@ -92,5 +92,6 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
     {
         base.ExposeData();
         Scribe_Values.Look(ref _yearsReversed, "yearsReversed", 0);
+        Scribe_Values.Look(ref _moodBonus, "moodBonus", 0);
     }
 }

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -36,20 +36,20 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
 
     public override string LabelCap => CurStageIndex switch
     {
-        4 => "Fully regenerated",
-        3 => "Majorly regenerated",
-        2 => "Substantially regenerated",
-        1 => "Mildly regenerated",
-        _ => "Regenerated"
+        4 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Full".Translate(),
+        3 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Major".Translate(),
+        2 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Substantial".Translate(),
+        1 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Mild".Translate(),
+        _ => "BetterRimworlds.CryoRegenesis.BodyPositivity.Label.Some".Translate()
     };
 
     public override string BaseDescription => CurStageIndex switch
     {
-        4 => "My body feels like it did in my earliest adulthood - fresh, strong, and full of potential!",
-        3 => "60 years gone! I recognize my younger self in the mirror - the vigor of my prime is returning!",
-        2 => "40 years erased! My joints move smoothly again and my energy is returning.",
-        1 => "I feel 20 years younger! The weight of time has been lifted from my body.",
-        _ => "I feel a few years younger."
+        4 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Full".Translate(),
+        3 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Major".Translate(_yearsReversed),
+        2 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial".Translate(_yearsReversed),
+        1 => "BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild".Translate(_yearsReversed),
+        _ => "BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some".Translate(),
     };
 
     public override float MoodOffset() => CurStageIndex switch

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -1,0 +1,96 @@
+// ==== ./Source/Thought_RegenesisBodyPositivity.cs ====
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class Thought_RegenesisBodyPositivity : Thought_DurationBased
+{
+    private int _yearsReversed;
+    private int _moodBonus;
+
+    public void SetYearsReversed(int years)
+    {
+        this._yearsReversed = years;
+    }
+    
+    public override void Init()
+    {
+        base.Init();
+        this._moodBonus = BetterRandom.pick(-15, 15);
+    }
+
+
+    public override int CurStageIndex
+    {
+        get
+        {
+            // Messages.Message("Years Younger: " + this._yearsReversed, MessageTypeDefOf.PositiveEvent);
+            if (_yearsReversed >= 60) return 4;
+            if (_yearsReversed >= 40) return 3;
+            if (_yearsReversed >= 20) return 2;
+            if (_yearsReversed >= 10) return 1;
+            return 0;
+        }
+    }
+
+    public override string LabelCap => CurStageIndex switch
+    {
+        4 => "Fully regenerated",
+        3 => "Majorly regenerated",
+        2 => "Substantially regenerated",
+        1 => "Mildly regenerated",
+        _ => "Regenerated"
+    };
+
+    public override string BaseDescription => CurStageIndex switch
+    {
+        4 => "My body feels like it did in my earliest adulthood - fresh, strong, and full of potential!",
+        3 => "60 years gone! I recognize my younger self in the mirror - the vigor of my prime is returning!",
+        2 => "40 years erased! My joints move smoothly again and my energy is returning.",
+        1 => "I feel 20 years younger! The weight of time has been lifted from my body.",
+        _ => "I feel a few years younger."
+    };
+
+    public override float MoodOffset() => CurStageIndex switch
+    {
+        4 => 40f + this._moodBonus,
+        3 => 35f + this._moodBonus,
+        2 => 25f + this._moodBonus,
+        1 => 20f + this._moodBonus,
+        _ => 15f + this._moodBonus
+    };
+
+    public override void CalculateDuration()
+    {
+        if (pawn == null)
+        {
+            DurationDays = BetterRandom.pick(5, 60);
+            return;
+        }
+
+        bool isBodyPurist = pawn.story?.traits?.HasTrait(TraitDefOf.BodyPurist) ?? false;
+
+        bool recentlyResurrected = pawn.health?.hediffSet?.HasHediff(HediffDefOf.ResurrectionSickness) ?? false;
+
+        if (recentlyResurrected)
+        {
+            DurationDays = BetterRandom.pick(60, 600);
+        }
+        else if (isBodyPurist)
+        {
+            DurationDays = BetterRandom.pick(30, 300) * BetterRandom.pick(1, 3);
+            this._moodBonus = BetterRandom.pick(1, 2);
+        }
+        else
+        {
+            DurationDays = BetterRandom.pick(30, 300);
+        }
+    }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+        Scribe_Values.Look(ref _yearsReversed, "yearsReversed", 0);
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,9 @@ configurations=("v1.2" "v1.3" "v1.4" "v1.5" "v1.6")
 dotnet restore "$solutionPath"
 
 function sync_mod() {
+    rm -rf "${MOD}/Languages/SpanishLatin"
+    cp -avf ${MOD}/Languages/Spanish ${MOD}/Languages/SpanishLatin
+
     # Copy over the mod directory.
     rsync -a ${MOD} /rimworld/1.2/Mods/
 


### PR DESCRIPTION
## **User description**
* **[2026-04-29 06:52:14 CDT]** Added BetterRandom utility class for deterministic random number generation
* **[2026-04-29 06:55:59 CDT]** Fixed Ejection to properly handle prisoners
* **[2026-04-29 07:00:49 CDT]** Now freezes the corpse's rotting state preservation during resurrection.
* **[2026-04-29 07:04:03 CDT]** Fixed the thought stage calculation for the age regression mood boost.
* **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
* **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v5.1.0: deterministic random utility; new duration-driven resurrection thoughts (stronger luciferium gratitude, revamped body-positivity stages); boosted “Regenesis High”.

* **Bug Fixes**
  * Preserve corpse rot during resurrection; improved prisoner ejection/handling and recruitability; fixed mood/thought stage calculation for age regression; added extended resurrection thought variant.

* **Localization**
  * Added keyed translations for many languages.

* **Documentation**
  * README updated with v5.1.0 changelog (2026-04-29).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Improve resurrection outcomes and add richer regeneration thoughts**

### What Changed
- Resurrected pawns now get mood thoughts that change based on how much younger they become, with stronger reactions for bigger age reversals.
- The “grateful to be alive” resurrection thought now lasts longer and gives a larger mood boost.
- Prisoners keep their recovery-related needs handled correctly when they are ejected from the casket.
- Corpses keep their rot state while waiting for resurrection, and the casket now shows this progress when debug mode is on.
- Added translated text for the new regeneration thoughts and updated the changelog for version 5.1.0.

### Impact
`✅ Clearer resurrection rewards`
`✅ Fewer prisoner recovery issues`
`✅ Less corpse decay during resurrection`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0EiB2YFFvOoFU1sv_Y_yPpzQQvbQXKbEK07FYVhAZyk&org=BetterRimworlds)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
