### PR TITLE
Version 6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,8 @@ The combination of resource costs and permanent Luciferium addiction ensures res
 * **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.
 * **[2026-05-25 12:39:21 COT]** Increased the research cost.
 * **[2026-05-25 12:43:28 COT]** Completely reimplemented the True Age display to not use global UI widgets.
+
+**Version 6.1.0: 2026-05-28**
+* **[2026-05-28 18:09:22 COT]** Fixed Colonist despawning / lost forever when entering an unpowered CryoRegen pod.
+* **[2026-05-28 22:26:31 COT]** Added cryosleep counter as well to the new True Age popup.
+

--- a/Source/CharacterCardAgePatch.cs
+++ b/Source/CharacterCardAgePatch.cs
@@ -10,6 +10,7 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
 using System.Reflection;
 using HarmonyLib;
 using RimWorld;
@@ -85,6 +86,8 @@ internal static class CharacterCardAgePatch
         }
 
         float trueAgeYears = tracker.GetTrueAgeYears();
+        float chronologicalAgeYears = pawn.ageTracker.AgeChronologicalYearsFloat;
+        float cryptosleepYears = Math.Max(0f, chronologicalAgeYears - trueAgeYears);
 
         string translatedLabel = "BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge".Translate();
         string label = $"<b>{translatedLabel}:</b> ";
@@ -135,7 +138,8 @@ internal static class CharacterCardAgePatch
             lineRect,
             $"{translatedLabel}: {trueAgeYears:N2} years\n" +
             $"Biological age: {pawn.ageTracker.AgeBiologicalYearsFloat:N2} years\n" +
-            $"Chronological age: {pawn.ageTracker.AgeChronologicalYearsFloat:N2} years"
+            $"Cryptosleep: {cryptosleepYears:N2} years\n" +
+            $"Chronological age: {chronologicalAgeYears:N2} years"
         );
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -330,11 +330,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             return false;
         }
 
-        if (IsPowerUnavailable)
-        {
-            return false;
-        }
-
         resurrector.InitialRot = -1f;
 
         if (thing.def.defName.StartsWith("Corpse_"))
@@ -360,11 +355,18 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             this.regenesisCycle.BeginNewPawn(pawn);
             this.RecordTrueAgeSnapshot(pawn);
 
-            #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
-            power.PowerOutput = -props.PowerConsumption;
-            #else
-            power.PowerOutput = -ActivePowerConsumption;
-            #endif
+            if (!IsPowerUnavailable)
+            {
+                #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
+                power.PowerOutput = -props.PowerConsumption;
+                #else
+                power.PowerOutput = -ActivePowerConsumption;
+                #endif
+            }
+            else if (power != null)
+            {
+                power.PowerOutput = 0;
+            }
 
             // foreach (Hediff hediff in pawn.health.hediffSet.GetHediffs<Hediff>().ToList())
             // {


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Prevent pawns from disappearing when they enter an unpowered CryoRegen pod, and show cryptosleep time in the True Age popup**

### What Changed
- Pawns can now be placed into a CryoRegen pod even when it has no power, avoiding the case where colonists were lost after entering an unpowered pod
- When power is unavailable, the pod no longer tries to run as if it were active
- The True Age popup now includes a cryptosleep counter alongside true age, biological age, and chronological age

### Impact
`✅ Fewer colonist-loss incidents`
`✅ Safer use of unpowered CryoRegen pods`
`✅ Clearer age details for sleep-state pawns`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed colonists despawning or being permanently lost when entering an unpowered CryoRegen pod.

* **New Features**
  * Added cryosleep counter display to the True Age popup.
  * Expanded character age information to show both Cryptosleep and Chronological age details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BetterRimworlds/CryoRegenesis/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->