### PR TITLE
Version 6.0.0

### DIFF
--- a/CryoRegenesis/Defs/ResearchProjectDefs/CryoRegenesisResearchProject.xml
+++ b/CryoRegenesis/Defs/ResearchProjectDefs/CryoRegenesisResearchProject.xml
@@ -4,7 +4,7 @@
 		<defName>CryoRegenesis</defName>
 		<label>cryoregenesis casket</label>
 		<description>Allows colonists to construct CryoRegenesis™ caskets, which can reduce colonists age using large amounts of uranium.</description>
-		<baseCost>1200</baseCost>
+		<baseCost>2000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
 			<li>Cryptosleep</li>

--- a/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
+++ b/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
@@ -49,7 +49,7 @@
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
 				<shortCircuitInRain>false</shortCircuitInRain>
-				<basePowerConsumption>3000</basePowerConsumption>
+				<basePowerConsumption>0</basePowerConsumption>
 			</li>
 			<li Class="CompProperties_Refuelable">
 				<fuelConsumptionRate>0.75</fuelConsumptionRate>

--- a/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
+++ b/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>تم محو {0} عامًا! مفاصلي تتحرك بسلاسة مرة أخرى وطاقتي تعود.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>أشعر بأنني أصغر بـ {0} عامًا! ثقل الزمن قد أُزيل من جسدي.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>أشعر بأنني أصغر ببضع سنوات.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>العمر الحقيقي</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
+++ b/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anys esborrats! Les meves articulacions tornen a moure's amb suavitat i la meva energia està tornant.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Em sento {0} anys més jove! El pes del temps ha estat alliberat del meu cos.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Em sento uns anys més jove.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edat real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
+++ b/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>抹去了{0}年！我的关节重新灵活转动，精力正在恢复。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>我感觉年轻了{0}岁！时间的重负已从我的身上卸下。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感觉年轻了几岁。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真实年龄</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
+++ b/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>抹去了{0}年！我的關節重新靈活轉動，精力正在恢復。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>我感覺年輕了{0}歲！時間的重負已從我的身上卸下。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感覺年輕了幾歲。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真實年齡</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
+++ b/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>Smazáno {0} let! Mé klouby se opět hladce pohybují a má energie se vrací.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Cítím se o {0} let mladší! Břímě času bylo sejmuto z mého těla.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítím se o několik let mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutečný věk</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
+++ b/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år slettet! Mine led bevæger sig igen smidigt, og min energi vender tilbage.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jeg føler mig {0} år yngre! Tidens byrde er blevet fjernet fra min krop.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler mig nogle år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ægte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
+++ b/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} jaar gewist! Mijn gewrichten bewegen weer soepel en mijn energie keert terug.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Ik voel me {0} jaar jonger! De last van de tijd is van mijn lichaam genomen.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ik voel me een paar jaar jonger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Echte leeftijd</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -17,4 +17,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} years erased! My joints move smoothly again and my energy is returning.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>I feel {0} years younger! The weight of time has been lifted from my body.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>I feel a few years younger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>True Age</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
+++ b/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} aastat kustutatud! Mu liigesed liiguvad jälle sujuvalt ja mu energia naaseb.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tunnen end {0} aastat nooremalt! Aja koorem on mu kehast eemaldatud.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen end mõne aasta nooremalt.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tegelik vanus</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
+++ b/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} vuotta pyyhitty pois! Niveleni liikkuvat taas sujuvasti ja energiani palaa.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tunnen oloni {0} vuotta nuoremmaksi! Ajan taakka on poistettu kehostani.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen oloni muutaman vuoden nuoremmaksi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Todellinen ikä</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/French/Keyed/French.xml
+++ b/CryoRegenesis/Languages/French/Keyed/French.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} années effacées ! Mes articulations bougent à nouveau avec souplesse et mon énergie revient.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Je me sens {0} ans plus jeune ! Le poids du temps a été retiré de mon corps.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Je me sens quelques années plus jeune.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Âge réel</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/German/Keyed/German.xml
+++ b/CryoRegenesis/Languages/German/Keyed/German.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} Jahre ausgelöscht! Meine Gelenke bewegen sich wieder geschmeidig und meine Energie kehrt zurück.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Ich fühle mich um {0} Jahre jünger! Die Last der Zeit wurde von meinem Körper genommen.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ich fühle mich um einige Jahre jünger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Wahres Alter</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
+++ b/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} χρόνια σβησμένα! Οι αρθρώσεις μου κινούνται ξανά ομαλά και η ενέργειά μου επιστρέφει.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Νιώθω {0} χρόνια νεότερος! Το βάρος του χρόνου έχει αφαιρεθεί από το σώμα μου.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Νιώθω μερικά χρόνια νεότερος.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Πραγματική ηλικία</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
+++ b/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} साल मिटा दिए गए! मेरे जोड़ फिर से सहजता से चल रहे हैं और मेरी ऊर्जा वापस आ रही है।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>मैं अपने आपको {0} साल युवा महसूस कर रहा हूं! समय का बोझ मेरे शरीर से हटा दिया गया है।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>मैं अपने आपको कुछ साल युवा महसूस कर रहा हूं।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>वास्तविक आयु</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
+++ b/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} év törölve! Az ízületeim újra simán mozognak, és az energiám visszatér.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0} évvel fiatalabbnak érzem magam! Az idő terhe eltávolítódott a testemből.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Néhány évvel fiatalabbnak érzem magam.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Valódi kor</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
+++ b/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anni cancellati! Le mie articolazioni si muovono di nuovo con fluidità e la mia energia sta tornando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Mi sento {0} anni più giovane! Il peso del tempo è stato rimosso dal mio corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mi sento qualche anno più giovane.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Età reale</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
+++ b/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0}年が消え去った！関節が再び滑らかに動き、活力が戻ってきている。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0}年若くなった気分だ！時間の重みが体から取り除かれた。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>数年若くなった気分だ。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>実年齢</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
+++ b/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0}년이 지워졌다! 관절이 다시 부드럽게 움직이고 에너지가 돌아오고 있다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>{0}년 젊어진 기분이다! 시간의 무게가 내 몸에서 사라졌다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>몇 년 젊어진 기분이다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>실제 나이</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
+++ b/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år visket ut! Leddene mine beveger seg igjen smidig, og energien min vender tilbake.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jeg føler meg {0} år yngre! Tidens byrde er fjernet fra kroppen min.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler meg noen år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ekte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
+++ b/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>Wymazano {0} lat! Moje stawy znów poruszają się płynnie, a moja energia powraca.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Czuję się o {0} lat młodszy! Ciężar czasu został zdjęty z mojego ciała.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Czuję się o kilka lat młodszy.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Prawdziwy wiek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
+++ b/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anos apagados! Minhas articulações voltam a se mover com suavidade e minha energia está voltando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Sinto-me {0} anos mais jovem! O peso do tempo foi tirado do meu corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
+++ b/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} anos apagados! Minhas articulações voltam a se mover com suavidade e minha energia está retornando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Sinto-me {0} anos mais jovem! O peso do tempo foi removido do meu corpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
+++ b/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} ani șterși! Articulațiile mele se mișcă din nou cu ușurință și energia mea revine.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Mă simt cu {0} ani mai tânăr! Greutatea timpului a fost îndepărtată din corpul meu.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mă simt cu câțiva ani mai tânăr.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Vârstă reală</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
+++ b/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} лет стёрто! Мои суставы снова двигаются плавно, и моя энергия возвращается.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Я чувствую себя на {0} лет моложе! Бремя времени было снято с моего тела.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я чувствую себя на несколько лет моложе.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Настоящий возраст</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
+++ b/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} rokov vymazaných! Moje kĺby sa opäť hýbu plynulo a moja energia sa vracia.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Cítim sa o {0} rokov mladší! Bremeno času bolo odstránené z môjho tela.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítim sa o niekoľko rokov mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutočný vek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>¡{0} años borrados! Mis articulaciones vuelven a moverse con suavidad y mi energía está regresando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>¡Me siento {0} años más joven! El peso del tiempo ha sido quitado de mi cuerpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
@@ -17,4 +17,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>¡{0} años borrados! Mis articulaciones vuelven a moverse con suavidad y mi energía está regresando.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>¡Me siento {0} años más joven! El peso del tiempo ha sido quitado de mi cuerpo.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
+++ b/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} år utraderade! Mina leder rör sig åter smidigt och min energi återvänder.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Jag känner mig {0} år yngre! Tidens börda har avlägsnats från min kropp.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jag känner mig några år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Verklig ålder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
+++ b/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} yıl silindi! Eklemlerim tekrar pürüzsüz hareket ediyor ve enerjim geri dönüyor.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Kendimi {0} yıl daha genç hissediyorum! Zamanın yükü bedenimden kaldırıldı.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Kendimi birkaç yıl daha genç hissediyorum.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Gerçek yaş</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
+++ b/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} років стерто! Мої суглоби знову рухаються плавно, і моя енергія повертається.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Я відчуваю себе на {0} років молодшим! Тягар часу було знято з мого тіла.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я відчуваю себе на кілька років молодшим.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Справжній вік</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
+++ b/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
@@ -18,4 +18,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>{0} năm đã bị xóa sổ! Các khớp của tôi lại cử động trơn tru và năng lượng đang trở lại.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Substantial>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>Tôi cảm thấy trẻ hơn {0} tuổi! Gánh nặng của thời gian đã được gỡ bỏ khỏi cơ thể tôi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Mild>
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tôi cảm thấy trẻ hơn vài năm.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
+
+    <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tuổi thật</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 </LanguageData>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ cure all age-related infirmities as well as every physical injury!
  • Luciferium need cannot be cured, nor can psychological addictions, though physical
    tolerances will disappear.
  • Resurrects dead Pawns that 1) have a brain and 2) haven't been left unrefrigerated for more than 1 day.
+ • Humanlike pawns now track a separate True Age, preserving total lived time even after de-aging.
+
+## Supported RimWorld Versions
+
+- RimWorld 1.2
+- RimWorld 1.3
+- RimWorld 1.4
+- RimWorld 1.5
+- RimWorld 1.6
+
+## Power Behavior
+
+- Idle CryoRegenesis caskets no longer require power.
+- If power fails, the casket falls back to normal cryptosleep behavior until power is restored.
 
 Stock up on Uranium. You'll need a whole lot of it!
 
@@ -37,18 +51,25 @@ Bringing someone back from the dead requires significant resources:
 ## New Mood Effects
 
 **"Grateful to be alive!" (Resurrection only)**
-- Humanlike pawns who are resurrected gain a powerful +28 mood buff lasting 60 days
+- Humanlike pawns who are resurrected gain a powerful +45 mood buff
+- This thought can last anywhere from 1 to 10 years
 - Represents the profound psychological impact of near-death experiences
 - Prevents post-resurrection mental breaks and helps colonists readjust to life
 
 **"I feel younger!" (Age Reversal)**
 - New staged mood buff based on years regenerated:
-  - 20 years reversed: +15 mood - "I feel 20 years younger!"
-  - 40 years reversed: +25 mood - "Substantially regenerated"
-  - 60 years reversed: +35 mood - "Majorly regenerated" 
-  - 80+ years reversed: +40 mood - "Fully regenerated"
-- Lasts 60 days as colonists enjoy their renewed youth
+  - 1-9 years reversed: around +15 mood - "Regenerated"
+  - 10-19 years reversed: around +20 mood - "Mildly regenerated"
+  - 20-39 years reversed: around +25 mood - "Substantially regenerated"
+  - 40-59 years reversed: around +35 mood - "Majorly regenerated"
+  - 60+ years reversed: around +40 mood - "Fully regenerated"
+- Exact mood impact varies because the thought includes a randomized bonus or penalty
+- Duration is variable rather than fixed:
+  - Usually 30 to 300 days
+  - 60 to 600 days if the pawn was recently resurrected
+  - Body Purists can experience even stronger and longer-lasting effects
 - Stacks with resurrection mood bonus when applicable
+- Strong rejuvenation can make some prisoners recruitable again
 
 ### Balance Notes
 The combination of resource costs and permanent Luciferium addiction ensures resurrection remains a serious decision rather than a casual convenience. Plan accordingly and maintain a steady Luciferium supply for your immortal colonists!
@@ -139,3 +160,11 @@ The combination of resource costs and permanent Luciferium addiction ensures res
 * **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
 * **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.
 
+**Version 6.0.0: 2026-05-25**
+* **[2026-05-25 09:08:39 COT]** Refactored out Cosmetics, Resurrection, and Happy Thoughts from the CryoRegenesis god class.
+* **[2026-05-25 09:27:53 COT]** Added a True Age mechanism for tracking total Living Time.
+* **[2026-05-25 10:12:55 COT]** Split the actual regenesis code out of the CroRegenesis god class.
+* **[2026-05-25 10:16:42 COT]** An idle cryoregenesis casket no longer needs power.
+* **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.
+* **[2026-05-25 12:39:21 COT]** Increased the research cost.
+* **[2026-05-25 12:43:28 COT]** Completely reimplemented the True Age display to not use global UI widgets.

--- a/Source/BetterRandom.cs
+++ b/Source/BetterRandom.cs
@@ -1,3 +1,14 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
 using System;
 
 namespace BetterRimworlds;

--- a/Source/CharacterCardAgePatch.cs
+++ b/Source/CharacterCardAgePatch.cs
@@ -1,3 +1,4 @@
+// ==== Source/CharacterCardAgePatch.cs ====
 /*
  * This file is part of CryoRegenesis, a Better Rimworlds Project.
  *
@@ -25,6 +26,44 @@ internal static class CharacterCardAgePatch
     private static readonly Color TrueAgeValueColor = new Color(0.8f, 0.9f, 0.1f);
     private static readonly Color CoverColor = new Color(0.13f, 0.13f, 0.13f);
 
+    private static GUIStyle trueAgeLabelStyle;
+    private static GUIStyle trueAgeValueStyle;
+
+    private static GUIStyle TrueAgeLabelStyle
+    {
+        get
+        {
+            if (trueAgeLabelStyle == null)
+            {
+                trueAgeLabelStyle = new GUIStyle(GUI.skin.label)
+                {
+                    alignment = TextAnchor.UpperLeft,
+                    richText = true,
+                    wordWrap = false,
+                    clipping = TextClipping.Clip
+                };
+
+                trueAgeLabelStyle.normal.textColor = TrueAgeLabelColor;
+            }
+
+            return trueAgeLabelStyle;
+        }
+    }
+
+    private static GUIStyle TrueAgeValueStyle
+    {
+        get
+        {
+            if (trueAgeValueStyle == null)
+            {
+                trueAgeValueStyle = new GUIStyle(TrueAgeLabelStyle);
+                trueAgeValueStyle.normal.textColor = TrueAgeValueColor;
+            }
+
+            return trueAgeValueStyle;
+        }
+    }
+
     private static MethodBase TargetMethod()
     {
         return AccessTools.Method(typeof(CharacterCardUtility), "DrawCharacterCard");
@@ -37,36 +76,66 @@ internal static class CharacterCardAgePatch
             return;
         }
 
-        TrueAgeTracker tracker = pawn.health?.hediffSet?.GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+        TrueAgeTracker tracker =
+            pawn.health?.hediffSet?.GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+
         if (tracker == null)
         {
             return;
         }
 
         float trueAgeYears = tracker.GetTrueAgeYears();
-        string label = $"<b>{"BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate()}:</b> ";
+
+        string translatedLabel = "BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate();
+        string label = $"<b>{translatedLabel}:</b> ";
         string value = $"<b>{trueAgeYears:F2}</b>";
 
-        Text.Font = GameFont.Small;
-        Text.Anchor = TextAnchor.UpperLeft;
+        GUIStyle labelStyle = TrueAgeLabelStyle;
+        GUIStyle valueStyle = TrueAgeValueStyle;
 
-        Rect lineRect = new Rect(rect.x, rect.y + 66f, rect.width, Text.LineHeight);
-        Color oldColor = GUI.color;
+        float lineHeight = labelStyle.CalcHeight(new GUIContent(label), rect.width);
+        if (lineHeight <= 0f)
+        {
+            lineHeight = 24f;
+        }
+
+        Rect lineRect = new Rect(rect.x, rect.y + 66f, rect.width, lineHeight);
+
         Widgets.DrawBoxSolid(lineRect, CoverColor);
-        GUI.color = TrueAgeLabelColor;
-        Widgets.Label(lineRect, label);
 
-        float labelWidth = Text.CalcSize(label.StripTags()).x;
-        Rect valueRect = new Rect(lineRect.x + labelWidth, lineRect.y, lineRect.width - labelWidth, lineRect.height);
-        GUI.color = TrueAgeValueColor;
-        Widgets.Label(valueRect, value);
-        GUI.color = oldColor;
+        GUI.Label(lineRect, label, labelStyle);
 
+        float labelWidth = labelStyle.CalcSize(new GUIContent(label)).x;
+        Rect valueRect = new Rect(
+            lineRect.x + labelWidth,
+            lineRect.y,
+            lineRect.width - labelWidth,
+            lineRect.height
+        );
+
+        GUI.Label(valueRect, value, valueStyle);
+
+        // Less than ideal. Translates but wraps along the lines.
+        // int bioYears, bioQuadrums, bioDays;
+        // int chronoYears, chronoQuads, chronoDays;
+        // float bioHours = 0f, chronoHours;
+        //
+        // pawn.ageTracker.AgeBiologicalTicks.TicksToPeriod(out bioYears, out bioQuadrums, out bioDays, out bioHours);
+        // pawn.ageTracker.AgeChronologicalTicks.TicksToPeriod(out chronoYears, out chronoQuads, out chronoDays, out chronoHours);
+        //
+        // TooltipHandler.TipRegion(
+        //     lineRect,
+        //     $"{translatedLabel}: {"PeriodYears".Translate(trueAgeYears)}\n" +
+        //     $"{"AgeBiological".Translate(bioYears, bioQuadrums, bioDays)}\n" +
+        //     $"{"AgeChronological".Translate(chronoYears, chronoQuads, chronoDays)}"
+        // );
+
+        // Doesn't translate but looks much better.
         TooltipHandler.TipRegion(
             lineRect,
-            $"{"BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate()}: {trueAgeYears:F2} years\n" +
-            $"{"Biological Age".Translate()}: {pawn.ageTracker.AgeBiologicalYearsFloat:F2} years\n" +
-            $"{"Chronological Age".Translate()}: {pawn.ageTracker.AgeChronologicalYearsFloat:F2} years"
+            $"{translatedLabel}: {trueAgeYears:N2} years\n" +
+            $"Biological age: {pawn.ageTracker.AgeBiologicalYearsFloat:N2} years\n" +
+            $"Chronological age: {pawn.ageTracker.AgeChronologicalYearsFloat:N2} years"
         );
     }
 }

--- a/Source/CharacterCardAgePatch.cs
+++ b/Source/CharacterCardAgePatch.cs
@@ -1,0 +1,72 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+[HarmonyPatch]
+internal static class CharacterCardAgePatch
+{
+    private static readonly Color TrueAgeLabelColor = new Color(0.87059f, 0.16078f, 0.06275f);
+    // private static readonly Color TrueAgeValueColor = new Color(0.228f, 0.58f, 1f);
+    private static readonly Color TrueAgeValueColor = new Color(0.8f, 0.9f, 0.1f);
+    private static readonly Color CoverColor = new Color(0.13f, 0.13f, 0.13f);
+
+    private static MethodBase TargetMethod()
+    {
+        return AccessTools.Method(typeof(CharacterCardUtility), "DrawCharacterCard");
+    }
+
+    private static void Postfix(Rect rect, Pawn pawn)
+    {
+        if (pawn?.ageTracker == null)
+        {
+            return;
+        }
+
+        TrueAgeTracker tracker = pawn.health?.hediffSet?.GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+        if (tracker == null)
+        {
+            return;
+        }
+
+        float trueAgeYears = tracker.GetTrueAgeYears();
+        string label = $"<b>{"BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate()}:</b> ";
+        string value = $"<b>{trueAgeYears:F2}</b>";
+
+        Text.Font = GameFont.Small;
+        Text.Anchor = TextAnchor.UpperLeft;
+
+        Rect lineRect = new Rect(rect.x, rect.y + 66f, rect.width, Text.LineHeight);
+        Color oldColor = GUI.color;
+        Widgets.DrawBoxSolid(lineRect, CoverColor);
+        GUI.color = TrueAgeLabelColor;
+        Widgets.Label(lineRect, label);
+
+        float labelWidth = Text.CalcSize(label.StripTags()).x;
+        Rect valueRect = new Rect(lineRect.x + labelWidth, lineRect.y, lineRect.width - labelWidth, lineRect.height);
+        GUI.color = TrueAgeValueColor;
+        Widgets.Label(valueRect, value);
+        GUI.color = oldColor;
+
+        TooltipHandler.TipRegion(
+            lineRect,
+            $"{"BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate()}: {trueAgeYears:F2} years\n" +
+            $"{"Biological Age".Translate()}: {pawn.ageTracker.AgeBiologicalYearsFloat:F2} years\n" +
+            $"{"Chronological Age".Translate()}: {pawn.ageTracker.AgeChronologicalYearsFloat:F2} years"
+        );
+    }
+}

--- a/Source/Cosmetics.cs
+++ b/Source/Cosmetics.cs
@@ -1,0 +1,173 @@
+// ==== ./Source/PawnCosmetics.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Random = System.Random;
+
+// ReSharper disable All
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class Cosmetics
+{
+    private readonly Random rnd = new Random();
+
+    public bool PossiblyChangeHairColor(Pawn pawn)
+    {
+        // This only affects human-like pawns.
+        if (pawn.RaceProps.Humanlike == false)
+        {
+            return false;
+        }
+
+        // If they have white or gray hair already, definitely change it!
+        if (this.HasWhiteOrGrayHair(pawn))
+        {
+            int pawnAge = pawn.ageTracker.AgeBiologicalYears;
+            if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawn.gender} and {pawnAge} years old.");
+            // Substantially reduce the odds if the pawn is over the age of 50 (-10% per year).
+            if (pawnAge >= 50)
+            {
+                if (pawnAge >= 60)
+                {
+                    if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn age ({pawnAge}) is over 60, not changing hair color.");
+                    return false;
+                }
+
+                int rangeMax = pawnAge - 50 + 1;
+                int randomNum = rnd.Next(0, pawnAge - 50 + 1);
+                if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn age ({pawnAge}) is >= 50 < 60, max range: {rangeMax}. Random number = {randomNum}.");
+
+                // 0-1 @ 50 = 50%; 0-2 @ 51 = 33% chance, 0-3 @ 52 = 25% ... 0-10 @ 59 = 9%
+                if (randomNum == 0)
+                {
+                    if (CryoRegenesis.Settings.debugMode) Log.Message("Changing the hair color!!");
+                    return this.ChangeHairColorRandomly(pawn);
+                }
+
+                return false;
+            }
+            // If the pawn is male and older than 55, definitely change it.
+            // -or-
+            // If the pawn is female and older than 30, definitely change it.
+            else if (
+                (pawn.gender == Gender.Male && pawnAge <= 55) ||
+                (pawn.gender == Gender.Female && pawnAge <= 30)
+                )
+            {
+                if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawnAge} years old and prematurely balding. Changing the hair color!!");
+                return this.ChangeHairColorRandomly(pawn);
+            }
+        }
+
+        var dice1 = rnd.Next(1, 7);
+        var dice2 = rnd.Next(1, 7);
+        var diceSum = dice1 + dice2;
+
+        if (CryoRegenesis.Settings.debugMode) Log.Message($"Dice rolls: ({dice1}, {dice2}) = {diceSum}");
+
+        // One in Three chance that their hair color will be changed otherwise.
+        // Stats taken from https://statweb.stanford.edu/~susan/courses/s60/split/node65.html (http://archive.is/wip/v39lj)
+        // 2 = 2.78%, 3 = 5.56%, 4 = 8.33%, 5 = 11.11%, 11 = 5.56% = 33.34%
+        if (diceSum <= 5 || diceSum == 11)
+        {
+            Log.Message("Fate smiles in their favor! Changing the hair color!!");
+            return this.ChangeHairColorRandomly(pawn);
+        }
+
+        return false;
+    }
+
+    private List<Color> GetHairColors()
+    {
+        var BRIGHTRED   = new Color(237.00f / 256.0f, 41.00f / 256.0f, 57.00f / 256.0f);
+        var DARKRED     = new Color(146.00f / 256.0f, 39.00f / 256.0f, 36.00f / 256.0f);
+        var HAZEL       = new Color(132.61f / 256.0f, 83.20f / 256.0f, 47.10f / 256.0f);
+        var BROWN       = new Color(64.00f / 256.0f, 51.20f / 256.0f, 38.40f / 256.0f);
+        var DARKBROWN   = new Color(51.20f / 256.0f, 51.20f / 256.0f, 51.20f / 256.0f);
+        var BLACK       = new Color(51.20f / 256.0f, 51.20f / 256.0f, 51.20f / 256.0f);
+        var DARKBLACK   = new Color(20.20f / 256.0f, 20.20f / 256.0f, 20.20f / 256.0f);
+        var BLONDE      = new Color(222.00f / 256.0f, 188.00f / 256.0f, 153.00f / 256.0f);
+        var LIGHTBLONDE = new Color(250.00f / 256.0f, 240.00f / 256.0f, 190.00f / 256.0f);
+
+        var colorList = new List<Color>()
+        {
+            BRIGHTRED, DARKRED, HAZEL, BLONDE, LIGHTBLONDE
+        };
+
+        return colorList;
+    }
+
+    private void RerenderPawn(Pawn pawn)
+    {
+        #if !RIMWORLD15 && !RIMWORLD16
+        // Tell the pawn's Drawer that the Person has had a hair-change makeover.
+        // This code is from https://github.com/KiameV/rimworld-changedresser/blob/f0b8fcf9073cd1c232fcd26b0b083cb3137924a3/Source/UI/DresserUI.cs
+        // Copyright (c) 2017 Travis Offtermatt
+        // MIT License
+        pawn.Drawer.renderer.graphics.ResolveAllGraphics();
+        #else
+        pawn.Drawer.renderer.renderTree.SetDirty();
+        #endif
+        PortraitsCache.SetDirty(pawn);
+    }
+
+    private void ChangeHairColor(Pawn pawn, Color hairColor)
+    {
+        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
+        pawn.story.HairColor = hairColor;
+        #else
+        pawn.story.hairColor = hairColor;
+        #endif
+        this.RerenderPawn(pawn);
+    }
+
+    private bool ChangeHairColorRandomly(Pawn pawn)
+    {
+        if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawn.ageTracker.AgeChronologicalYears} chronological years old ({pawn.ageTracker.AgeChronologicalTicks} Ticks)");
+        int seed = Convert.ToInt32(pawn.ageTracker.AgeChronologicalTicks > Int32.MaxValue - 1
+            ? pawn.ageTracker.AgeChronologicalTicks % Int32.MaxValue
+            : pawn.ageTracker.AgeChronologicalTicks);
+
+        var rnd = new Random(seed);
+        var colorList = this.GetHairColors();
+
+        this.ChangeHairColor(pawn, colorList[rnd.Next(colorList.Count)]);
+
+        return true;
+    }
+
+    private bool HasWhiteOrGrayHair(Pawn pawn)
+    {
+        string hsv;
+        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
+        Color hairColor = pawn.story.HairColor;
+        #else
+        Color hairColor = pawn.story.hairColor;
+        #endif
+        Color.RGBToHSV(hairColor, out float H, out float S, out float V);
+        S *= 100;
+        V *= 100;
+        hsv = string.Format("{0:0.00}°, {1:0.00}%, {2:0.00}%", H, S, V);
+
+        if (CryoRegenesis.Settings.debugMode) Log.Message("Pawn's hair color: " + hairColor + " (" + hsv + " HSV)" + "; body type: " + pawn.story.bodyType);
+
+        // if (H <= 5 && S <= 5 && V >= 40)
+        // {
+        //     Log.Message("Grey / White hair detected!");
+        // }
+
+        return (H < 5 && S <= 5 && V >= 40);
+    }
+}

--- a/Source/CryoRegenesis.TrueAge.cs
+++ b/Source/CryoRegenesis.TrueAge.cs
@@ -1,0 +1,74 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public partial class Building_CryoRegenesis
+{
+    // Original biological age in ticks when the pawn entered CryoRegenesis.
+    // Used to calculate exact de-aging for the TrueAgeTracker ledger.
+    private long origBiologicalAgeTicks = -1L;
+
+    private void ExposeTrueAgeData()
+    {
+        Scribe_Values.Look(ref this.origBiologicalAgeTicks, "OrigBiologicalAgeTicks", -1L);
+    }
+
+    private void RecordTrueAgeSnapshot(Pawn pawn)
+    {
+        if (pawn?.ageTracker == null)
+        {
+            this.origBiologicalAgeTicks = -1L;
+            return;
+        }
+
+        this.origBiologicalAgeTicks = pawn.ageTracker.AgeBiologicalTicks;
+    }
+
+    private void ApplyTrueAgeOnEject(Pawn pawn)
+    {
+        // Update the TrueAgeTracker with the exact de-aging that occurred.
+        //
+        // This is done once, on ejection, instead of every de-aging tick.
+        // At this moment the procedure is complete and the final biological
+        // age is known.
+        if (pawn == null || this.origBiologicalAgeTicks <= 0)
+        {
+            return;
+        }
+
+        long removedAgeTicks = this.origBiologicalAgeTicks - pawn.ageTracker.AgeBiologicalTicks;
+        if (removedAgeTicks <= 0)
+        {
+            return;
+        }
+
+        try
+        {
+            TrueAgeTracker tracker =
+                RegenesisThoughts.GetOrAddTrueAgeTracker(pawn, this.origBiologicalAgeTicks);
+            tracker?.RecordCryoRegenesisDeAging(removedAgeTicks);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"[CryoRegenesis] Failed to update true-age tracking for {pawn.Name}; ejecting anyway. {ex}");
+        }
+    }
+
+    private void ResetTrueAgeTracking()
+    {
+        this.origBiologicalAgeTicks = -1L;
+    }
+}

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -1,7 +1,8 @@
+// ==== ./Source/CryoRegenesis.cs ====
 /*
  * This file is part of CryoRegenesis, a Better Rimworlds Project.
  *
- * Copyright © 2020-2024 Theodore R. Smith
+ * Copyright © 2020-2026 Theodore R. Smith
  * Author: Theodore R. Smith <hopeseekr@gmail.com>
  *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
  *   https://github.com/BetterRimworlds/CryoRegenesis
@@ -18,6 +19,7 @@ using Verse;
 // ReSharper disable All
 
 namespace BetterRimworlds.CryoRegenesis;
+
 public class CryoRegenesis: Mod
 {
     public static Settings Settings;
@@ -52,6 +54,8 @@ public class CryoRegenesis: Mod
 public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 {
     private Random rnd = new Random();
+    private readonly Cosmetics cosmetics = new Cosmetics();
+    private readonly Resurrector resurrector = new Resurrector();
 
     private bool enteredHealthy = false;
 
@@ -126,9 +130,12 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 
         // Require more fuel for faster rates.
         float fuelPerReversedYear = 1.0f * ((float)rate / 250);
-
-        fuelConsumption =  fuelPerReversedYear / ((float)GenDate.TicksPerYear / rate);
+        fuelConsumption = fuelPerReversedYear / ((float)GenDate.TicksPerYear / rate);
         // Log.Message("Fuel consumption per Tick: " + fuelConsumption);
+
+        resurrector.Initialize(refuelable, fuelprops, power,
+            onRejected:    () => base.EjectContents(),
+            onResurrected: HandleResurrectionComplete);
 
         if (HasAnyContents)
         {
@@ -139,12 +146,19 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             }
             else if (ContainedThing is Corpse corpse)
             {
-                var rotProgress = corpse.GetComp<CompRottable>().RotProgress;
-                this.InitialRot = rotProgress;
+                resurrector.InitialRot = corpse.GetComp<CompRottable>().RotProgress;
             }
-    }
+        }
 
         this.contentsKnown = true;
+    }
+
+    private void HandleResurrectionComplete(Pawn pawn)
+    {
+        power.PowerOn = false;
+        power.PowerOutput = 0;
+        this.EjectContents();
+        pawn.health.AddHediff(HediffDefOf.Anesthetic, null, null);
     }
 
     private int determineCurableInjuries(Pawn pawn)
@@ -274,14 +288,16 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
     public override void ExposeData()
     {
         base.ExposeData();
-        string fuelReqs = String.Join(",", this.ResurrectionFuelReqs);
+        string fuelReqs = String.Join(",", resurrector.ResurrectionFuelReqs);
         Scribe_Values.Look<string>(ref fuelReqs, "ResurrectionFuelReqs");
-        Scribe_Values.Look<float>(ref ResurrectionProgress, "ResurrectionProgress", 0f);
+        float resProgress = resurrector.ResurrectionProgress;
+        Scribe_Values.Look<float>(ref resProgress, "ResurrectionProgress", 0f);
+        resurrector.ResurrectionProgress = resProgress;
         Scribe_Values.Look(ref origAge, "OrigAge", 50);
 
         if (String.IsNullOrEmpty(fuelReqs) == false)
         {
-            this.ResurrectionFuelReqs = fuelReqs.Split(',').Select(int.Parse).ToArray();
+            resurrector.ResurrectionFuelReqs = fuelReqs.Split(',').Select(int.Parse).ToArray();
         }
     }
 
@@ -331,164 +347,6 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         }
     }
 
-    private float ResurrectionProgress = 0f;
-    private const int REQ_GOLD = 500;
-    private const int REQ_URANIUM = 150;
-    private const int REQ_LUCIFERIUM = 50;
-    private int[] ResurrectionFuelReqs = new int[3]{REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM};
-    private float InitialRot = -1;
-
-    private void ResetFuelRequirement()
-    {
-        this.fuelprops.fuelFilter = new ThingFilter();
-        this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium, true);
-        this.ResurrectionFuelReqs[0] -= (int)this.refuelable.Fuel;
-        this.fuelprops.fuelCapacity = 150;
-        this.ResurrectionProgress = 0f;
-    }
-
-    private void Resurrect(Corpse corpse)
-    {
-        // Make sure that they have a brain. Everything else is optional.
-        var deadPawn = corpse.InnerPawn;
-        var pawnBrain = deadPawn.health.hediffSet.GetBrain();
-        if (pawnBrain == null)
-        {
-            Messages.Message("[CryoRegenesis] Pawn rejected: No brain.", MessageTypeDefOf.RejectInput);
-            base.EjectContents();
-            return;
-        }
-
-        // Make sure that the corpse isn't more than 10% degraded.
-        var rottable = corpse.GetComp<CompRottable>();
-        // If they've been dead and unfrozen for more than 1 day, the CryoRegenesis casket cannot resurrect them.
-        if (rottable != null && rottable.RotProgress > 60_000)
-        {
-            Messages.Message("[CryoRegenesis] Pawn rejected: More than 1 day unfrozen ("  + rottable.RotProgress +"). Their brain is too degraded.", MessageTypeDefOf.RejectInput);
-            base.EjectContents();
-            return;
-        }
-
-        // --- State Machine for Resource Gathering ---
-
-        // State 1: Need Luciferium (first priority as requested)
-        if (this.ResurrectionFuelReqs[2] > 0)
-        {
-            // Configure the refuelable component to accept Luciferium
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium, false);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold, false);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, true);
-
-            // Set the capacity to what is still needed
-            this.fuelprops.fuelCapacity = this.ResurrectionFuelReqs[2];
-
-            // If fuel has been delivered, process it
-            if (this.refuelable.Fuel > 0)
-            {
-                int delivered = (int)Math.Ceiling(this.refuelable.Fuel);
-                this.ResurrectionFuelReqs[2] -= delivered; // Fixed index to update Luciferium
-                this.refuelable.ConsumeFuel(this.refuelable.Fuel);
-                Log.Message($"[CryoRegenesis] Luciferium delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[2]}");
-            }
-
-            // Stop processing for this tick; we are waiting for more fuel.
-            return;
-        }
-        // State 2: Need Uranium (checked after Luciferium is complete)
-        else if (this.ResurrectionFuelReqs[0] > 0)
-        {
-            // Configure the refuelable component to accept Uranium
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium, true);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold, false);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, false);
-
-            // Set the capacity to what is still needed
-            this.fuelprops.fuelCapacity = this.ResurrectionFuelReqs[0];
-
-            // If fuel has been delivered, process it
-            if (this.refuelable.Fuel > 0)
-            {
-                int delivered = (int)Math.Ceiling(this.refuelable.Fuel);
-                this.ResurrectionFuelReqs[0] -= delivered;
-                this.refuelable.ConsumeFuel(this.refuelable.Fuel);
-                Log.Message($"[CryoRegenesis] Uranium delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[0]}");
-            }
-
-            // Stop processing for this tick; we are waiting for more fuel.
-            return;
-        }
-        // State 3: Need Gold (checked after Luciferium and Uranium are complete)
-        else if (this.ResurrectionFuelReqs[1] > 0)
-        {
-            // Configure the refuelable component to accept Gold
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium, false);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold, true);
-            this.fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, false);
-
-            // Set the capacity to what is still needed
-            this.fuelprops.fuelCapacity = this.ResurrectionFuelReqs[1];
-
-            // If fuel has been delivered, process it
-            if (this.refuelable.Fuel > 0)
-            {
-                int delivered = (int)Math.Ceiling(this.refuelable.Fuel);
-                this.ResurrectionFuelReqs[1] -= delivered;
-                this.refuelable.ConsumeFuel(this.refuelable.Fuel);
-                Log.Message($"[CryoRegenesis] Gold delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[1]}");
-            }
-
-            // Stop processing for this tick; we are waiting for more fuel.
-            return;
-        }
-
-        if (Find.TickManager.TicksGame % 1000 == 0)
-        {
-            return;
-        }
-
-        // --- Resurrection Progress (only runs if all fuel requirements are met) ---
-        // The check for fuel requirements is implicitly handled by falling through the if/else-if chain.
-
-        // Turn off refueling now that we're full
-        this.fuelprops.fuelCapacity = 0;
-
-        // Adjust this value to control resurrection speed
-        float resurrectionFactor = 0.001f;
-
-        // Increment progress
-        this.ResurrectionProgress += resurrectionFactor;
-        this.ResurrectionProgress = Mathf.Clamp01(this.ResurrectionProgress); // Ensure it stays between 0 and 1
-
-        if (CryoRegenesis.Settings.debugMode)
-            Log.Message($"[CryoRegenesis] Resurrection Progress: {this.ResurrectionProgress * 100:F1}%");
-
-        // Check if resurrection is complete
-        if (this.ResurrectionProgress >= 1.0f)
-        {
-            var resurrectedPawn = corpse.InnerPawn;
-            Log.Message($"[CryoRegenesis] {resurrectedPawn.Name} has been resurrected!");
-            Messages.Message($"[CryoRegenesis] {resurrectedPawn.Name} has been resurrected!", resurrectedPawn, MessageTypeDefOf.PositiveEvent);
-
-    #if RIMWORLD15 || RIMWORLD16
-            ResurrectionUtility.TryResurrectWithSideEffects(resurrectedPawn);
-    #else
-            ResurrectionUtility.ResurrectWithSideEffects(resurrectedPawn);
-    #endif
-
-            power.PowerOn = false;
-            power.PowerOutput = 0;
-            this.ResurrectionProgress = 0f;
-
-            this.EjectContents();
-
-            resurrectedPawn.health.AddHediff(HediffDefOf.Anesthetic, null, null);
-            this.AddLuciferiumAsResurrectionSideEffect(resurrectedPawn);
-
-            // Reset fuel requirements for the next pawn
-            this.ResetFuelRequirement();
-        }
-    }
-
     #if RIMWORLD16
     protected override void Tick()
     #else
@@ -502,7 +360,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 
         if (!HasAnyContents)
         {
-            this.ResetFuelRequirement();
+            resurrector.ResetFuelRequirement();
             return;
         }
 
@@ -514,8 +372,8 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
                 // Turn off / pause rotting once inside.
                 var corpse = ContainedThing as Corpse;
                 var rottable = corpse.GetComp<CompRottable>();
-                rottable.RotProgress = this.InitialRot;
-                this.Resurrect(corpse);
+                rottable.RotProgress = resurrector.InitialRot;
+                resurrector.Process(corpse);
             }
 
             return;
@@ -647,6 +505,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         else
             power.PowerOutput = 0;
     }
+
     public override void EjectContents()
     {
         if (ContainedThing is not Pawn)
@@ -679,12 +538,12 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
                 pawn.needs.comfort.SetInitialLevel();
             }
 
-            this.possiblyChangeHairColor(pawn);
+            cosmetics.PossiblyChangeHairColor(pawn);
 
             // Give them a positive thought.
             int currentAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
 
-            AddCryoregenesisThought(pawn, this.origAge, currentAge);
+            RegenesisThoughts.AddBodyPositivityThought(pawn, this.origAge, currentAge);
         }
 
         pawn.needs.rest.SetInitialLevel();
@@ -701,154 +560,6 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         // }
     }
 
-    protected List<Color> getHairColors()
-    {
-        var BRIGHTRED   = new Color(237.00f / 256.0f, 41.00f / 256.0f, 57.00f / 256.0f);
-        var DARKRED     = new Color(146.00f / 256.0f, 39.00f / 256.0f, 36.00f / 256.0f);
-        var HAZEL       = new Color(132.61f / 256.0f, 83.20f / 256.0f, 47.10f / 256.0f);
-        var BROWN       = new Color(64.00f / 256.0f, 51.20f / 256.0f, 38.40f / 256.0f);
-        var DARKBROWN   = new Color(51.20f / 256.0f, 51.20f / 256.0f, 51.20f / 256.0f);
-        var BLACK       = new Color(51.20f / 256.0f, 51.20f / 256.0f, 51.20f / 256.0f);
-        var DARKBLACK   = new Color(20.20f / 256.0f, 20.20f / 256.0f, 20.20f / 256.0f);
-        var BLONDE      = new Color(222.00f / 256.0f, 188.00f / 256.0f, 153.00f / 256.0f);
-        var LIGHTBLONDE = new Color(250.00f / 256.0f, 240.00f / 256.0f, 190.00f / 256.0f);
-
-        var colorList = new List<Color>()
-        {
-            BRIGHTRED, DARKRED, HAZEL, BLONDE, LIGHTBLONDE
-        };
-
-        return colorList;
-    }
-
-    protected void rerenderPawn(Pawn pawn)
-    {
-        #if !RIMWORLD15 && !RIMWORLD16
-        // Tell the pawn's Drawer that the Person has had a hair-change makeover.
-        // This code is from https://github.com/KiameV/rimworld-changedresser/blob/f0b8fcf9073cd1c232fcd26b0b083cb3137924a3/Source/UI/DresserUI.cs
-        // Copyright (c) 2017 Travis Offtermatt
-        // MIT License
-        pawn.Drawer.renderer.graphics.ResolveAllGraphics();
-        #else
-        pawn.Drawer.renderer.renderTree.SetDirty();
-        #endif
-        PortraitsCache.SetDirty(pawn);
-    }
-
-    protected void changeHairColor(Pawn pawn, Color hairColor)
-    {
-        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
-        pawn.story.HairColor = hairColor;
-        #else
-        pawn.story.hairColor = hairColor;
-        #endif
-        this.rerenderPawn(pawn);
-    }
-
-    protected bool changeHairColorRandomly(Pawn pawn)
-    {
-        if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawn.ageTracker.AgeChronologicalYears} chronological years old ({pawn.ageTracker.AgeChronologicalTicks} Ticks)");
-        int seed = Convert.ToInt32(pawn.ageTracker.AgeChronologicalTicks > Int32.MaxValue - 1
-            ? pawn.ageTracker.AgeChronologicalTicks % Int32.MaxValue
-            : pawn.ageTracker.AgeChronologicalTicks);
-
-        var rnd = new Random(seed);
-        var colorList = this.getHairColors();
-
-        this.changeHairColor(pawn, colorList[rnd.Next(colorList.Count)]);
-
-        return true;
-    }
-
-    protected bool hasWhiteOrGrayHair(Pawn pawn)
-    {
-        string hsv;
-        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
-        Color hairColor = pawn.story.HairColor;
-        #else
-        Color hairColor = pawn.story.hairColor;
-        #endif
-        Color.RGBToHSV(hairColor, out float H, out float S, out float V);
-        S *= 100;
-        V *= 100;
-        hsv = string.Format("{0:0.00}°, {1:0.00}%, {2:0.00}%", H, S, V);
-
-        if (CryoRegenesis.Settings.debugMode) Log.Message("Pawn's hair color: " + hairColor + " (" + hsv + " HSV)" + "; body type: " + pawn.story.bodyType);
-
-        // if (H <= 5 && S <= 5 && V >= 40)
-        // {
-        //     Log.Message("Grey / White hair detected!");
-        // }
-
-        return (H < 5 && S <= 5 && V >= 40);
-    }
-
-    protected bool possiblyChangeHairColor(Pawn pawn)
-    {
-        // This only affects human-like pawns.
-        if (pawn.RaceProps.Humanlike == false)
-        {
-            return false;
-        }
-
-        // If they have white or gray hair already, definitely change it!
-        if (this.hasWhiteOrGrayHair(pawn))
-        {
-            int pawnAge = pawn.ageTracker.AgeBiologicalYears;
-            if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawn.gender} and {pawnAge} years old.");
-            // Substantially reduce the odds if the pawn is over the age of 50 (-10% per year).
-            if (pawnAge >= 50)
-            {
-                if (pawnAge >= 60)
-                {
-                    if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn age ({pawnAge}) is over 60, not changing hair color.");
-                    return false;
-                }
-
-                int rangeMax = pawnAge - 50 + 1;
-                int randomNum = rnd.Next(0, pawnAge - 50 + 1);
-                if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn age ({pawnAge}) is >= 50 < 60, max range: {rangeMax}. Random number = {randomNum}.");
-
-                // 0-1 @ 50 = 50%; 0-2 @ 51 = 33% chance, 0-3 @ 52 = 25% ... 0-10 @ 59 = 9%
-                if (randomNum == 0)
-                {
-                    if (CryoRegenesis.Settings.debugMode) Log.Message("Changing the hair color!!");
-                    return this.changeHairColorRandomly(pawn);
-                }
-
-                return false;
-            }
-            // If the pawn is male and older than 55, definitely change it.
-            // -or-
-            // If the pawn is female and older than 30, definitely change it.
-            else if (
-                (pawn.gender == Gender.Male && pawnAge <= 55) ||
-                (pawn.gender == Gender.Female && pawnAge <= 30)
-                )
-            {
-                if (CryoRegenesis.Settings.debugMode) Log.Message($"Pawn is {pawnAge} years old and prematurely balding. Changing the hair color!!");
-                return this.changeHairColorRandomly(pawn);
-            }
-        }
-
-        var dice1 = rnd.Next(1, 7);
-        var dice2 = rnd.Next(1, 7);
-        var diceSum = dice1 + dice2;
-
-        if (CryoRegenesis.Settings.debugMode) Log.Message($"Dice rolls: ({dice1}, {dice2}) = {diceSum}");
-
-        // One in Three chance that their hair color will be changed otherwise.
-        // Stats taken from https://statweb.stanford.edu/~susan/courses/s60/split/node65.html (http://archive.is/wip/v39lj)
-        // 2 = 2.78%, 3 = 5.56%, 4 = 8.33%, 5 = 11.11%, 11 = 5.56% = 33.34%
-        if (diceSum <= 5 || diceSum == 11)
-        {
-            Log.Message("Fate smiles in their favor! Changing the hair color!!");
-            return this.changeHairColorRandomly(pawn);
-        }
-
-        return false;
-    }
-
     public override bool TryAcceptThing(Thing thing, bool allowSpecialEffects = true)
     {
         if (thing == null)
@@ -861,12 +572,11 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
             return false;
         }
 
-        this.InitialRot = -1;
+        resurrector.InitialRot = -1f;
 
         if (thing.def.defName.StartsWith("Corpse_"))
         {
-            this.ResurrectionProgress = 0f;
-            this.ResurrectionFuelReqs = new int[3]{REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM};
+            resurrector.ResetForNewCorpse();
 
             bool status = base.TryAcceptThing(thing, allowSpecialEffects);
             if (status)
@@ -874,7 +584,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
                 // Record the initial rot level.
                 var corpse = ContainedThing as Corpse;
                 var rottable = corpse.GetComp<CompRottable>();
-                this.InitialRot = rottable.RotProgress;
+                resurrector.InitialRot = rottable.RotProgress;
             }
 
             return status;
@@ -935,18 +645,18 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
                     debugString = $"; Rotting: {rotProgress}";
                 }
 
-                string status = $"Dead (Resurrecting: {this.ResurrectionProgress * 100:F1}%{debugString})\n";
-                if (this.ResurrectionFuelReqs[2] > 0)
+                string status = $"Dead (Resurrecting: {resurrector.ResurrectionProgress * 100:F1}%{debugString})\n";
+                if (resurrector.ResurrectionFuelReqs[2] > 0)
                 {
-                    status += "Needed Luciferium: " + this.ResurrectionFuelReqs[2] + "\n";
+                    status += "Needed Luciferium: " + resurrector.ResurrectionFuelReqs[2] + "\n";
                 }
-                else if (this.ResurrectionFuelReqs[0] > 0)
+                else if (resurrector.ResurrectionFuelReqs[0] > 0)
                 {
-                    status += "Needed Uranium: " + this.ResurrectionFuelReqs[0] + "\n";
+                    status += "Needed Uranium: " + resurrector.ResurrectionFuelReqs[0] + "\n";
                 }
-                else if (this.ResurrectionFuelReqs[1] > 0)
+                else if (resurrector.ResurrectionFuelReqs[1] > 0)
                 {
-                    status += "Needed Gold: " + this.ResurrectionFuelReqs[1] + "\n";
+                    status += "Needed Gold: " + resurrector.ResurrectionFuelReqs[1] + "\n";
                 }
 
                 return status + base.GetInspectString();
@@ -987,63 +697,5 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         Log.Message("Target age: " + this.targetAge);
 
         return this.targetAge;
-    }
-
-    public void AddLuciferiumAsResurrectionSideEffect(Pawn pawn)
-    {
-        if (pawn?.health?.hediffSet == null)
-            return;
-
-        // Add the addiction directly
-        HediffDef luciferiumAddiction = DefDatabase<HediffDef>.GetNamed("LuciferiumAddiction");
-        Hediff addictionHediff = HediffMaker.MakeHediff(luciferiumAddiction, pawn);
-        pawn.health.AddHediff(addictionHediff);
-
-        // Important: Set the last dose time to prevent immediate withdrawal
-        Need_Chemical drugNeed = pawn.needs?.AllNeeds.OfType<Need_Chemical>()
-            .FirstOrDefault(n => n.def.defName == "Chemical_Luciferium");
-
-        if (drugNeed != null)
-        {
-            drugNeed.CurLevel = drugNeed.MaxLevel; // Start them off satisfied
-        }
-
-        pawn.needs?.mood?.thoughts?.memories?.TryGainMemory(
-            DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_LuciferiumSideEffect")
-        );
-    }
-
-    public static void AddCryoregenesisThought(Pawn pawn, int origAge, int newAge)
-    {
-        int yearsRegressed = origAge - newAge;
-        if (yearsRegressed <= 0) return;
-
-        // Get the def
-        var thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_BodyPositivity");
-
-        // Create the thought instance manually so we can initialize it
-        var thought = ThoughtMaker.MakeThought(thoughtDef) as Thought_RegenesisBodyPositivity;
-        if (thought == null) return;
-
-        // Set the years BEFORE adding it to the pawn
-        thought.SetYearsReversed(yearsRegressed);
-
-        // Add the initialized thought instance (not the def)
-        pawn.needs.mood?.thoughts.memories.TryGainMemory(thought);
-
-        if (CryoRegenesis.Settings.debugMode)
-            Log.Warning($"Old age {origAge} | New age: {newAge} | Years reversed: {yearsRegressed} | Stage: {thought.CurStageIndex}");
-
-        // Use the thought's actual stage for the prisoner check
-        #if !RIMWORLD12 && !RIMWORLD13
-        if (thought.CurStageIndex >= 2)
-        {
-            if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
-            {
-                pawn.guest.Recruitable = true;
-                Messages.Message("Grateful to be so much younger, " + pawn.Name + " is now recruitable.", pawn, MessageTypeDefOf.PositiveEvent);
-            }
-        }
-        #endif
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -68,6 +68,8 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
     CompProperties_Refuelable fuelprops;
 
     protected Map currentMap;
+    private bool IsDisconnectedFromPowerGrid => power?.PowerNet == null;
+    private bool IsPowerUnavailable => power == null || !power.PowerOn || IsDisconnectedFromPowerGrid;
 
     public override void SpawnSetup(Map map, bool respawningAfterLoad)
     {
@@ -135,6 +137,16 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
     #endif
     {
         base.Tick();
+
+        if (IsPowerUnavailable)
+        {
+            if (power != null)
+            {
+                power.PowerOutput = 0;
+            }
+
+            return;
+        }
 
         bool hasInjuries;
         bool isTargetAge;
@@ -245,7 +257,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
     {
         if (ContainedThing is not Pawn)
         {
-            power.PowerOutput = 0;
+            if (power != null)
+            {
+                power.PowerOutput = 0;
+            }
+
             base.EjectContents();
 
             return;
@@ -284,7 +300,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         pawn.needs.rest.SetInitialLevel();
         pawn.needs.food.SetInitialLevel();
 
-        power.PowerOutput = 0;
+        if (power != null)
+        {
+            power.PowerOutput = 0;
+        }
+
         this.ApplyTrueAgeOnEject(pawn);
         base.EjectContents();
 
@@ -306,6 +326,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         }
 
         if (thing.IsDessicated())
+        {
+            return false;
+        }
+
+        if (IsPowerUnavailable)
         {
             return false;
         }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -51,7 +51,7 @@ public class CryoRegenesis: Mod
     }
 }
 
-public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
+public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 {
     private Random rnd = new Random();
     private readonly Cosmetics cosmetics = new Cosmetics();
@@ -294,6 +294,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         Scribe_Values.Look<float>(ref resProgress, "ResurrectionProgress", 0f);
         resurrector.ResurrectionProgress = resProgress;
         Scribe_Values.Look(ref origAge, "OrigAge", 50);
+        this.ExposeTrueAgeData();
 
         if (String.IsNullOrEmpty(fuelReqs) == false)
         {
@@ -550,7 +551,10 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         pawn.needs.food.SetInitialLevel();
 
         power.PowerOutput = 0;
+        this.ApplyTrueAgeOnEject(pawn);
         base.EjectContents();
+
+        this.ResetTrueAgeTracking();
 
         // if (pawn.IsColonist == false)
         // {
@@ -595,6 +599,7 @@ public class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
         if (base.TryAcceptThing(thing, allowSpecialEffects))
         {
             this.origAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
+            this.RecordTrueAgeSnapshot(pawn);
 
             restoreCoolDown = -1000;
 

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -52,6 +52,7 @@ public class CryoRegenesis: Mod
 
 public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 {
+    private const float ActivePowerConsumption = 3000f;
     private readonly Cosmetics cosmetics = new Cosmetics();
     private readonly RegenesisCycle regenesisCycle = new RegenesisCycle();
     private readonly Resurrector resurrector = new Resurrector();
@@ -222,7 +223,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                 #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
                 power.PowerOutput = -props.PowerConsumption;
                 #else
-                power.PowerOutput = -props.basePowerConsumption;
+                power.PowerOutput = -ActivePowerConsumption;
                 #endif
 
                 if (power.PowerOn)
@@ -337,7 +338,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
             power.PowerOutput = -props.PowerConsumption;
             #else
-            power.PowerOutput = -props.basePowerConsumption;
+            power.PowerOutput = -ActivePowerConsumption;
             #endif
 
             // foreach (Hediff hediff in pawn.health.hediffSet.GetHediffs<Hediff>().ToList())

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -13,7 +13,6 @@
 using RimWorld;
 using System.Reflection;
 using HarmonyLib;
-using Random=System.Random;
 using UnityEngine;
 using Verse;
 // ReSharper disable All
@@ -53,15 +52,9 @@ public class CryoRegenesis: Mod
 
 public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThingHolder
 {
-    private Random rnd = new Random();
     private readonly Cosmetics cosmetics = new Cosmetics();
+    private readonly RegenesisCycle regenesisCycle = new RegenesisCycle();
     private readonly Resurrector resurrector = new Resurrector();
-
-    private bool enteredHealthy = false;
-
-    //bool isSafeToRepair = true;
-    long restoreCoolDown = -1000;
-    int targetAge; // 21 for humans. 25% of life expectancy for every other lifeform.
     //int rate = 30;
     //int rate = 150;
     int rate = 500;
@@ -73,50 +66,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
     CompProperties_Power props;
     CompProperties_Refuelable fuelprops;
 
-    private IList<Hediff> hediffsToHeal = new List<Hediff>();
-
     protected Map currentMap;
-
-    protected string TTLToHeal;
-
-    private int origAge;
-
-    // @see https://github.com/goudaQuiche/BloodAndStains/blob/c8fdf1a312186eb17505c9b2f3e6e5cd3c408e7c/Source/BloodDripping/ToolsHediff.cs
-    public static bool HasBionicParent(Pawn pawn, BodyPartRecord BPR)
-    {
-        List<BodyPartRecord> allParents = new List<BodyPartRecord>();
-
-        if (BPR.IsCorePart)
-            return false;
-
-        BodyPartRecord recursiveBPR = BPR.parent;
-
-        while (!recursiveBPR.IsCorePart)
-        {
-            if (!recursiveBPR.IsCorePart)
-                allParents.Add(recursiveBPR);
-
-            recursiveBPR = recursiveBPR.parent;
-        }
-
-        if (allParents.NullOrEmpty())
-            return false;
-
-        //Log.Warning("Found " + allParents.Count + " parent bpr");
-
-        foreach(BodyPartRecord curP in allParents)
-        {
-            IEnumerable<Hediff> hList = pawn.health.hediffSet.hediffs.Where(
-                h => h.Part == curP
-                     && h.def.countsAsAddedPartOrImplant
-                     && (h.def.label.Contains("bionic") || h.def.label.Contains("archotech"))
-            );
-            if (!hList.EnumerableNullOrEmpty())
-                return true;
-        }
-
-        return false;
-    }
 
     public override void SpawnSetup(Map map, bool respawningAfterLoad)
     {
@@ -141,8 +91,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         {
             if (ContainedThing is Pawn pawn)
             {
-                this.configTargetAge(pawn);
-                this.enteredHealthy = this.determineCurableInjuries(pawn) == 0;
+                this.regenesisCycle.InitializeForLoadedPawn(pawn);
             }
             else if (ContainedThing is Corpse corpse)
             {
@@ -161,130 +110,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         pawn.health.AddHediff(HediffDefOf.Anesthetic, null, null);
     }
 
-    private int determineCurableInjuries(Pawn pawn)
-    {
-        List<string> hediffsToIgnore = new List<string>()
-        {
-            "joywire",
-            "painstopper",
-            "luciferium",
-            "penoxycyline",
-            "cryptosleep sickness",
-        };
-        this.hediffsToHeal = new List<Hediff>();
-
-        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
-        var hediffsOfPawn = new List<Hediff>();
-        pawn.health.hediffSet.GetHediffs<Hediff>(ref hediffsOfPawn);
-        foreach (Hediff hediff in hediffsOfPawn.ToList())
-        #else
-        foreach (Hediff hediff in pawn.health.hediffSet.GetHediffs<Hediff>().ToList())
-        #endif
-        {
-            // Ignore joywires, luciferium and more!
-            if (hediffsToIgnore.Contains(hediff.def.label)) {
-                continue;
-            }
-
-            // Ignore all highs.
-            if (hediff.def.label.Contains("high on ")) {
-                continue;
-            }
-
-            //// Ignore all tolerances.
-            //if (hediff.def.label.Contains(" tolerance"))
-            //{
-            //    continue;
-            //}
-
-            // Ignore addictions.
-            if (hediff.def.IsAddiction) {
-                continue;
-            }
-
-            // Ignore everything alcohol related.
-            if (hediff.def.label.Contains("alcohol")) {
-                continue;
-            }
-
-            // Don't heal anything not marked as "bad", if they have the setting enabled.
-            if (CryoRegenesis.Settings.healSimpleProsthetics == false && hediff.def.tendable == false)
-            {
-                continue;
-            }
-
-            // Ignore all implants.
-            if (hediff.def.hediffClass == typeof(Hediff_Implant))
-            {
-                continue;
-            }
-
-            // Ignore bionic body parts.
-            if (hediff.def.label.Contains("bionic") || hediff.def.label.Contains("archotech"))
-            {
-                continue;
-            }
-
-            // Ignore surgically-removed parts (bionics / arcotech)
-            if (hediff.def.label == "missing body part")
-            {
-                // But only if they have a bionic or archotech part...
-                if (HasBionicParent(pawn, hediff.Part))
-                {
-                    continue;
-                }
-            }
-
-            // Ignore a hediff not marked as bad...
-            if (CryoRegenesis.Settings.healNotBad == false && hediff.def.isBad == false)
-            {
-                continue;
-            }
-
-            this.hediffsToHeal.Add(hediff);
-            if (CryoRegenesis.Settings.debugMode)
-                Log.Message(hediff.def.description + " ( " + hediff.def.hediffClass + ") = " + hediff.GetType().Name);
-        }
-
-        return this.hediffsToHeal.Count;
-    }
-
-    public int AgeHediffs(Pawn pawn)
-    {
-        if (pawn != null)
-        {
-            int hediffs = 0;
-            foreach (Hediff injury in this.hediffsToHeal)
-            {
-                string injuryName = injury.def.label;
-                if (injuryName == "cataract")
-                {
-                    hediffs += 1;
-                }
-                else if (injuryName == "hearing loss")
-                {
-                    hediffs += 1;
-                }
-                else if (injuryName == "bad back" || injuryName == "frail" || injuryName == "dementia" || injuryName == "alzheimer's")
-                    hediffs += 1;
-            }
-            return hediffs;
-        }
-        return 0;
-    }
-
-    protected int InjuryHediffs(Pawn pawn)
-    {
-        if (pawn != null)
-        {
-            int OldAgeHediffs = this.AgeHediffs(pawn);
-
-            return this.hediffsToHeal.Count() - OldAgeHediffs;
-        }
-
-        return 0;
-    }
-
     public override void ExposeData()
     {
         base.ExposeData();
@@ -293,58 +118,12 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         float resProgress = resurrector.ResurrectionProgress;
         Scribe_Values.Look<float>(ref resProgress, "ResurrectionProgress", 0f);
         resurrector.ResurrectionProgress = resProgress;
-        Scribe_Values.Look(ref origAge, "OrigAge", 50);
+        this.regenesisCycle.ExposeData();
         this.ExposeTrueAgeData();
 
         if (String.IsNullOrEmpty(fuelReqs) == false)
         {
             resurrector.ResurrectionFuelReqs = fuelReqs.Split(',').Select(int.Parse).ToArray();
-        }
-    }
-
-    private int CalculateHealingTime(Pawn pawn)
-    {
-        // Get the pawn's age in Years. e.g., 65 years.
-        int pawnAge = (int) (pawn.ageTracker.AgeBiologicalTicks / GenDate.TicksPerYear);
-
-        // If the pawn is 25% of its max age or younger, set it for a year or less.
-        if (pawnAge <= (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25)) {
-            return GenDate.TicksPerYear / rnd.Next(1, 4);
-        }
-        else if (pawnAge < 100)
-        {
-            // Get the decade. e.g., 7th decade
-            int decadeOfLife = (pawnAge / 10) + 1;
-
-            // 10  =   ?? - 10    = 10
-            //  9  =   11 -  9      20
-            //  8  =   11 -  8      30
-            //  7  =   11 -  7      40
-            //  6  =   11 -  6      50
-            //  5  =   11 -  5      60
-            //  4  =   11 -  4      70
-            //  3  =   11 -  3      80
-            //  2  =   11 -  2      90
-            //  1  =   11 -  1   = 100
-
-            int baseFrequency = (11 - decadeOfLife) * 10;
-            // E.g., if decade = 8, base = 30, min = 30 * (30/100) = 9
-            // E.g., if decade = 4, base = 70, min = 70 * (70/100) = 49
-            int minFrequency = (int)((double)baseFrequency * (double)baseFrequency / 100);
-            // E.g., if decade = 8, base = 30, max = 30 * ((30+100) / 100) = 39
-            // E.g., if decade = 4, base = 70, max = 70 * ((70+100) / 100) = 119
-            int maxFrequency = (int)((double)baseFrequency * (((double)baseFrequency + 100) / 100));
-
-            double frequency = rnd.Next(minFrequency, maxFrequency);
-
-            if (CryoRegenesis.Settings.debugMode) Log.Message("Healing Frequency: Base (" + baseFrequency + ") Min (" + minFrequency + ") Max (" + maxFrequency + ") Actual: " + frequency + "%");
-
-            return (int)Math.Round((frequency / 100) * (GenDate.TicksPerYear * decadeOfLife));
-        }
-        else
-        {
-            // For immortals and other long-living creatures, like Thrumbos, it's 8-12 years.
-            return GenDate.TicksPerYear * (8 + rnd.Next(0, 4));
         }
     }
 
@@ -385,8 +164,8 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             Pawn pawn = ContainedThing as Pawn;
             float pawnAge = pawn.ageTracker.AgeBiologicalTicks / GenDate.TicksPerYear;
 
-            isTargetAge = pawn.ageTracker.AgeBiologicalTicks <= ((GenDate.TicksPerYear * this.targetAge) + rate);
-            hasInjuries = this.hediffsToHeal != null && this.hediffsToHeal.Any();
+            isTargetAge = this.regenesisCycle.IsTargetAge(pawn, rate);
+            hasInjuries = this.regenesisCycle.HasCurableInjuries;
 
             // if (this.isSafeToRepair == false)
             // {
@@ -399,9 +178,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
             if (power.PowerOn)
             {
-                long ticksLeft = (pawn.ageTracker.AgeBiologicalTicks - restoreCoolDown);
-                double repairAge = (double)restoreCoolDown / (double)GenDate.TicksPerYear;
-
                 if (isTargetAge && !hasInjuries)
                 {
                     this.EjectContents();
@@ -414,77 +190,34 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
                 if (power.PowerOn && hasInjuries && !isTargetAge /*&& pawn.ageTracker.AgeBiologicalTicks % GenDate.TicksPerSeason <= rate*/)
                 {
-                    //float timeLeft = ((float) ticksLeft / (float) GenDate.TicksPerYear);
-                    float totalDays = (float) ticksLeft / (float) GenDate.TicksPerDay;
-                    ticksLeft.TicksToPeriod(out int years, out int quadrums, out int days, out float hours);
-                    string timeToWait = "";
-                    timeToWait += TranslatorFormattedStringExtensions.Translate(years == 1 ? "Period1Year" : "PeriodYears", (NamedArgument) years);
-                    timeToWait += ", " + TranslatorFormattedStringExtensions.Translate(quadrums == 1 ? "Period1Quadrum" : "PeriodQuadrums", (NamedArgument) quadrums);
-                    timeToWait += " (" + TranslatorFormattedStringExtensions.Translate(days == 1 ? "Period1Day" : "PeriodDays", string.Format("{0:0.00}", totalDays)) + ")";
-
-                    this.TTLToHeal = timeToWait;
-                    if (pawn.ageTracker.AgeBiologicalTicks % GenDate.TicksPerSeason <= rate)
-                    {
-                        if (CryoRegenesis.Settings.debugMode) Log.Message("(" + pawn.Name.ToStringShort + ") Time to Wait: " + timeToWait + " | Next repair at: " + repairAge);
-                    }
+                    this.regenesisCycle.UpdateHealingEta(pawn, rate);
                 }
 
-                if (hasInjuries && ticksLeft <= 0 && refuelable.FuelPercentOfMax < 0.10f)
+                if (this.regenesisCycle.IsOutOfFuelForHealing(pawn, refuelable))
                 {
                     Log.Message("Not enough Uranium to heal.");
                 }
 
                 if (isTargetAge)
                 {
-                    restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks;
+                    this.regenesisCycle.MarkTargetAgeReached(pawn);
                 }
 
-                // Remove all health-related injuries if they're younger than the repairAge.
-                if (hasInjuries && restoreCoolDown > -1000 && pawn.ageTracker.AgeBiologicalTicks <= restoreCoolDown)
+                this.regenesisCycle.TryHealNextInjury(pawn, refuelable);
+
+                if (this.regenesisCycle.ShouldScheduleHealing(pawn))
                 {
-                    string hediffName;
-                    foreach (Hediff hediff in this.hediffsToHeal)
-                    {
-                        hediffName = hediff.def.label;
-
-                        refuelable.ConsumeFuel(Math.Max(refuelable.FuelPercentOfMax * 0.10f, 10));
-
-                        pawn.health.RemoveHediff(hediff);
-                        this.hediffsToHeal.RemoveAt(0);
-
-                        restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - GenDate.TicksPerYear;
-                        if (ticksLeft < 0)
-                        {
-                            restoreCoolDown += ticksLeft;
-                        }
-                        //restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - GenDate.TicksPerSeason;
-                        if (CryoRegenesis.Settings.debugMode) Log.Message("Cured HEDIFF: " + hediffName + " @ " + hediff.def.description + " | " + hediff.ToString());
-
-                        // Look for new injuries caused by the healing. E.g., removing a prostetic leg will lead to numerous new
-                        // injuries in the feet.
-                        this.determineCurableInjuries(pawn);
-                        break;
-                    }
-                }
-
-                if (hasInjuries && (ticksLeft <= 0 || restoreCoolDown == -1000))
-                {
-                    int ticksToWait = this.CalculateHealingTime(pawn);
-
-                    restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - ticksToWait;
-                    repairAge = (double)restoreCoolDown / (double)GenDate.TicksPerYear;
-                    if (CryoRegenesis.Settings.debugMode) Log.Message("Current Age in Ticks: " + pawn.ageTracker.AgeBiologicalTicks + " vs. " + restoreCoolDown);
-                    if (CryoRegenesis.Settings.debugMode) Log.Message("(" + pawn.Name.ToStringShort + ") Years to Wait: " + ((double)ticksToWait / (double)GenDate.TicksPerYear) + " | Next repair at: " + repairAge);
+                    this.regenesisCycle.ScheduleNextHealing(pawn);
                 }
             }
 
-            if (CryoRegenesis.Settings.regenUntilHealed == true && this.enteredHealthy == false && pawn.RaceProps.Humanlike && !this.hediffsToHeal.Any())
+            if (this.regenesisCycle.ShouldEjectAfterHealing(pawn))
             {
                 Log.Warning("No more injuries; ejecting.");
                 this.EjectContents();
             }
 
-            if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * targetAge)
+            if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
             {
                 #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
                 power.PowerOutput = -props.PowerConsumption;
@@ -494,11 +227,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
                 if (power.PowerOn)
                 {
-                    if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * targetAge)
+                    if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
                     {
                         refuelable.ConsumeFuel(fuelConsumption * ((pawnAge - 10) * 0.1f));
 
-                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, GenDate.TicksPerYear * targetAge);
+                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, GenDate.TicksPerYear * this.regenesisCycle.TargetAge);
                     }
                 }
             }
@@ -544,7 +277,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             // Give them a positive thought.
             int currentAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
 
-            RegenesisThoughts.AddBodyPositivityThought(pawn, this.origAge, currentAge);
+            RegenesisThoughts.AddBodyPositivityThought(pawn, this.regenesisCycle.OriginalAge, currentAge);
         }
 
         pawn.needs.rest.SetInitialLevel();
@@ -598,10 +331,8 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
         if (base.TryAcceptThing(thing, allowSpecialEffects))
         {
-            this.origAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
+            this.regenesisCycle.BeginNewPawn(pawn);
             this.RecordTrueAgeSnapshot(pawn);
-
-            restoreCoolDown = -1000;
 
             #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
             power.PowerOutput = -props.PowerConsumption;
@@ -626,9 +357,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             //         return false;
             //     }
             // }
-
-            this.configTargetAge(pawn);
-            this.enteredHealthy = this.determineCurableInjuries(pawn) == 0;
 
             return true;
         }
@@ -673,34 +401,15 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             string bioTime = "AgeBiological".Translate((NamedArgument) years,
                 (NamedArgument) quadrums, (NamedArgument) days);
 
-            if (this.hediffsToHeal.Any())
+            if (this.regenesisCycle.HasCurableInjuries)
             {
-                return base.GetInspectString() + ", " + AgeHediffs(pawn).ToString() + " Age Disabilities, " + InjuryHediffs(pawn).ToString() + " Injuries\n" + bioTime + "\nTime To Heal: " + this.TTLToHeal;
+                return base.GetInspectString() + ", " + this.regenesisCycle.AgeHediffs() + " Age Disabilities, " + this.regenesisCycle.InjuryHediffs() + " Injuries\n" + bioTime + "\nTime To Heal: " + this.regenesisCycle.TtlToHeal;
             }
             else
             {
-                return base.GetInspectString() + ", " + AgeHediffs(pawn).ToString() + " Age Disabilities, " + InjuryHediffs(pawn).ToString() + " Injuries\n" + bioTime;
+                return base.GetInspectString() + ", " + this.regenesisCycle.AgeHediffs() + " Age Disabilities, " + this.regenesisCycle.InjuryHediffs() + " Injuries\n" + bioTime;
             }
         }
         else return base.GetInspectString();
-    }
-
-    private int configTargetAge(Pawn pawn)
-    {
-        // Determine the pawn's target age based on their species' life expectancy.
-        // 21 for humans. 25% of life expectancy for everything else.
-        if (pawn.def.defName == "Human")
-        {
-            this.targetAge = CryoRegenesis.Settings.targetAge;
-        }
-        else
-        {
-            this.targetAge = (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25);
-        }
-        Log.Message("Pawn name: " + pawn.def.defName);
-        Log.Message("Life expectancy: " + pawn.RaceProps.lifeExpectancy);
-        Log.Message("Target age: " + this.targetAge);
-
-        return this.targetAge;
     }
 }

--- a/Source/CryoRegenesis.csproj
+++ b/Source/CryoRegenesis.csproj
@@ -44,6 +44,14 @@
       <HintPath>/rimworld/1.2/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>/rimworld/1.2/RimWorldLinux_Data/Managed/UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>/rimworld/1.2/RimWorldLinux_Data/Managed/UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="0Harmony">
       <HintPath>/rimworld/1.2/Mods/Harmony/Current/Assemblies/0Harmony.dll</HintPath>
       <Private>False</Private>
@@ -64,6 +72,14 @@
       <HintPath>/rimworld/1.3/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>/rimworld/1.3/RimWorldLinux_Data/Managed/UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>/rimworld/1.3/RimWorldLinux_Data/Managed/UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="0Harmony">
       <HintPath>/rimworld/1.3/Mods/Harmony/Current/Assemblies/0Harmony.dll</HintPath>
       <Private>False</Private>
@@ -82,6 +98,10 @@
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>/rimworld/1.4/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>/rimworld/1.4/RimWorldLinux_Data/Managed/UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
@@ -108,6 +128,10 @@
       <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>/rimworld/1.5/RimWorldLinux_Data/Managed/UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
@@ -130,6 +154,10 @@
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>/rimworld/1.6-steam/RimWorldLinux_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>/rimworld/1.6-steam/RimWorldLinux_Data/Managed/UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -1,0 +1,337 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using Random = System.Random;
+using UnityEngine;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class RegenesisCycle
+{
+    private const long NoRegenesisInProgress = -1000;
+
+    private readonly Random rnd = new Random();
+    private IList<Hediff> hediffsToHeal = new List<Hediff>();
+    private bool enteredHealthy;
+    private long restoreCoolDown = NoRegenesisInProgress;
+    private int targetAge;
+    private string ttlToHeal;
+    private int origAge;
+
+    public bool EnteredHealthy => this.enteredHealthy;
+    public bool HasCurableInjuries => this.hediffsToHeal.Any();
+    public int OriginalAge => this.origAge;
+    public int TargetAge => this.targetAge;
+    public string TtlToHeal => this.ttlToHeal;
+
+    public void ExposeData()
+    {
+        Scribe_Values.Look(ref this.origAge, "OrigAge", 50);
+    }
+
+    public void InitializeForLoadedPawn(Pawn pawn)
+    {
+        this.ConfigureTargetAge(pawn);
+        this.enteredHealthy = this.DetermineCurableInjuries(pawn) == 0;
+    }
+
+    public void BeginNewPawn(Pawn pawn)
+    {
+        this.origAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
+        this.restoreCoolDown = NoRegenesisInProgress;
+        this.ttlToHeal = null;
+        this.InitializeForLoadedPawn(pawn);
+    }
+
+    public void MarkTargetAgeReached(Pawn pawn)
+    {
+        this.restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks;
+    }
+
+    public bool IsTargetAge(Pawn pawn, int rate)
+    {
+        return pawn.ageTracker.AgeBiologicalTicks <= ((GenDate.TicksPerYear * this.targetAge) + rate);
+    }
+
+    public void UpdateHealingEta(Pawn pawn, int rate)
+    {
+        if (!this.HasCurableInjuries || this.IsTargetAge(pawn, rate) || this.restoreCoolDown == NoRegenesisInProgress)
+        {
+            return;
+        }
+
+        long ticksLeft = pawn.ageTracker.AgeBiologicalTicks - this.restoreCoolDown;
+        double repairAge = (double)this.restoreCoolDown / GenDate.TicksPerYear;
+        float totalDays = (float)ticksLeft / GenDate.TicksPerDay;
+        ticksLeft.TicksToPeriod(out int years, out int quadrums, out int days, out float hours);
+
+        string timeToWait = "";
+        timeToWait += TranslatorFormattedStringExtensions.Translate(years == 1 ? "Period1Year" : "PeriodYears", (NamedArgument)years);
+        timeToWait += ", " + TranslatorFormattedStringExtensions.Translate(quadrums == 1 ? "Period1Quadrum" : "PeriodQuadrums", (NamedArgument)quadrums);
+        timeToWait += " (" + TranslatorFormattedStringExtensions.Translate(days == 1 ? "Period1Day" : "PeriodDays", string.Format("{0:0.00}", totalDays)) + ")";
+        this.ttlToHeal = timeToWait;
+
+        if (pawn.ageTracker.AgeBiologicalTicks % GenDate.TicksPerSeason <= rate && CryoRegenesis.Settings.debugMode)
+        {
+            Log.Message("(" + pawn.Name.ToStringShort + ") Time to Wait: " + timeToWait + " | Next repair at: " + repairAge);
+        }
+    }
+
+    public bool IsOutOfFuelForHealing(Pawn pawn, CompRefuelable refuelable)
+    {
+        long ticksLeft = pawn.ageTracker.AgeBiologicalTicks - this.restoreCoolDown;
+        return this.HasCurableInjuries && ticksLeft <= 0 && refuelable.FuelPercentOfMax < 0.10f;
+    }
+
+    public bool ShouldScheduleHealing(Pawn pawn)
+    {
+        long ticksLeft = pawn.ageTracker.AgeBiologicalTicks - this.restoreCoolDown;
+        return this.HasCurableInjuries && (ticksLeft <= 0 || this.restoreCoolDown == NoRegenesisInProgress);
+    }
+
+    public void ScheduleNextHealing(Pawn pawn)
+    {
+        int ticksToWait = this.CalculateHealingTime(pawn);
+        this.restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - ticksToWait;
+        double repairAge = (double)this.restoreCoolDown / GenDate.TicksPerYear;
+
+        if (CryoRegenesis.Settings.debugMode)
+        {
+            Log.Message("Current Age in Ticks: " + pawn.ageTracker.AgeBiologicalTicks + " vs. " + this.restoreCoolDown);
+            Log.Message("(" + pawn.Name.ToStringShort + ") Years to Wait: " + ((double)ticksToWait / GenDate.TicksPerYear) + " | Next repair at: " + repairAge);
+        }
+    }
+
+    public bool TryHealNextInjury(Pawn pawn, CompRefuelable refuelable)
+    {
+        if (!this.HasCurableInjuries || this.restoreCoolDown <= NoRegenesisInProgress)
+        {
+            return false;
+        }
+
+        long ticksLeft = pawn.ageTracker.AgeBiologicalTicks - this.restoreCoolDown;
+        if (pawn.ageTracker.AgeBiologicalTicks > this.restoreCoolDown)
+        {
+            return false;
+        }
+
+        Hediff hediff = this.hediffsToHeal[0];
+        string hediffName = hediff.def.label;
+
+        refuelable.ConsumeFuel(Math.Max(refuelable.FuelPercentOfMax * 0.10f, 10));
+        pawn.health.RemoveHediff(hediff);
+        this.hediffsToHeal.RemoveAt(0);
+
+        this.restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - GenDate.TicksPerYear;
+        if (ticksLeft < 0)
+        {
+            this.restoreCoolDown += ticksLeft;
+        }
+
+        if (CryoRegenesis.Settings.debugMode)
+        {
+            Log.Message("Cured HEDIFF: " + hediffName + " @ " + hediff.def.description + " | " + hediff);
+        }
+
+        // Re-scan because removing one hediff can expose new curable injuries.
+        this.DetermineCurableInjuries(pawn);
+        return true;
+    }
+
+    public bool ShouldEjectAfterHealing(Pawn pawn)
+    {
+        return CryoRegenesis.Settings.regenUntilHealed
+            && !this.enteredHealthy
+            && pawn.RaceProps.Humanlike
+            && !this.HasCurableInjuries;
+    }
+
+    public int AgeHediffs()
+    {
+        int hediffCount = 0;
+        foreach (Hediff injury in this.hediffsToHeal)
+        {
+            string injuryName = injury.def.label;
+            if (injuryName == "cataract" || injuryName == "hearing loss")
+            {
+                hediffCount += 1;
+            }
+            else if (injuryName == "bad back" || injuryName == "frail" || injuryName == "dementia" || injuryName == "alzheimer's")
+            {
+                hediffCount += 1;
+            }
+        }
+
+        return hediffCount;
+    }
+
+    public int InjuryHediffs()
+    {
+        return this.hediffsToHeal.Count - this.AgeHediffs();
+    }
+
+    public static bool HasBionicParent(Pawn pawn, BodyPartRecord bodyPart)
+    {
+        List<BodyPartRecord> allParents = new List<BodyPartRecord>();
+
+        if (bodyPart.IsCorePart)
+        {
+            return false;
+        }
+
+        BodyPartRecord recursiveBodyPart = bodyPart.parent;
+        while (!recursiveBodyPart.IsCorePart)
+        {
+            allParents.Add(recursiveBodyPart);
+            recursiveBodyPart = recursiveBodyPart.parent;
+        }
+
+        if (allParents.NullOrEmpty())
+        {
+            return false;
+        }
+
+        foreach (BodyPartRecord currentParent in allParents)
+        {
+            IEnumerable<Hediff> matchingHediffs = pawn.health.hediffSet.hediffs.Where(
+                h => h.Part == currentParent
+                     && h.def.countsAsAddedPartOrImplant
+                     && (h.def.label.Contains("bionic") || h.def.label.Contains("archotech")));
+            if (!matchingHediffs.EnumerableNullOrEmpty())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private int DetermineCurableInjuries(Pawn pawn)
+    {
+        List<string> hediffsToIgnore = new List<string>()
+        {
+            "joywire",
+            "painstopper",
+            "luciferium",
+            "penoxycyline",
+            "cryptosleep sickness",
+        };
+        this.hediffsToHeal = new List<Hediff>();
+
+        #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
+        var hediffsOfPawn = new List<Hediff>();
+        pawn.health.hediffSet.GetHediffs<Hediff>(ref hediffsOfPawn);
+        foreach (Hediff hediff in hediffsOfPawn.ToList())
+        #else
+        foreach (Hediff hediff in pawn.health.hediffSet.GetHediffs<Hediff>().ToList())
+        #endif
+        {
+            if (hediffsToIgnore.Contains(hediff.def.label))
+            {
+                continue;
+            }
+
+            if (hediff.def.label.Contains("high on "))
+            {
+                continue;
+            }
+
+            if (hediff.def.IsAddiction)
+            {
+                continue;
+            }
+
+            if (hediff.def.label.Contains("alcohol"))
+            {
+                continue;
+            }
+
+            if (!CryoRegenesis.Settings.healSimpleProsthetics && !hediff.def.tendable)
+            {
+                continue;
+            }
+
+            if (hediff.def.hediffClass == typeof(Hediff_Implant))
+            {
+                continue;
+            }
+
+            if (hediff.def.label.Contains("bionic") || hediff.def.label.Contains("archotech"))
+            {
+                continue;
+            }
+
+            if (hediff.def.label == "missing body part" && HasBionicParent(pawn, hediff.Part))
+            {
+                continue;
+            }
+
+            if (!CryoRegenesis.Settings.healNotBad && !hediff.def.isBad)
+            {
+                continue;
+            }
+
+            this.hediffsToHeal.Add(hediff);
+            if (CryoRegenesis.Settings.debugMode)
+            {
+                Log.Message(hediff.def.description + " ( " + hediff.def.hediffClass + ") = " + hediff.GetType().Name);
+            }
+        }
+
+        return this.hediffsToHeal.Count;
+    }
+
+    private int CalculateHealingTime(Pawn pawn)
+    {
+        int pawnAge = (int)(pawn.ageTracker.AgeBiologicalTicks / GenDate.TicksPerYear);
+
+        if (pawnAge <= (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25))
+        {
+            return GenDate.TicksPerYear / this.rnd.Next(1, 4);
+        }
+
+        if (pawnAge < 100)
+        {
+            int decadeOfLife = (pawnAge / 10) + 1;
+            int baseFrequency = (11 - decadeOfLife) * 10;
+            int minFrequency = (int)((double)baseFrequency * baseFrequency / 100);
+            int maxFrequency = (int)((double)baseFrequency * (((double)baseFrequency + 100) / 100));
+
+            double frequency = this.rnd.Next(minFrequency, maxFrequency);
+            if (CryoRegenesis.Settings.debugMode)
+            {
+                Log.Message("Healing Frequency: Base (" + baseFrequency + ") Min (" + minFrequency + ") Max (" + maxFrequency + ") Actual: " + frequency + "%");
+            }
+
+            return (int)Math.Round((frequency / 100) * (GenDate.TicksPerYear * decadeOfLife));
+        }
+
+        return GenDate.TicksPerYear * (8 + this.rnd.Next(0, 4));
+    }
+
+    private void ConfigureTargetAge(Pawn pawn)
+    {
+        if (pawn.def.defName == "Human")
+        {
+            this.targetAge = CryoRegenesis.Settings.targetAge;
+        }
+        else
+        {
+            this.targetAge = (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25);
+        }
+
+        Log.Message("Pawn name: " + pawn.def.defName);
+        Log.Message("Life expectancy: " + pawn.RaceProps.lifeExpectancy);
+        Log.Message("Target age: " + this.targetAge);
+    }
+}

--- a/Source/RegenesisThoughts.cs
+++ b/Source/RegenesisThoughts.cs
@@ -1,0 +1,94 @@
+// ==== ./Source/RegenesisThoughts.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using Verse;
+// ReSharper disable All
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public static class RegenesisThoughts
+{
+    public static void AddBodyPositivityThought(Pawn pawn, int origAge, int newAge)
+    {
+        int yearsRegressed = origAge - newAge;
+        if (yearsRegressed <= 0) return;
+
+        // Get the def
+        var thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_BodyPositivity");
+
+        // Create the thought instance manually so we can initialize it
+        var thought = ThoughtMaker.MakeThought(thoughtDef) as Thought_RegenesisBodyPositivity;
+        if (thought == null) return;
+
+        // Set the years BEFORE adding it to the pawn
+        thought.SetYearsReversed(yearsRegressed);
+
+        // Add the initialized thought instance (not the def)
+        pawn.needs.mood?.thoughts.memories.TryGainMemory(thought);
+
+        if (CryoRegenesis.Settings.debugMode)
+            Log.Warning($"Old age {origAge} | New age: {newAge} | Years reversed: {yearsRegressed} | Stage: {thought.CurStageIndex}");
+
+        // Use the thought's actual stage for the prisoner check
+        #if !RIMWORLD12 && !RIMWORLD13
+        if (thought.CurStageIndex >= 2)
+        {
+            if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
+            {
+                pawn.guest.Recruitable = true;
+                Messages.Message("Grateful to be so much younger, " + pawn.Name + " is now recruitable.", pawn, MessageTypeDefOf.PositiveEvent);
+            }
+        }
+        #endif
+    }
+
+    /// Get the pawn's existing TrueAgeTracker, or add and initialize one.
+    ///
+    /// On first use, the tracker is initialized with the pawn's
+    /// pre-CryoRegenesis biological age — because before this moment,
+    /// True Age = Bio Age.
+    public static TrueAgeTracker GetOrAddTrueAgeTracker(Pawn pawn, long preRegenesisBioTicks)
+    {
+        if (pawn?.health?.hediffSet == null || pawn.RaceProps?.Humanlike != true)
+        {
+            return null;
+        }
+
+        HediffDef trueAgeDef = DefDatabase<HediffDef>.GetNamedSilentFail("TrueAgeTracker");
+        if (trueAgeDef == null)
+        {
+            Log.Warning("[CryoRegenesis] TrueAgeTracker hediff def is missing; skipping true-age tracking.");
+            return null;
+        }
+
+        TrueAgeTracker tracker = pawn.health.hediffSet
+            .GetFirstHediffOfDef(trueAgeDef)
+            as TrueAgeTracker;
+
+        if (tracker == null)
+        {
+            tracker = HediffMaker.MakeHediff(trueAgeDef, pawn) as TrueAgeTracker;
+
+            if (tracker == null)
+            {
+                return null;
+            }
+
+            pawn.health.AddHediff(tracker);
+        }
+
+        tracker.Initialize(preRegenesisBioTicks);
+
+        return tracker;
+    }
+}

--- a/Source/Resurrector.cs
+++ b/Source/Resurrector.cs
@@ -1,0 +1,239 @@
+// ==== ./Source/CorpseResurrector.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using System;
+using System.Linq;
+using UnityEngine;
+using Verse;
+// ReSharper disable All
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class Resurrector
+{
+    public const int REQ_URANIUM    = 150;
+    public const int REQ_GOLD       = 500;
+    public const int REQ_LUCIFERIUM = 50;
+
+    // State — kept public for Building_CryoRegenesis.ExposeData serialization.
+    public float ResurrectionProgress = 0f;
+    public int[] ResurrectionFuelReqs = new int[3] { REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM };
+    public float InitialRot = -1f;
+
+    private CompRefuelable refuelable;
+    private CompProperties_Refuelable fuelprops;
+    private CompPowerTrader power;
+    private Action onRejected;
+    private Action<Pawn> onResurrected;
+
+    /// <summary>
+    /// Wire up building components and ejection callbacks. Must be called from SpawnSetup.
+    /// </summary>
+    public void Initialize(
+        CompRefuelable refuelable,
+        CompProperties_Refuelable fuelprops,
+        CompPowerTrader power,
+        Action onRejected,
+        Action<Pawn> onResurrected)
+    {
+        this.refuelable    = refuelable;
+        this.fuelprops     = fuelprops;
+        this.power         = power;
+        this.onRejected    = onRejected;
+        this.onResurrected = onResurrected;
+    }
+
+    public void ResetFuelRequirement()
+    {
+        fuelprops.fuelFilter = new ThingFilter();
+        fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium, true);
+        ResurrectionFuelReqs[0] -= (int)refuelable.Fuel;
+        fuelprops.fuelCapacity = 150;
+        ResurrectionProgress = 0f;
+    }
+
+    /// <summary>Full reset when a new corpse is accepted.</summary>
+    public void ResetForNewCorpse()
+    {
+        ResurrectionProgress = 0f;
+        ResurrectionFuelReqs = new int[3] { REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM };
+    }
+
+    /// <summary>
+    /// Drive the resurrection state machine for one tick cycle.
+    /// Calls onRejected or onResurrected when the state resolves.
+    /// </summary>
+    public void Process(Corpse corpse)
+    {
+        // Make sure that they have a brain. Everything else is optional.
+        var deadPawn  = corpse.InnerPawn;
+        var pawnBrain = deadPawn.health.hediffSet.GetBrain();
+        if (pawnBrain == null)
+        {
+            Messages.Message("[CryoRegenesis] Pawn rejected: No brain.", MessageTypeDefOf.RejectInput);
+            onRejected();
+            return;
+        }
+
+        // Make sure that the corpse isn't more than 10% degraded.
+        var rottable = corpse.GetComp<CompRottable>();
+        // If they've been dead and unfrozen for more than 1 day, the CryoRegenesis casket cannot resurrect them.
+        if (rottable != null && rottable.RotProgress > 60_000)
+        {
+            Messages.Message(
+                "[CryoRegenesis] Pawn rejected: More than 1 day unfrozen (" + rottable.RotProgress + "). Their brain is too degraded.",
+                MessageTypeDefOf.RejectInput);
+            onRejected();
+            return;
+        }
+
+        // --- State Machine for Resource Gathering ---
+
+        // State 1: Need Luciferium (first priority as requested)
+        if (this.ResurrectionFuelReqs[2] > 0)
+        {
+            // Configure the refuelable component to accept Luciferium
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium,    false);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold,       false);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, true);
+
+            // Set the capacity to what is still needed
+            fuelprops.fuelCapacity = this.ResurrectionFuelReqs[2];
+
+            // If fuel has been delivered, process it
+            if (refuelable.Fuel > 0)
+            {
+                int delivered = (int)Math.Ceiling(refuelable.Fuel);
+                this.ResurrectionFuelReqs[2] -= delivered;
+                refuelable.ConsumeFuel(refuelable.Fuel);
+                Log.Message($"[CryoRegenesis] Luciferium delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[2]}");
+            }
+
+            // Stop processing for this tick; we are waiting for more fuel.
+            return;
+        }
+        // State 2: Need Uranium (checked after Luciferium is complete)
+        else if (this.ResurrectionFuelReqs[0] > 0)
+        {
+            // Configure the refuelable component to accept Uranium
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium,    true);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold,       false);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, false);
+
+            // Set the capacity to what is still needed
+            fuelprops.fuelCapacity = this.ResurrectionFuelReqs[0];
+
+            // If fuel has been delivered, process it
+            if (refuelable.Fuel > 0)
+            {
+                int delivered = (int)Math.Ceiling(refuelable.Fuel);
+                this.ResurrectionFuelReqs[0] -= delivered;
+                refuelable.ConsumeFuel(refuelable.Fuel);
+                Log.Message($"[CryoRegenesis] Uranium delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[0]}");
+            }
+
+            // Stop processing for this tick; we are waiting for more fuel.
+            return;
+        }
+        // State 3: Need Gold (checked after Luciferium and Uranium are complete)
+        else if (this.ResurrectionFuelReqs[1] > 0)
+        {
+            // Configure the refuelable component to accept Gold
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Uranium,    false);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Gold,       true);
+            fuelprops.fuelFilter.SetAllow(ThingDefOf.Luciferium, false);
+
+            // Set the capacity to what is still needed
+            fuelprops.fuelCapacity = this.ResurrectionFuelReqs[1];
+
+            // If fuel has been delivered, process it
+            if (refuelable.Fuel > 0)
+            {
+                int delivered = (int)Math.Ceiling(refuelable.Fuel);
+                this.ResurrectionFuelReqs[1] -= delivered;
+                refuelable.ConsumeFuel(refuelable.Fuel);
+                Log.Message($"[CryoRegenesis] Gold delivered: {delivered}. Needed: {this.ResurrectionFuelReqs[1]}");
+            }
+
+            // Stop processing for this tick; we are waiting for more fuel.
+            return;
+        }
+
+        if (Find.TickManager.TicksGame % 1000 == 0)
+        {
+            return;
+        }
+
+        // --- Resurrection Progress (only runs if all fuel requirements are met) ---
+        // The check for fuel requirements is implicitly handled by falling through the if/else-if chain.
+
+        // Turn off refueling now that we're full
+        fuelprops.fuelCapacity = 0;
+
+        // Adjust this value to control resurrection speed
+        float resurrectionFactor = 0.001f;
+
+        // Increment progress
+        this.ResurrectionProgress += resurrectionFactor;
+        this.ResurrectionProgress = Mathf.Clamp01(this.ResurrectionProgress); // Ensure it stays between 0 and 1
+
+        if (CryoRegenesis.Settings.debugMode)
+            Log.Message($"[CryoRegenesis] Resurrection Progress: {this.ResurrectionProgress * 100:F1}%");
+
+        // Check if resurrection is complete
+        if (this.ResurrectionProgress >= 1.0f)
+        {
+            var resurrectedPawn = corpse.InnerPawn;
+            Log.Message($"[CryoRegenesis] {resurrectedPawn.Name} has been resurrected!");
+            Messages.Message($"[CryoRegenesis] {resurrectedPawn.Name} has been resurrected!", resurrectedPawn, MessageTypeDefOf.PositiveEvent);
+
+            #if RIMWORLD15 || RIMWORLD16
+            ResurrectionUtility.TryResurrectWithSideEffects(resurrectedPawn);
+            #else
+            ResurrectionUtility.ResurrectWithSideEffects(resurrectedPawn);
+            #endif
+
+            this.ResurrectionProgress = 0f;
+            this.AddLuciferiumSideEffect(resurrectedPawn);
+
+            // Reset fuel requirements for the next pawn
+            this.ResetFuelRequirement();
+
+            onResurrected(resurrectedPawn);
+        }
+    }
+
+    public void AddLuciferiumSideEffect(Pawn pawn)
+    {
+        if (pawn?.health?.hediffSet == null)
+            return;
+
+        // Add the addiction directly
+        HediffDef luciferiumAddiction = DefDatabase<HediffDef>.GetNamed("LuciferiumAddiction");
+        Hediff addictionHediff = HediffMaker.MakeHediff(luciferiumAddiction, pawn);
+        pawn.health.AddHediff(addictionHediff);
+
+        // Important: Set the last dose time to prevent immediate withdrawal
+        Need_Chemical drugNeed = pawn.needs?.AllNeeds.OfType<Need_Chemical>()
+            .FirstOrDefault(n => n.def.defName == "Chemical_Luciferium");
+
+        if (drugNeed != null)
+        {
+            drugNeed.CurLevel = drugNeed.MaxLevel; // Start them off satisfied
+        }
+
+        pawn.needs?.mood?.thoughts?.memories?.TryGainMemory(
+            DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_LuciferiumSideEffect")
+        );
+    }
+}

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -1,7 +1,7 @@
 /*
  * This file is part of CryoRegenesis, a Better Rimworlds Project.
  *
- * Copyright © 2020-2024 Theodore R. Smith
+ * Copyright © 2020-2026 Theodore R. Smith
  * Author: Theodore R. Smith <hopeseekr@gmail.com>
  *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
  *   https://github.com/BetterRimworlds/CryoRegenesis

--- a/Source/Thought_DurationBased.cs
+++ b/Source/Thought_DurationBased.cs
@@ -1,4 +1,15 @@
 // ==== ./Source/Thought_DurationBased.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
 using RimWorld;
 using Verse;
 

--- a/Source/Thought_LuciferiumSideEffect.cs
+++ b/Source/Thought_LuciferiumSideEffect.cs
@@ -1,4 +1,15 @@
 // ==== Source/CryoRegenesis/Thought_CryoRegenesis_LuciferiumSideEffect.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
 using RimWorld;
 using Verse;
 

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -1,4 +1,15 @@
 // ==== ./Source/Thought_RegenesisBodyPositivity.cs ====
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
 using RimWorld;
 using Verse;
 
@@ -13,7 +24,7 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
     {
         this._yearsReversed = years;
     }
-    
+
     public override void Init()
     {
         base.Init();

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -1,0 +1,132 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *   GPG Fingerprint: D8EA 6E4D 5952 159D 7759  2BB4 EEB6 CE72 F441 EC41
+ *   https://github.com/BetterRimworlds/CryoRegenesis
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+[DefOf]
+public static class TrueAgeDefOf
+{
+    public static HediffDef TrueAgeTracker;
+
+    static TrueAgeDefOf()
+    {
+        DefOfHelper.EnsureInitializedInCtor(typeof(TrueAgeDefOf));
+    }
+}
+
+/// <summary>
+/// Invisible hediff that tracks a pawn's True Age independently of
+/// vanilla biological/chronological age. Added when a pawn first uses
+/// the CryoRegenesis Casket.
+///
+/// For pawns who have never used CryoRegenesis, True Age = Bio Age.
+///
+/// Ledger:
+///   consciousAliveTicks           – time actually lived while awake
+///   cryoRegenesisRemovedAgeTicks  – biological age removed by CryoRegenesis
+///
+/// True Age = consciousAliveTicks (converted to years)
+///
+/// No suspension tracking is needed:
+///   - In cryptosleep: pawn is despawned, Tick() never fires
+///   - In Stargate buffer: pawn is in a timeless state
+///   - In both cases, consciousAliveTicks simply stops incrementing
+/// </summary>
+public class TrueAgeTracker : HediffWithComps
+{
+    public bool aliveYearsInitialized = false;
+    public long consciousAliveTicks = 0;
+    public long cryoRegenesisRemovedAgeTicks = 0;
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+
+        Scribe_Values.Look(ref this.aliveYearsInitialized, "aliveYearsInitialized", false);
+        Scribe_Values.Look(ref this.consciousAliveTicks, "consciousAliveTicks", 0L);
+        Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
+    }
+
+    public override void Tick()
+    {
+        base.Tick();
+
+        if (!this.aliveYearsInitialized)
+        {
+            return;
+        }
+
+        if (this.pawn != null && this.pawn.Dead)
+        {
+            return;
+        }
+
+        this.consciousAliveTicks++;
+    }
+
+    /// <summary>
+    /// Initialize the ledger with the pawn's pre-CryoRegenesis biological age.
+    /// Called once, when the hediff is first added.
+    ///
+    /// Before this moment, True Age = Bio Age, so the pawn's current
+    /// biological age IS their lived time.
+    /// </summary>
+    public void Initialize(long preRegenesisBioTicks)
+    {
+        if (this.aliveYearsInitialized)
+        {
+            return;
+        }
+
+        this.consciousAliveTicks = preRegenesisBioTicks;
+        this.aliveYearsInitialized = true;
+    }
+
+    /// <summary>
+    /// Record that CryoRegenesis has removed biological age.
+    /// This does NOT reduce consciousAliveTicks — the pawn still
+    /// lived through that time.
+    /// </summary>
+    public void RecordCryoRegenesisDeAging(long removedTicks)
+    {
+        if (removedTicks <= 0)
+        {
+            return;
+        }
+
+        this.cryoRegenesisRemovedAgeTicks += removedTicks;
+    }
+
+    public long GetTrueAgeTicks()
+    {
+        return this.consciousAliveTicks;
+    }
+
+    public float GetTrueAgeYears()
+    {
+        return AgeTicksToYears(this.consciousAliveTicks);
+    }
+
+    public float GetCryoRegenesisRemovedAgeYears()
+    {
+        return AgeTicksToYears(this.cryoRegenesisRemovedAgeTicks);
+    }
+
+    private static float AgeTicksToYears(long ticks)
+    {
+        return (float)ticks / 3600000f;
+    }
+
+    public override bool Visible => false;
+}


### PR DESCRIPTION
## **User description**
* **[2026-05-25 09:08:39 COT]** Refactored out Cosmetics, Resurrection, and Happy Thoughts from the CryoRegenesis god class.
* **[2026-05-25 09:27:53 COT]** Added a True Age mechanism for tracking total Living Time.
* **[2026-05-25 10:12:55 COT]** Split the actual regenesis code out of the CroRegenesis god class.
* **[2026-05-25 10:16:42 COT]** An idle cryoregenesis casket no longer needs power.
* **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.


___

## **CodeAnt-AI Description**
**Show a pawn’s true age and keep the casket working when power is lost**

### What Changed
- Added a True Age line to the pawn character card, with a tooltip that shows true age alongside biological and chronological age.
- The cryoregenesis casket now stays idle without drawing power, and it switches to normal cryptosleep behavior when the power grid fails.
- Updated language files so the new age label appears in supported translations.

### Impact
`✅ Clearer age tracking`
`✅ Lower power use while idle`
`✅ Fewer power-loss interruptions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * True Age tracking (persists through cryogenesis) and shown on character cards with tooltip
  * Overhauled regenesis/resurrection with staged healing flow and cosmetics (hair-color changes)
  * Resurrection can apply a Luciferium side effect

* **Balance**
  * CryoRegenesis research cost increased
  * Idle cryopod now consumes zero power

* **Documentation**
  * Added localization for 30+ languages and updated changelog (v6.0.0)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BetterRimworlds/CryoRegenesis/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->