### PR TITLE
Version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,170 @@
+# BetterRimworlds/CryoRegenesis ChangeLog
+
+## v7.0.0
+
+* **[2026-07-23 11:33:33 EEST]** Fixed simple prosthetics remaining after regeneration.
+* **[2026-07-19 09:12:20 CDT]** Repositioned the True Age to the right.
+* **[2026-07-18 14:11:59 CDT]** Body positivity thoughts now stack and scale duration from lifetime True Age years erased.
+* **[2026-07-12 21:11:16 CDT]** Marked the CryoRegenesis casket as player-ejectable.
+* **[2026-07-12 20:21:20 CDT]** Fixed Carry-to-CryoRegenesis never appearing or working for downed, sedated, and guest pawns.
+* **[2026-07-10 22:12:38 COT]** [m] Removed the watch for building as it is no longer useful in The Age of AI.
+* **[2026-07-09 09:16:13 COT]** Updated the README with Stargate references.
+* **[2026-07-09 02:46:37 COT]** Fixed a regression where pawns with Bionic or Archotech legs could not be properly downed.
+* **[2026-07-09 02:39:04 COT]** Pawns now cannot be attempted to be carried to a CryoRegenesis casket if none are available.
+* **[2026-07-09 02:36:32 COT]** Removed the Heal Not Bad HeDiffs mechanism completely.
+* **[2026-07-08 09:40:26 COT]** Fixed the instant ejection of non-Human humanlikes (xenotypes, Empire pawns, modded races) from CryoRegenesis.
+* **[2026-07-07 19:17:47 COT]** Added animal support for CryoRegenesis carry.
+* **[2026-07-07 19:17:17 COT]** All downed humanlikes can now be carried to CryoRegenesis caskets.
+* **[2026-07-07 19:10:52 COT]** Added a sedate-and-carry pipeline for placing pawns into CryoRegenesis caskets via the Operations tab.
+* **[2026-07-07 19:10:03 COT]** Added the missing True Age def.
+* **[2026-07-02 12:46:22 COT]** Added support for taking Royalty guests and prisoners to the CryoRegenesis casket.
+
+## v6.0.0
+
+* **[2026-06-29 05:24:28 COT]** [m] Simple README and About.xml improvements.
+* **[2026-06-28 19:40:41 COT]** Moved the True Age below the Royalty indicator.
+* **[2026-06-28 17:13:38 COT]** Greatly simplified the csproj.
+
+## v6.1.0
+
+* **[2026-05-28 22:26:31 COT]** Added cryosleep counter as well to the new True Age popup.
+* **[2026-05-28 18:09:22 COT]** Fixed Colonist despawning / lost forever when entering an unpowered CryoRegen pod.
+
+## v6.0.0
+
+* **[2026-05-25 18:42:17 COT]** Updated the README for v6.0.0.
+* **[2026-05-25 12:43:28 COT]** Completely reimplemented the True Age display to not use global UI widgets.
+* **[2026-05-25 12:39:21 COT]** Increased the research cost.
+* **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.
+* **[2026-05-25 10:16:42 COT]** An idle cryoregenesis casket no longer needs power.
+* **[2026-05-25 10:12:55 COT]** Split the actual regenesis code out of the CroRegenesis god class.
+* **[2026-05-25 09:27:53 COT]** Added a True Age mechanism for tracking total Living Time.
+* **[2026-05-25 09:08:39 COT]** Refactored out Cosmetics, Resurrection, and Happy Thoughts from the CryoRegenesis god class.
+
+## v5.1.0
+
+* **[2026-05-05 11:04:27 COT]** Translated into many different languages.
+* **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.
+* **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
+* **[2026-04-29 07:04:03 CDT]** Fixed the thought stage calculation for the age regression mood boost.
+* **[2026-04-29 07:00:49 CDT]** Now freezes the corpse's rotting state preservation during resurrection.
+* **[2026-04-29 06:55:59 CDT]** Fixed Ejection to properly handle prisoners
+* **[2026-04-29 06:52:14 CDT]** Added BetterRandom utility class for deterministic random number generation
+
+## v5.0.0: Resurrection Improvements
+
+* **[2026-04-29 05:06:26 CDT]** Fail the build if any of the Rimworld versions fail to compile.
+* **[2025-07-22 23:47:41 ART]** Added happy thoughts about being regenerated.
+* **[2025-07-22 06:45:26 ART]** Added a "Grateful to be alive!" thought when pawns are resurrected.
+* **[2025-07-22 06:28:00 ART]** Added Luciferium addiction to resurrected pawns.
+* **[2025-07-22 06:05:47 ART]** Cause resurrected pawns to be under anesthetic on revival.
+* **[2025-07-22 05:58:41 ART]** Store the pawn's original age for use later.
+* **[2025-07-22 05:45:45 ART]** Fixed the resurrection system.
+* **[2025-07-14 09:00:11 ART]** Fixed the requirements gathering for resurrection.
+* **[2025-07-11 20:25:25 ART]** Added support for Rimworld v1.6.
+* **[2025-07-11 20:01:11 ART]** Migrated to a modern dotnet SDK project.
+
+## v4.1.0: .NET v9.0 and C# v10.0.
+
+* **[2025-03-14 15:52:36 COT]** Rearchitected the files to the BetterRimworlds standard layout.
+* **[2025-03-06 07:27:19 COT]** Ported to .NET v9.0 and C# v10.0.
+
+## v4.0.0
+
+* **[2024-05-13 17:18:40 COT]** Stored the Resurrection fuel and progress in the savegame.
+* **[2024-05-13 09:14:16 COT]** [m] Mild cosmetic fix.
+* **[2024-05-13 09:08:19 COT]** Added a resurrection demo video.
+* **[2024-05-13 08:47:12 COT]** Code cleanup.
+* **[2024-05-12 13:53:08 COT]** Implemented the resurrection of corpses.
+* **[2024-03-15 01:30:19 CST]** Version 3.1.0.
+* **[2024-03-15 01:16:24 CST]** Cured the CyroRegenesis Quantum Anomaly that broke when guests were put in.
+* **[2024-03-15 00:47:43 CST]** Added optional code (enabled by default) to not heal any hediffs that are not marked as "bad".
+* **[2024-03-15 00:46:43 CST]** Made the CryoRegenesis flickable (turns it into a normal cryocasket).
+* **[2024-03-15 00:44:32 CST]** Upgraded to Rimworld v1.5.
+* **[2024-03-15 00:44:12 CST]** Majorly refactored the deploy script.
+* **[2024-03-09 11:46:39 CST]** Update README.md
+* **[2023-07-29 01:43:18 GST]** Fixed a bug that prohibited animals from being put in the cryocasket.
+* **[2023-05-22 10:37:45 GST]** Version 3.0.0.
+* **[2023-05-22 10:31:53 GST]** Block non-colonist humans from being placed in the casket.
+* **[2023-05-22 09:47:45 GST]** Added functionality to never heal implants.
+* **[2023-05-22 09:47:24 GST]** Added an option to not try to heal anything that isn't tendable.
+* **[2023-05-22 09:44:19 GST]** Added a new option for the target age of Human pawns.
+* **[2023-05-22 09:43:34 GST]** Added a new option to only regen until the pawn is healed.
+* **[2023-05-22 09:42:55 GST]** Enabled the new optional debug messaging system.
+* **[2023-05-22 09:38:56 GST]** [m] Rearranged the SpawnSetup method.
+* **[2023-05-22 09:32:17 GST]** Added Mod Settings.
+* **[2023-05-22 09:30:13 GST]** Added a proper Mod class.
+* **[2023-05-21 19:41:18 GST]** Update README.md: Added info about Cargo
+* **[2023-03-26 13:41:29 CEST]** Re-added more hair colors.
+
+
+## v2.6.0
+
+* **[2023-01-13 06:35:04 EST]** Fixed a bug in v1.4 support.
+* **[2023-01-13 06:23:38 EST]** Version 2.6.0.
+* **[2023-01-13 06:16:45 EST]** Upgraded to Rimworld v1.4.3580.
+* **[2023-01-13 06:15:43 EST]** Automatically package all of the supported versions DLLs into the v1.2 Mod directory.
+* **[2023-01-13 06:12:40 EST]** Moved the Defs into the standard location.
+* **[2022-05-26 05:13:10 CST]** Reverse the age of animals completely.
+* **[2022-01-29 13:19:22 COT]** Version 2.5.0.
+* **[2022-01-29 13:10:02 COT]** Now the chamber reanalyzes for new injuries after each healing.
+* **[2022-01-29 13:02:11 COT]** Properly determine healing frequency for species with lower life expenctancies.
+* **[2022-01-29 13:01:15 COT]** Properly count Old Age disabilities.
+* **[2022-01-29 13:00:53 COT]** Completely ignore missing body parts due to bionics.
+* **[2022-01-29 12:59:46 COT]** Reverse age any pawn that enters healthy.
+* **[2022-01-29 12:51:07 COT]** Increased the cost to build by 250 Gold.
+* **[2022-01-28 18:11:00 COT]** Eject the pawn when there are no more injuries.
+* **[2022-01-28 18:10:00 COT]** Heal the pawn no matter what.
+* **[2021-10-29 03:51:52 COT]** FIXED: Age is shown when there are no injuries.
+* **[2021-10-28 08:33:48 COT]** Version 2.0.
+* **[2021-10-28 08:31:10 COT]** Show the Contents tab with the pawn inside.
+* **[2021-10-28 07:59:53 COT]** Added the "Time To Heal" to the casket display.
+* **[2021-10-28 06:57:34 COT]** Added a deploy script.
+* **[2021-10-28 06:26:09 COT]** Added support for compiling for both Rimworld v1.2 and v1.3.
+* **[2021-10-28 02:52:26 COT]** Don't heal over bionics, but do heal peg legs, etc.
+* **[2021-10-28 01:00:32 COT]** Don't copy over all of the assemblies.
+* **[2021-10-28 00:35:43 COT]** Added Linux build support.
+
+## v1.1.0
+
+* **[2021-06-17 22:45:32 MDT]** Version 1.1.
+* **[2021-06-17 22:39:56 MDT]** Reset the pawn's rest, joy and comfort levels on reawakening.
+* **[2021-06-17 22:38:02 MDT]** Ignore "missing body parts" for more efficient handling of bionics.
+
+## v1.2.2719
+
+* **[2020-08-11 09:11:17 CDT]** Upgraded to Rimworld v1.2.2719.
+* **[2020-08-10 22:11:40 CDT]** Released to Steam Workshop!!
+
+## v1.1.2654
+
+* **[2020-08-10 21:08:59 CDT]** Ported to v1.1.2654 + lots of release changes.
+* **[2020-08-10 21:03:41 CDT]** Report time frames in years, quadrums and days.
+
+## v1.0.2559
+
+* **[2020-08-06 17:11:37 CDT]** Upgraded to v1.0.2559.
+* **[2020-08-05 07:14:51 CDT]** Upgraded to B18-0.18.1722.
+* **[2020-08-06 18:02:33 CDT]** Upgraded to A17-0.17.1557.
+* **[2020-08-04 21:39:22 CDT]** Completely reworked how curable injuries are determined. Ignore drugs + addictions.
+* **[2020-08-04 10:33:00 CDT]** Upgraded to A16-0.16.1393.
+* **[2020-08-03 13:18:12 CDT]** Upgraded to A15-0.15.1284.
+* **[2020-08-03 16:02:23 CDT]** Fixed the Definition files.
+* **[2020-08-03 04:09:06 CDT]** Remove negative and now-irrelevant thoughts upon ejection.
+* **[2020-08-03 04:08:24 CDT]** Ignore joywires during the regenesis process.
+* **[2020-08-03 04:07:55 CDT]** Properly notify the user on errors.
+* **[2020-08-03 04:07:15 CDT]** Auto-eject the person when cryoregenesis is compelete.
+* **[2020-07-28 20:18:09 CDT]** Simplified the healing logic.
+* **[2020-07-28 19:01:56 CDT]** [m] Force Visual Studio 2019 to save with LF line endings.
+* **[2020-07-28 18:51:31 CDT]** Dynamically determine a creature's target age based on its life expectancy.
+* **[2020-07-26 07:53:48 CDT]** Added logic for rejuvenating Methuselah pawns > 100 years old.
+* **[2020-07-26 07:52:57 CDT]** Reduced the amount of Uranium needed, as it was WAYY too much!
+* **[2020-07-24 14:29:46 CDT]** Always use fuel if there's something to do.
+* **[2020-07-24 14:29:01 CDT]** Refuse to heal if pregnant or has implants.
+* **[2020-07-24 09:40:43 CDT]** Heal primarily based off of Uranium consumption.
+* **[2020-07-23 23:28:18 CDT]** Lots and lots of improvements that I'm pretty happy with.
+* **[2020-07-22 22:25:38 CDT]** Added restorative powers. Heal 1 injury per regressed bio-year, starting at age 25.
+* **[2020-07-22 22:22:07 CDT]** Backported the mod to Rimworld A14.
+* **[2020-07-22 22:11:26 CDT]** More renames.
+* **[2020-07-22 22:09:20 CDT]** Initial renames from CryptoRestore to CryoRegenesis.
+* **[2020-07-22 22:06:37 CDT]** Initial. Based off of kittycat2002/CryptoRestore-Casket@1.1.1

--- a/CryoRegenesis/Defs/Hediffs/CryoRegenesisSedation.xml
+++ b/CryoRegenesis/Defs/Hediffs/CryoRegenesisSedation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <HediffDef>
+    <defName>CryoRegenesisSedation</defName>
+    <label>CryoRegenesis sedation</label>
+    <description>
+      A short-acting neuromuscular suppression state used to safely prepare a pawn for CryoRegenesis casket insertion.
+    </description>
+
+    <hediffClass>HediffWithComps</hediffClass>
+    <initialSeverity>1.0</initialSeverity>
+    <isBad>true</isBad>
+
+    <stages>
+      <li>
+        <label>sedated</label>
+        <capMods>
+          <li>
+            <capacity>Moving</capacity>
+            <offset>-1.0</offset>
+          </li>
+        </capMods>
+      </li>
+    </stages>
+
+    <comps>
+      <li Class="HediffCompProperties_Disappears">
+        <disappearsAfterTicks>4000</disappearsAfterTicks>
+        <showRemainingTime>true</showRemainingTime>
+      </li>
+    </comps>
+  </HediffDef>
+
+</Defs>

--- a/CryoRegenesis/Defs/Hediffs/CryoRegenesisSedation.xml
+++ b/CryoRegenesis/Defs/Hediffs/CryoRegenesisSedation.xml
@@ -18,7 +18,8 @@
         <capMods>
           <li>
             <capacity>Moving</capacity>
-            <offset>-1.0</offset>
+            <!-- Force zero movement even when bionic/archotech parts add capacity. -->
+            <offset>-10.0</offset>
           </li>
         </capMods>
       </li>

--- a/CryoRegenesis/Defs/Hediffs/TrueAgeTracker.xml
+++ b/CryoRegenesis/Defs/Hediffs/TrueAgeTracker.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+    <HediffDef>
+        <defName>TrueAgeTracker</defName>
+        <hediffClass>BetterRimworlds.CryoRegenesis.TrueAgeTracker</hediffClass>
+        <label>true age tracker</label>
+        <description>Hidden CryoRegenesis bookkeeping for tracking a pawn's true lived age.</description>
+        <displayWound>false</displayWound>
+        <isBad>false</isBad>
+        <lethalSeverity>-1</lethalSeverity>
+        <makesSickThought>false</makesSickThought>
+    </HediffDef>
+</Defs>

--- a/CryoRegenesis/Defs/JobDefs/CarryToCryoRegenesis.xml
+++ b/CryoRegenesis/Defs/JobDefs/CarryToCryoRegenesis.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- ==== CryoRegenesis/Defs/JobDefs/CarryToCryoRegenesis.xml ==== -->
+<Defs>
+
+  <JobDef>
+    <defName>CR_CarryToCryoRegenesis</defName>
+    <driverClass>BetterRimworlds.CryoRegenesis.JobDriver_CarryToCryoRegenesis</driverClass>
+    <reportString>Carrying TargetA to a CryoRegenesis casket.</reportString>
+    <checkOverrideOnExpire>false</checkOverrideOnExpire>
+    <alwaysShowWeapon>false</alwaysShowWeapon>
+    <casualInterruptible>false</casualInterruptible>
+  </JobDef>
+
+</Defs>

--- a/CryoRegenesis/Defs/RecipeDefs/CryoRegenesis_Recipes.xml
+++ b/CryoRegenesis/Defs/RecipeDefs/CryoRegenesis_Recipes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <RecipeDef>
+    <defName>CR_AdministerCryoRegenesisSedation</defName>
+    <label>administer CryoRegenesis sedation</label>
+    <description>
+      Administer a short-acting CryoRegenesis-compatible sedative protocol. This does not consume medicine, but requires doctor work.
+    </description>
+
+    <workerClass>BetterRimworlds.CryoRegenesis.Recipe_AdministerCryoRegenesisSedation</workerClass>
+
+    <jobString>Administering CryoRegenesis sedation.</jobString>
+    <jobStringTendedTo>Administering CryoRegenesis sedation to patient.</jobStringTendedTo>
+
+    <workAmount>600</workAmount>
+    <workSkill>Medicine</workSkill>
+
+    <targetsBodyPart>false</targetsBodyPart>
+    <anesthetize>false</anesthetize>
+    <hideBodyPartNames>true</hideBodyPartNames>
+
+    <surgerySuccessChanceFactor>99999</surgerySuccessChanceFactor>
+
+    <ingredients />
+
+<!--    <recipeUsers>-->
+<!--      <li>Human</li>-->
+<!--    </recipeUsers>-->
+  </RecipeDef>
+
+</Defs>

--- a/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
+++ b/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
@@ -34,6 +34,7 @@
 		<defaultPlacingRot>South</defaultPlacingRot>
 		<building>
 			<ai_chillDestination>false</ai_chillDestination>
+			<isPlayerEjectable>true</isPlayerEjectable>
 		</building>
 		<costList>
 			<Steel>250</Steel>

--- a/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
+++ b/CryoRegenesis/Defs/ThoughtDefs/CryoRegenesis.xml
@@ -15,6 +15,8 @@
     <ThoughtDef>
         <defName>CryoRegenesis_BodyPositivity</defName>
         <thoughtClass>BetterRimworlds.CryoRegenesis.Thought_RegenesisBodyPositivity</thoughtClass>
+        <stackLimit>5</stackLimit>
+        <stackedEffectMultiplier>0.75</stackedEffectMultiplier>
         <stages>
             <li>
                 <label>Regenerated</label>

--- a/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
+++ b/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>أشعر بأنني أصغر ببضع سنوات.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>العمر الحقيقي</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>احمل إلى تابوت كريو ريجينيسيس</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>لا يوجد تابوت كريو ريجينيسيس يمكن الوصول إليه</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
+++ b/CryoRegenesis/Languages/Arabic/Keyed/Arabic.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>أشعر بأنني أصغر ببضع سنوات.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>العمر الحقيقي</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>لا يوجد تابوت كريو ريجينيسيس متاح.</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>احمل إلى تابوت كريو ريجينيسيس</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>لا يوجد تابوت كريو ريجينيسيس يمكن الوصول إليه</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
+++ b/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Em sento uns anys més jove.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edat real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No hi ha cap taüt de CryoRegenesis disponible</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Porta al taüt de CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>No hi ha cap taüt de CryoRegenesis accessible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
+++ b/CryoRegenesis/Languages/Catalan/Keyed/Catalan.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Em sento uns anys més jove.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edat real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Porta al taüt de CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>No hi ha cap taüt de CryoRegenesis accessible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
+++ b/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感觉年轻了几岁。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真实年龄</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>搬到 CryoRegenesis 冷冻舱</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>没有可到达的 CryoRegenesis 冷冻舱</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
+++ b/CryoRegenesis/Languages/ChineseSimplified/Keyed/ChineseSimplified.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感觉年轻了几岁。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真实年龄</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>没有可用的 CryoRegenesis 冷冻舱。</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>搬到 CryoRegenesis 冷冻舱</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>没有可到达的 CryoRegenesis 冷冻舱</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
+++ b/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感覺年輕了幾歲。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真實年齡</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>沒有可用的 CryoRegenesis 冷凍艙。</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>搬到 CryoRegenesis 冷凍艙</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>沒有可到達的 CryoRegenesis 冷凍艙</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
+++ b/CryoRegenesis/Languages/ChineseTraditional/Keyed/ChineseTraditional.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>我感覺年輕了幾歲。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>真實年齡</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>搬到 CryoRegenesis 冷凍艙</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>沒有可到達的 CryoRegenesis 冷凍艙</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
+++ b/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítím se o několik let mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutečný věk</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Žádný dostupný kryoregenesanční sarkofág</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Odnést do kryoregenesančního sarkofágu</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Žádný dostupný kryoregenesanční sarkofág</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
+++ b/CryoRegenesis/Languages/Czech/Keyed/Czech.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítím se o několik let mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutečný věk</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Odnést do kryoregenesančního sarkofágu</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Žádný dostupný kryoregenesanční sarkofág</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
+++ b/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler mig nogle år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ægte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ingen tilgængelig CryoRegenesis-kiste</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Bær til CryoRegenesis-kiste</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ingen tilgængelig CryoRegenesis-kiste</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
+++ b/CryoRegenesis/Languages/Danish/Keyed/Danish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler mig nogle år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ægte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Bær til CryoRegenesis-kiste</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ingen tilgængelig CryoRegenesis-kiste</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
+++ b/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ik voel me een paar jaar jonger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Echte leeftijd</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Breng naar CryoRegenesis-kist</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Geen bereikbare CryoRegenesis-kist</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
+++ b/CryoRegenesis/Languages/Dutch/Keyed/Dutch.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ik voel me een paar jaar jonger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Echte leeftijd</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Geen beschikbare CryoRegenesis-kist</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Breng naar CryoRegenesis-kist</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Geen bereikbare CryoRegenesis-kist</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -23,5 +23,5 @@
     <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No available CryoRegenesis casket.</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
 
     <CarryToCryoRegenesisCasket>Carry to CryoRegenesis casket</CarryToCryoRegenesisCasket>
-    <NoReachableCryoRegenesis>No reachable CryoRegenesis casket</NoReachableCryoRegenesis>
+    <NoReachableCryoRegenesis>No available CryoRegenesis casket</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -19,4 +19,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>I feel a few years younger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>True Age</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+
+    <CarryToCryoRegenesisCasket>Carry to CryoRegenesis casket</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>No reachable CryoRegenesis casket</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -20,6 +20,8 @@
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>True Age</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
 
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No available CryoRegenesis casket.</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
+
     <CarryToCryoRegenesisCasket>Carry to CryoRegenesis casket</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>No reachable CryoRegenesis casket</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
+++ b/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen end mõne aasta nooremalt.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tegelik vanus</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ühtegi CryoRegenesis'i kirstu pole saadaval</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Kanna CryoRegenesis'i kirstu</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ühtegi ligipääsetavat CryoRegenesis'i kirstu pole</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
+++ b/CryoRegenesis/Languages/Estonian/Keyed/Estonian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen end mõne aasta nooremalt.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tegelik vanus</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Kanna CryoRegenesis'i kirstu</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ühtegi ligipääsetavat CryoRegenesis'i kirstu pole</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
+++ b/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen oloni muutaman vuoden nuoremmaksi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Todellinen ikä</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Kannetaan CryoRegenesis-arkkuun</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ei saavutettavaa CryoRegenesis-arkkua</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
+++ b/CryoRegenesis/Languages/Finnish/Keyed/Finnish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tunnen oloni muutaman vuoden nuoremmaksi.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Todellinen ikä</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ei saatavilla olevaa CryoRegenesis-arkkua</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Kannetaan CryoRegenesis-arkkuun</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ei saavutettavaa CryoRegenesis-arkkua</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/French/Keyed/French.xml
+++ b/CryoRegenesis/Languages/French/Keyed/French.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Je me sens quelques années plus jeune.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Âge réel</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Aucun sarcophage CryoRegenesis disponible</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Porter au sarcophage de CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Aucun sarcophage CryoRegenesis accessible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/French/Keyed/French.xml
+++ b/CryoRegenesis/Languages/French/Keyed/French.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Je me sens quelques années plus jeune.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Âge réel</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Porter au sarcophage de CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Aucun sarcophage CryoRegenesis accessible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/German/Keyed/German.xml
+++ b/CryoRegenesis/Languages/German/Keyed/German.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ich fühle mich um einige Jahre jünger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Wahres Alter</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Zur CryoRegenesis-Kapsel tragen</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Keine erreichbare CryoRegenesis-Kapsel</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/German/Keyed/German.xml
+++ b/CryoRegenesis/Languages/German/Keyed/German.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Ich fühle mich um einige Jahre jünger.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Wahres Alter</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Keine verfügbare CryoRegenesis-Kapsel</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Zur CryoRegenesis-Kapsel tragen</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Keine erreichbare CryoRegenesis-Kapsel</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
+++ b/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Νιώθω μερικά χρόνια νεότερος.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Πραγματική ηλικία</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Μεταφορά στη λάρνακα CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Δεν υπάρχει προσβάσιμη λάρνακα CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
+++ b/CryoRegenesis/Languages/Greek/Keyed/Greek.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Νιώθω μερικά χρόνια νεότερος.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Πραγματική ηλικία</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Δεν υπάρχει διαθέσιμη λάρνακα CryoRegenesis</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Μεταφορά στη λάρνακα CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Δεν υπάρχει προσβάσιμη λάρνακα CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
+++ b/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>मैं अपने आपको कुछ साल युवा महसूस कर रहा हूं।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>वास्तविक आयु</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>क्रायोरेजेनेसिस कास्केट तक ले जाएँ</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>कोई सुलभ क्रायोरेजेनेसिस कास्केट नहीं</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
+++ b/CryoRegenesis/Languages/Hindi/Keyed/Hindi.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>मैं अपने आपको कुछ साल युवा महसूस कर रहा हूं।</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>वास्तविक आयु</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>कोई उपलब्ध क्रायोरेजेनेसिस कास्केट नहीं</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>क्रायोरेजेनेसिस कास्केट तक ले जाएँ</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>कोई सुलभ क्रायोरेजेनेसिस कास्केट नहीं</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
+++ b/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Néhány évvel fiatalabbnak érzem magam.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Valódi kor</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Nincs elérhető CryoRegenesis koporsó</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Vidd a CryoRegenesis koporsóhoz</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Nincs elérhető CryoRegenesis koporsó</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
+++ b/CryoRegenesis/Languages/Hungarian/Keyed/Hungarian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Néhány évvel fiatalabbnak érzem magam.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Valódi kor</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Vidd a CryoRegenesis koporsóhoz</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Nincs elérhető CryoRegenesis koporsó</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
+++ b/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mi sento qualche anno più giovane.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Età reale</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Porta al sarcofago di CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Nessun sarcofago CryoRegenesis raggiungibile</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
+++ b/CryoRegenesis/Languages/Italian/Keyed/Italian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mi sento qualche anno più giovane.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Età reale</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Nessun sarcofago CryoRegenesis disponibile</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Porta al sarcofago di CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Nessun sarcofago CryoRegenesis raggiungibile</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
+++ b/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>数年若くなった気分だ。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>実年齢</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>CryoRegenesisカスケットへ運ぶ</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>到達可能なCryoRegenesisカスケットがない</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
+++ b/CryoRegenesis/Languages/Japanese/Keyed/Japanese.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>数年若くなった気分だ。</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>実年齢</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>利用可能なCryoRegenesisカスケットがない</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>CryoRegenesisカスケットへ運ぶ</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>到達可能なCryoRegenesisカスケットがない</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
+++ b/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>몇 년 젊어진 기분이다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>실제 나이</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>크라이오레제네시스 관으로 옮기기</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>도달 가능한 크라이오레제네시스 관이 없음</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
+++ b/CryoRegenesis/Languages/Korean/Keyed/Korean.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>몇 년 젊어진 기분이다.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>실제 나이</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>사용 가능한 크라이오레제네시스 관이 없음</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>크라이오레제네시스 관으로 옮기기</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>도달 가능한 크라이오레제네시스 관이 없음</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
+++ b/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler meg noen år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ekte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ingen tilgjengelig CryoRegenesis-kiste</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Bær til CryoRegenesis-kiste</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ingen tilgjengelig CryoRegenesis-kiste</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
+++ b/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
@@ -22,5 +22,5 @@
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ekte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
     <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ingen tilgjengelig CryoRegenesis-kiste</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Bær til CryoRegenesis-kiste</CarryToCryoRegenesisCasket>
-    <NoReachableCryoRegenesis>Ingen tilgjengelig CryoRegenesis-kiste</NoReachableCryoRegenesis>
+    <NoReachableCryoRegenesis>Ingen nåbar CryoRegenesis-kiste</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
+++ b/CryoRegenesis/Languages/Norwegian/Keyed/Norwegian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jeg føler meg noen år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Ekte alder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Bær til CryoRegenesis-kiste</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ingen tilgjengelig CryoRegenesis-kiste</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
+++ b/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
@@ -22,5 +22,5 @@
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Prawdziwy wiek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
     <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Brak dostępnego sarkofagu CryoRegenesis</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Zanieś do sarkofagu CryoRegenesis</CarryToCryoRegenesisCasket>
-    <NoReachableCryoRegenesis>Brak dostępnego sarkofagu CryoRegenesis</NoReachableCryoRegenesis>
+    <NoReachableCryoRegenesis>Brak osiągalnego sarkofagu CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
+++ b/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Czuję się o kilka lat młodszy.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Prawdziwy wiek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Brak dostępnego sarkofagu CryoRegenesis</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Zanieś do sarkofagu CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Brak dostępnego sarkofagu CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
+++ b/CryoRegenesis/Languages/Polish/Keyed/Polish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Czuję się o kilka lat młodszy.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Prawdziwy wiek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Zanieś do sarkofagu CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Brak dostępnego sarkofagu CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
+++ b/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Nenhum sarcófago CryoRegenesis disponível</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Levar para o sarcófago CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Nenhum sarcófago CryoRegenesis alcançável</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
+++ b/CryoRegenesis/Languages/Portuguese/Keyed/Portuguese.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Levar para o sarcófago CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Nenhum sarcófago CryoRegenesis alcançável</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
+++ b/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Nenhum sarcófago CryoRegenesis disponível</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Levar para o sarcófago CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Nenhum sarcófago CryoRegenesis alcançável</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
+++ b/CryoRegenesis/Languages/PortugueseBrazilian/Keyed/PortugueseBrazilian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Sinto-me alguns anos mais jovem.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Idade real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Levar para o sarcófago CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Nenhum sarcófago CryoRegenesis alcançável</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
+++ b/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mă simt cu câțiva ani mai tânăr.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Vârstă reală</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Nu există niciun cufăr CryoRegenesis accesibil</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Cară la cufărul CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Nu există niciun cufăr CryoRegenesis accesibil</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
+++ b/CryoRegenesis/Languages/Romanian/Keyed/Romanian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Mă simt cu câțiva ani mai tânăr.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Vârstă reală</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Cară la cufărul CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Nu există niciun cufăr CryoRegenesis accesibil</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
+++ b/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я чувствую себя на несколько лет моложе.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Настоящий возраст</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Перенести в саркофаг CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Нет доступного саркофага CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
+++ b/CryoRegenesis/Languages/Russian/Keyed/Russian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я чувствую себя на несколько лет моложе.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Настоящий возраст</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Нет доступного саркофага CryoRegenesis</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Перенести в саркофаг CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Нет доступного саркофага CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
+++ b/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítim sa o niekoľko rokov mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutočný vek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Žiadny dostupný kryoregenesančný sarkofág</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Uniesť do kryoregenesančného sarkofágu</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Žiadny dostupný kryoregenesančný sarkofág</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
+++ b/CryoRegenesis/Languages/Slovak/Keyed/Slovak.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Cítim sa o niekoľko rokov mladší.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Skutočný vek</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Uniesť do kryoregenesančného sarkofágu</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Žiadny dostupný kryoregenesančný sarkofág</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No hay ningún ataúd de CryoRegenesis disponible</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Llevar al ataúd de CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>No hay ningún ataúd de CryoRegenesis accesible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/Spanish/Keyed/Spanish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Llevar al ataúd de CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>No hay ningún ataúd de CryoRegenesis accesible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No hay ningún ataúd de CryoRegenesis disponible</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Llevar al ataúd de CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>No hay ningún ataúd de CryoRegenesis accesible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
+++ b/CryoRegenesis/Languages/SpanishLatin/Keyed/Spanish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Me siento unos años más joven.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Edad real</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Llevar al ataúd de CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>No hay ningún ataúd de CryoRegenesis accesible</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
+++ b/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jag känner mig några år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Verklig ålder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Bär till CryoRegenesis-kista</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ingen nåbar CryoRegenesis-kista</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
+++ b/CryoRegenesis/Languages/Swedish/Keyed/Swedish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Jag känner mig några år yngre.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Verklig ålder</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ingen tillgänglig CryoRegenesis-kista</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Bär till CryoRegenesis-kista</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ingen nåbar CryoRegenesis-kista</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
+++ b/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Kendimi birkaç yıl daha genç hissediyorum.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Gerçek yaş</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>CryoRegenesis lahdine taşı</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Ulaşılabilir CryoRegenesis lahdi yok</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
+++ b/CryoRegenesis/Languages/Turkish/Keyed/Turkish.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Kendimi birkaç yıl daha genç hissediyorum.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Gerçek yaş</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Ulaşılabilir CryoRegenesis lahdi yok</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>CryoRegenesis lahdine taşı</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Ulaşılabilir CryoRegenesis lahdi yok</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
+++ b/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я відчуваю себе на кілька років молодшим.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Справжній вік</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Немає доступного саркофага CryoRegenesis</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Перенести до саркофага CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Немає доступного саркофага CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
+++ b/CryoRegenesis/Languages/Ukrainian/Keyed/Ukrainian.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Я відчуваю себе на кілька років молодшим.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Справжній вік</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Перенести до саркофага CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Немає доступного саркофага CryoRegenesis</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
+++ b/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
@@ -20,6 +20,7 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tôi cảm thấy trẻ hơn vài năm.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tuổi thật</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>Không có quan tài CryoRegenesis nào khả dụng</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
     <CarryToCryoRegenesisCasket>Đưa đến quan tài CryoRegenesis</CarryToCryoRegenesisCasket>
     <NoReachableCryoRegenesis>Không có quan tài CryoRegenesis nào có thể đến được</NoReachableCryoRegenesis>
 </LanguageData>

--- a/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
+++ b/CryoRegenesis/Languages/Vietnamese/Keyed/Vietnamese.xml
@@ -20,4 +20,6 @@
     <BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>Tôi cảm thấy trẻ hơn vài năm.</BetterRimworlds.CryoRegenesis.BodyPositivity.Desc.Some>
 
     <BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>Tuổi thật</BetterRimworlds.CryoRegenesis.CharacterCard.TrueAge>
+    <CarryToCryoRegenesisCasket>Đưa đến quan tài CryoRegenesis</CarryToCryoRegenesisCasket>
+    <NoReachableCryoRegenesis>Không có quan tài CryoRegenesis nào có thể đến được</NoReachableCryoRegenesis>
 </LanguageData>

--- a/README.md
+++ b/README.md
@@ -92,103 +92,68 @@ The combination of resource costs and permanent Luciferium addiction ensures res
 
 ## Changelog
 
-**Version 1.0: 2020-08-11**
-* **[2020-08-10 22:11:40 CDT]** All of the core functionality.
-* **[2020-08-11 09:11:17 CDT]** Added support for Rimworld v1.2.
+Last 365 days. For more, see [CHANGELOG.md](CHANGELOG.md).
 
-**Version 1.1: 2021-06-17**
-* **[2021-06-17 23:38:02 CDT]** Ignore "missing body parts" for more efficient handling of bionics.
-* **[2021-06-17 23:39:56 CDT]** Reset the pawn's rest, joy and comfort levels on reawakening.
+## v7.0.0
 
-**Version 2.0: 2021-10-28**
-* **[2021-10-28 00:35:43 CDT]** Added Linux build support.
-* **[2021-10-28 01:00:32 CDT]** [m] Don't copy over all of the assemblies.
-* **[2021-10-28 02:52:26 CDT]** Don't heal over bionics, but do heal peg legs, etc.
-* **[2021-10-28 06:26:09 CDT]** Added support for compiling for both Rimworld v1.2 and v1.3.
-* **[2021-10-28 06:57:34 CDT]** [m] Added a deploy script.
-* **[2021-10-28 07:59:53 CDT]** Added the "Time To Heal" to the casket display.
-* **[2021-10-28 08:31:10 CDT]** Show the Contents tab with the pawn inside.
+* **[2026-07-23 11:33:33 EEST]** Fixed simple prosthetics remaining after regeneration.
+* **[2026-07-19 09:12:20 CDT]** Repositioned the True Age to the right.
+* **[2026-07-18 14:11:59 CDT]** Body positivity thoughts now stack and scale duration from lifetime True Age years erased.
+* **[2026-07-12 21:11:16 CDT]** Marked the CryoRegenesis casket as player-ejectable.
+* **[2026-07-12 20:21:20 CDT]** Fixed Carry-to-CryoRegenesis never appearing or working for downed, sedated, and guest pawns.
+* **[2026-07-10 22:12:38 COT]** [m] Removed the watch for building as it is no longer useful in The Age of AI.
+* **[2026-07-09 09:16:13 COT]** Updated the README with Stargate references.
+* **[2026-07-09 02:46:37 COT]** Fixed a regression where pawns with Bionic or Archotech legs could not be properly downed.
+* **[2026-07-09 02:39:04 COT]** Pawns now cannot be attempted to be carried to a CryoRegenesis casket if none are available.
+* **[2026-07-09 02:36:32 COT]** Removed the Heal Not Bad HeDiffs mechanism completely.
+* **[2026-07-08 09:40:26 COT]** Fixed the instant ejection of non-Human humanlikes (xenotypes, Empire pawns, modded races) from CryoRegenesis.
+* **[2026-07-07 19:17:47 COT]** Added animal support for CryoRegenesis carry.
+* **[2026-07-07 19:17:17 COT]** All downed humanlikes can now be carried to CryoRegenesis caskets.
+* **[2026-07-07 19:10:52 COT]** Added a sedate-and-carry pipeline for placing pawns into CryoRegenesis caskets via the Operations tab.
+* **[2026-07-07 19:10:03 COT]** Added the missing True Age def.
+* **[2026-07-02 12:46:22 COT]** Added support for taking Royalty guests and prisoners to the CryoRegenesis casket.
 
-**Version 2.5: 2022-01-29**
-* **[2021-10-29 02:51:52 CDT]** FIXED: Age is shown when there are no injuries. origin/v2.0
-* **[2022-01-28 17:10:00 CDT]** Heal the pawn no matter what.
-* **[2022-01-28 17:11:00 CDT]** Eject the pawn when there are no more injuries.
-* **[2022-01-29 11:51:07 CDT]** Increased the cost to build by 250 Gold.
-* **[2022-01-29 11:59:46 CDT]** Reverse age any pawn that enters healthy.
-* **[2022-01-29 12:00:53 CDT]** Completely ignore missing body parts due to bionics.
-* **[2022-01-29 12:01:15 CDT]** Properly count Old Age disabilities.
-* **[2022-01-29 12:02:11 CDT]** Properly determine healing frequency for species with lower life expenctancies.
-* **[2022-01-29 12:10:02 CDT]** Now the chamber reanalyzes for new injuries after each healing.
+## v6.0.0
 
-**Version 2.6: 2023-01-13**
-* **[2022-05-26 06:13:10 CDT]** Reverse the age of animals completely.
-* **[2023-01-13 05:12:40 CDT]** Moved the Defs into the standard location.
-* **[2023-01-13 05:15:43 CDT]** Automatically package all of the supported versions DLLs into the v1.2 Mod directory.
-* **[2023-01-13 05:16:45 CDT]** Upgraded to Rimworld v1.4.3580.
-
-**Version 3.0: 2023-05-22**
-* **[2023-03-26 06:41:29 CDT]** Re-added more hair colors.
-* **[2023-05-21 10:41:18 CDT]** [m] Update README.md: Added info about Cargo.
-* **[2023-05-22 00:30:13 CDT]** [m] Added a proper Mod class.
-* **[2023-05-22 00:32:17 CDT]** Added Mod Settings.
-* **[2023-05-22 00:38:56 CDT]** [m] Rearranged the SpawnSetup method.
-* **[2023-05-22 00:42:55 CDT]** Enabled the new optional debug messaging system.
-* **[2023-05-22 00:43:34 CDT]** Added a new option to only regen until the pawn is healed.
-* **[2023-05-22 00:44:19 CDT]** Added a new option for the target age of Human pawns.
-* **[2023-05-22 00:47:24 CDT]** Added an option to not try to heal anything that isn't tendable.
-* **[2023-05-22 00:47:45 CDT]** Added functionality to never heal implants.
-* **[2023-05-22 01:31:53 CDT]** Block non-colonist humans from being placed in the casket to avoid CryoRegenesis Quantum Anomaly (Bug #6).
-
-**Version 3.0.1: 2023-07-28**
-* **[2023-07-28 16:43:18 CDT]** Fixed a bug that prohibited animals from being put in the cryocasket.
-
-**Version 3.1.0: 2024-03-15**
-* **[2024-03-15 01:44:12 CDT]** [m] Majorly refactored the deploy script.
-* **[2024-03-15 01:44:32 CDT]** Upgraded to Rimworld v1.5.
-* **[2024-03-15 01:46:43 CDT]** Made the CryoRegenesis flickable (turns it into a normal cryocasket).
-* **[2024-03-15 01:47:43 CDT]** Added optional code (enabled by default) to not heal any hediffs that are not marked as "bad".
-* **[2024-03-15 02:16:24 CDT]** Cured the CyroRegenesis Quantum Anomaly that broke when guests were put in.
-
-**Version 4.0.0: 2024-05-13**
-* **[2024-05-12 13:53:08 CDT]** Implemented the resurrection of corpses.
-
-**Version 4.1.0: 2025-03-15**
-* **[2025-03-06 06:27:19 CDT]** Ported to .NET v9.0 and C# v10.0.
-* **[2025-03-14 15:52:36 CDT]** Rearchitected the files to the BetterRimworlds standard layout.
-* **[2025-03-15 03:11:00 CDT]** [m] Tiny code cleanups.
-
-**Version 5.0.0: 2025-07-22**
-* **[2025-07-11 18:01:11 CDT]** Migrated to a modern dotnet SDK project.
-* **[2025-07-11 18:25:25 CDT]** Added support for Rimworld v1.6.
-* **[2025-07-14 07:00:11 CDT]** Fixed the requirements gathering for resurrection.
-* **[2025-07-22 03:45:45 CDT]** Fixed the resurrection system.
-* **[2025-07-22 03:58:41 CDT]** Store the pawn's original age for use later.
-* **[2025-07-22 04:05:47 CDT]** Cause resurrected pawns to be under anesthetic on revival.
-* **[2025-07-22 04:28:00 CDT]** Added Luciferium addiction to resurrected pawns.
-* **[2025-07-22 04:45:26 CDT]** Added a "Grateful to be a alive!" thought when pawns are resurrected.
-* **[2025-07-22 21:47:41 CDT]** Added happy thoughts about being regenerated.
-
-**Version 5.1.0: 2026-04-29**
-* **[2026-04-29 06:52:14 CDT]** Added BetterRandom utility class for deterministic random number generation
-* **[2026-04-29 06:55:59 CDT]** Fixed Ejection to properly handle prisoners
-* **[2026-04-29 07:00:49 CDT]** Now freezes the corpse's rotting state preservation during resurrection.
-* **[2026-04-29 07:04:03 CDT]** Fixed the thought stage calculation for the age regression mood boost.
-* **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
-* **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.
-
-**Version 6.0.0: 2026-05-25**
-* **[2026-05-25 09:08:39 COT]** Refactored out Cosmetics, Resurrection, and Happy Thoughts from the CryoRegenesis god class.
-* **[2026-05-25 09:27:53 COT]** Added a True Age mechanism for tracking total Living Time.
-* **[2026-05-25 10:12:55 COT]** Split the actual regenesis code out of the CroRegenesis god class.
-* **[2026-05-25 10:16:42 COT]** An idle cryoregenesis casket no longer needs power.
-* **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.
-* **[2026-05-25 12:39:21 COT]** Increased the research cost.
-* **[2026-05-25 12:43:28 COT]** Completely reimplemented the True Age display to not use global UI widgets.
-
-**Version 6.1.0: 2026-05-28**
-* **[2026-05-28 18:09:22 COT]** Fixed Colonist despawning / lost forever when entering an unpowered CryoRegen pod.
-* **[2026-05-28 22:26:31 COT]** Added cryosleep counter as well to the new True Age popup.
-
-**Version 6.2.0: 2026-06-28**
-* **[2026-06-28 17:13:38 COT]** Greatly simplified the csproj.
+* **[2026-06-29 05:24:28 COT]** [m] Simple README and About.xml improvements.
 * **[2026-06-28 19:40:41 COT]** Moved the True Age below the Royalty indicator.
+* **[2026-06-28 17:13:38 COT]** Greatly simplified the csproj.
+
+## v6.1.0
+
+* **[2026-05-28 22:26:31 COT]** Added cryosleep counter as well to the new True Age popup.
+* **[2026-05-28 18:09:22 COT]** Fixed Colonist despawning / lost forever when entering an unpowered CryoRegen pod.
+
+## v6.0.0
+
+* **[2026-05-25 18:42:17 COT]** Updated the README for v6.0.0.
+* **[2026-05-25 12:43:28 COT]** Completely reimplemented the True Age display to not use global UI widgets.
+* **[2026-05-25 12:39:21 COT]** Increased the research cost.
+* **[2026-05-25 10:28:48 COT]** Falls back to normal cryptosleep casket when power fails.
+* **[2026-05-25 10:16:42 COT]** An idle cryoregenesis casket no longer needs power.
+* **[2026-05-25 10:12:55 COT]** Split the actual regenesis code out of the CroRegenesis god class.
+* **[2026-05-25 09:27:53 COT]** Added a True Age mechanism for tracking total Living Time.
+* **[2026-05-25 09:08:39 COT]** Refactored out Cosmetics, Resurrection, and Happy Thoughts from the CryoRegenesis god class.
+
+## v5.1.0
+
+* **[2026-05-05 11:04:27 COT]** Translated into many different languages.
+* **[2026-04-29 21:03:02 CDT]** Greatly enhanced the Regenesis High.
+* **[2026-04-29 07:57:17 CDT]** Added a Grateful To Be Alive extended Thought upon resurrection.
+* **[2026-04-29 07:04:03 CDT]** Fixed the thought stage calculation for the age regression mood boost.
+* **[2026-04-29 07:00:49 CDT]** Now freezes the corpse's rotting state preservation during resurrection.
+* **[2026-04-29 06:55:59 CDT]** Fixed Ejection to properly handle prisoners
+* **[2026-04-29 06:52:14 CDT]** Added BetterRandom utility class for deterministic random number generation
+
+## v5.0.0: Resurrection Improvements
+
+* **[2026-04-29 05:06:26 CDT]** Fail the build if any of the Rimworld versions fail to compile.
+* **[2025-07-22 23:47:41 ART]** Added happy thoughts about being regenerated.
+* **[2025-07-22 06:45:26 ART]** Added a "Grateful to be alive!" thought when pawns are resurrected.
+* **[2025-07-22 06:28:00 ART]** Added Luciferium addiction to resurrected pawns.
+* **[2025-07-22 06:05:47 ART]** Cause resurrected pawns to be under anesthetic on revival.
+* **[2025-07-22 05:58:41 ART]** Store the pawn's original age for use later.
+* **[2025-07-22 05:45:45 ART]** Fixed the resurrection system.
+* **[2025-07-14 09:00:11 ART]** Fixed the requirements gathering for resurrection.
+* **[2025-07-11 20:25:25 ART]** Added support for Rimworld v1.6.
+* **[2025-07-11 20:01:11 ART]** Migrated to a modern dotnet SDK project.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ cure all age-related infirmities as well as every physical injury!
  * Resurrects dead Pawns that 1) have a brain and 2) haven't been left unrefrigerated for more than 1 day.
  * Humanlike pawns now track a separate True Age, preserving total lived time even after de-aging.
 
+## Inspiration: The Goa'uld Sarcophagus
+
+CryoRegenesis is a RimWorld port of the **Goa'uld sarcophagus** from *Stargate* (the motion picture) and *Stargate SG-1*. In the show, those devices rapidly heal injuries, reverse aging, extend life, and can even resurrect the recently dead — at a steep psychological and addictive cost. The Tok'ra refuse to use them for that reason.
+
+This mod maps that artifact onto RimWorld's systems: cryptosleep chassis, glittertech nanites, and **Luciferium** as the Faustian price of coming back from the dead (the body only keeps working if the mechanites keep flowing).
+
+| Goa'uld sarcophagus | CryoRegenesis |
+|---|---|
+| Heals injury and disease | Heals hediffs, old-age failures, and wounds |
+| Extends life / reverses aging | De-ages pawns (and animals) to youthful prime |
+| Resurrects the recently dead | Resurrects if the brain is intact and the corpse has been unrefrigerated for less than 1 day |
+| Narcotic / addictive side effects | Permanent Luciferium addiction on resurrection |
+| Tok'ra refuse it because it "takes the soul" | Expensive glittertech with a lasting cost, not free immortality |
+| Body restored, mind altered | Mood highs and "Grateful to be alive!" after revival |
+
+Part of the [Better Rimworlds](https://github.com/BetterRimworlds) collection — Stargate-inspired tech for multi-century hub-world colonies.
+
 ## Supported RimWorld Versions
 
 - RimWorld 1.2

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -1,6 +1,43 @@
 // ==== Source/AllowHostedGuestsPatch.cs ====
+/*
+ * Carry-to-CryoRegenesis float menu (FloatMenuMakerMap.AddHumanlikeOrders).
+ *
+ * =============================================================================
+ * INCIDENT: option missing for unconscious / Downed prisoners (RW 1.2)
+ * =============================================================================
+ *
+ * What players saw:
+ *   Right-click on an unconscious prisoner (Moving 0%, Downed) never offered
+ *   "Carry to CryoRegenesis casket", even though the feature was meant for every
+ *   immobilised humanlike / colony animal.
+ *
+ * What was *not* the primary bug (but still worth hardening):
+ *   - Cell-only GetThingList lookups miss bed occupants → use GenUI.TargetsAt
+ *     plus a small cell neighbourhood scan.
+ *   - Strict CanReserveAndReach without ignoreOtherReservations greys out
+ *     tended patients → do not gate the menu on path/reserve probes; let the
+ *     job fail at runtime if needed.
+ *   - Carriable state is broader than `pawn.Downed` alone: also treat Moving
+ *     capacity at 0% (and anesthetic / CryoRegenesis sedation) as eligible so
+ *     edge ticks and UI "Moving 0%" match player expectations.
+ *
+ * What *was* the primary bug:
+ *   This patch never ran on 1.2. Harmony PatchAll aborted because another
+ *   assembly patch targeted a DoRecruit signature that does not exist on 1.2.
+ *   See the Harmony loading docblock in CryoRegenesis.cs and TargetMethod
+ *   fallbacks on Patch_DoRecruit_RegenContract.
+ *
+ * How not to repeat this:
+ *   - If this option vanishes on one RW version only, verify the patch is
+ *     applied (log + Harmony) before changing IsCryoCarryTargetState again.
+ *   - Keep IsCryoCarryTargetState = Downed OR Moving <= 0% OR sedation hediffs.
+ *   - Keep casket lookup free of pathing/reservation requirements for the menu.
+ *   - Multi-version: AddHumanlikeOrders exists through 1.5; 1.6 uses a different
+ *     float-menu pipeline and needs a separate approach if support is required.
+ * =============================================================================
+ */
+
 using System.Collections.Generic;
-using System.Linq;
 using BetterRimworlds.CryoRegenesis;
 using HarmonyLib;
 using RimWorld;
@@ -13,7 +50,10 @@ namespace CryoRegenesis.HarmonyPatches
     [HarmonyPatch(typeof(FloatMenuMakerMap), "AddHumanlikeOrders")]
     public static class Patch_FloatMenuMakerMap_AddHumanlikeOrders_CryoRegenesis
     {
-        public static void Postfix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
+        public static void Postfix(
+            Vector3 clickPos,
+            Pawn pawn,
+            List<FloatMenuOption> opts)
         {
             if (pawn?.Map == null)
                 return;
@@ -22,71 +62,223 @@ namespace CryoRegenesis.HarmonyPatches
             if (pawn.Downed || pawn.Dead || pawn.IsBurning())
                 return;
 
-            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
-
-            if (targetPawn == null)
-                return;
-
-            if (!ShouldAllowCryoRegenesisCarry(targetPawn))
-                return;
-
-            string label = "CarryToCryoRegenesisCasket".Translate();
-
-            Building_CryoRegenesis casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
-
-            if (casket == null)
+            /*
+             * Collect candidate patients under the cursor.
+             *
+             * GenUI.TargetsAt finds multi-cell bed occupants that a single
+             * GetThingList(cell) can miss. A cell scan is kept as a fallback
+             * for edge cases (e.g. draw-pos slightly off the click).
+             *
+             * Intentionally NO pathing / CanReserveAndReach checks here.
+             * Prisoners in locked rooms, guests with area restrictions, and
+             * bed-bound patients often fail reachability probes even when a
+             * colonist can still walk over and carry them. The job/toils
+             * handle real pathing at runtime.
+             */
+            foreach (Pawn targetPawn in GetCryoCarryCandidates(clickPos, pawn))
             {
-                opts.Add(new FloatMenuOption(label + ": " + "NoReachableCryoRegenesis".Translate(), null));
-                return;
-            }
+                if (!ShouldAllowCryoRegenesisCarry(targetPawn))
+                    continue;
 
-            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "CannotReach".Translate(targetPawn.LabelShort), null));
-                return;
-            }
+                string label = "CarryToCryoRegenesisCasket".Translate();
 
-            if (!pawn.CanReserve(casket))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "Reserved".Translate(casket.Label), null));
-                return;
-            }
+                Building_CryoRegenesis casket =
+                    FindEmptyCryoRegenesisCasket(targetPawn);
 
-            FloatMenuOption option = new FloatMenuOption(
-                label,
-                delegate
+                if (casket == null)
                 {
-                    Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, targetPawn, casket);
+                    opts.Add(
+                        new FloatMenuOption(
+                            label
+                            + ": "
+                            + "NoReachableCryoRegenesis".Translate(),
+                            null));
 
-                    job.count = 1;
+                    continue;
+                }
 
-                    pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
-                },
-                MenuOptionPriority.RescueOrCapture
-            );
+                // Capture for the menu-option delegate.
+                Pawn patient = targetPawn;
 
-            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(option, pawn, targetPawn));
+                FloatMenuOption option = new FloatMenuOption(
+                    label,
+                    delegate
+                    {
+                        Building_CryoRegenesis chosen =
+                            FindEmptyCryoRegenesisCasket(patient);
+
+                        if (chosen == null)
+                        {
+                            Messages.Message(
+                                "NoReachableCryoRegenesis".Translate(),
+                                patient,
+                                MessageTypeDefOf.RejectInput,
+                                historical: false);
+
+                            return;
+                        }
+
+                        Job job = JobMaker.MakeJob(
+                            CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
+                            patient,
+                            chosen);
+
+                        job.count = 1;
+
+                        pawn.jobs.TryTakeOrderedJob(
+                            job,
+                            JobTag.Misc);
+                    },
+                    MenuOptionPriority.RescueOrCapture);
+
+                opts.Add(
+                    FloatMenuUtility.DecoratePrioritizedTask(
+                        option,
+                        pawn,
+                        targetPawn));
+            }
         }
 
-        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
+        private static IEnumerable<Pawn> GetCryoCarryCandidates(
+            Vector3 clickPos,
+            Pawn carrier)
         {
+            var seen = new HashSet<Pawn>();
+
+            TargetingParameters targetingParameters =
+                MakeCryoCarryTargetingParameters(carrier);
+
+#if RIMWORLD12
+            // RimWorld 1.2 prefers TargetsAt_NewTemp; TargetsAt is obsolete there.
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt_NewTemp(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#else
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#endif
+
+            foreach (LocalTargetInfo target in targets)
+            {
+                if (target.Thing is Pawn targetPawn && seen.Add(targetPawn))
+                    yield return targetPawn;
+            }
+
+            // Fallback: direct cell scan (covers some bed / multi-cell cases).
+            Map map = carrier.Map;
             IntVec3 cell = IntVec3.FromVector3(clickPos);
 
             if (!cell.InBounds(map))
-                return null;
+                yield break;
 
-            return cell
-                .GetThingList(map)
-                .OfType<Pawn>()
-                .FirstOrDefault(
-                    candidate =>
-                        candidate.Downed &&
-                        !candidate.Dead &&
-                        (
-                            candidate.RaceProps.Humanlike ||
-                            candidate.RaceProps.Animal
-                        )
-                );
+            for (int x = -1; x <= 1; x++)
+            {
+                for (int z = -1; z <= 1; z++)
+                {
+                    IntVec3 scanCell = new IntVec3(cell.x + x, cell.y, cell.z + z);
+
+                    if (!scanCell.InBounds(map))
+                        continue;
+
+                    List<Thing> things = scanCell.GetThingList(map);
+
+                    for (int i = 0; i < things.Count; i++)
+                    {
+                        if (things[i] is Pawn targetPawn &&
+                            seen.Add(targetPawn) &&
+                            IsCryoCarryTargetState(targetPawn))
+                        {
+                            yield return targetPawn;
+                        }
+                    }
+                }
+            }
+        }
+
+        /*
+         * Common-denominator replacement for TargetingParameters.ForRescue.
+         *
+         * Also accepts pawns under Anesthetic / CryoRegenesis sedation who may
+         * briefly not report as Downed (severity edge, just-applied hediff).
+         * ForRescue's onlyTargetIncapacitatedPawns would miss those.
+         */
+        private static TargetingParameters MakeCryoCarryTargetingParameters(
+            Pawn carrier)
+        {
+            return new TargetingParameters
+            {
+                canTargetLocations = false,
+                canTargetSelf = false,
+
+                canTargetPawns = true,
+                canTargetHumans = true,
+                canTargetAnimals = true,
+
+                canTargetBuildings = false,
+                canTargetItems = false,
+
+                // Do NOT set onlyTargetIncapacitatedPawns: anesthetized
+                // prisoners can fail that gate at certain severity edges.
+                // Our validator handles Downed + sedation explicitly.
+                onlyTargetIncapacitatedPawns = false,
+                mustBeSelectable = false,
+                mapObjectTargetsMustBeAutoAttackable = false,
+
+                validator = target =>
+                {
+                    if (!target.HasThing)
+                        return false;
+
+                    Pawn targetPawn = target.Thing as Pawn;
+
+                    return targetPawn != null
+                        && targetPawn != carrier
+                        && targetPawn.Spawned
+                        && IsCryoCarryTargetState(targetPawn);
+                }
+            };
+        }
+
+        /// <summary>
+        /// True when the pawn is carriable: Downed, Moving at 0%, or sedated
+        /// and about to collapse. JobDriver waits for Downed after sedation.
+        /// </summary>
+        private static bool IsCryoCarryTargetState(Pawn targetPawn)
+        {
+            if (targetPawn == null || targetPawn.Dead)
+                return false;
+
+            // Standard incapacitated flag (unconscious, pain shock, etc.).
+            if (targetPawn.Downed)
+                return true;
+
+            // Moving 0% — can't walk even if Downed hasn't flipped yet.
+            PawnCapacitiesHandler capacities = targetPawn.health?.capacities;
+            if (capacities != null &&
+                (!capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+                 capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f))
+            {
+                return true;
+            }
+
+            // Full Anesthetic or our cryo sedation (pending collapse).
+            if (targetPawn.health?.hediffSet == null)
+                return false;
+
+            if (targetPawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+                return true;
+
+            if (CryoRegenesisDefOf.CryoRegenesisSedation != null &&
+                targetPawn.health.hediffSet.HasHediff(
+                    CryoRegenesisDefOf.CryoRegenesisSedation))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
@@ -94,26 +286,24 @@ namespace CryoRegenesis.HarmonyPatches
             if (targetPawn == null)
                 return false;
 
-            if (targetPawn.Dead || !targetPawn.Downed)
+            if (!IsCryoCarryTargetState(targetPawn))
                 return false;
 
             /*
              * Animals.
              *
-             * Restricted to the player's faction so the option isn't
-             * offered on wild or enemy fauna. Species-level petness is
-             * deliberately irrelevant — a tamed warg, thrumbo, or other
-             * non-pet species is still eligible when it belongs to the
-             * player's faction.
+             * Restricted to the player's faction so the option isn't offered
+             * on wild or enemy fauna. Species-level petness is deliberately
+             * irrelevant: a tamed warg, thrumbo, or other non-pet species is
+             * still eligible when it belongs to the player's faction.
              */
             if (targetPawn.RaceProps.Animal)
                 return targetPawn.Faction == Faction.OfPlayer;
 
             /*
-             * Any downed humanlike is eligible — colonists, slaves,
-             * prisoners, guests, quest lodgers, and downed hostiles alike.
-             * The click already required Downed && !Dead, so this covers
-             * every rescue/capture-style scenario, including sedated pawns.
+             * Any qualifying humanlike is eligible: colonists, slaves,
+             * prisoners (including anesthetized quest prisoners), guests,
+             * quest lodgers, and downed hostiles alike.
              */
             if (targetPawn.RaceProps.Humanlike)
                 return true;
@@ -121,33 +311,43 @@ namespace CryoRegenesis.HarmonyPatches
             return false;
         }
 
-        private static Building_CryoRegenesis FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
+        /*
+         * Nearest empty colony CryoRegenesis casket. Intentionally no pathing
+         * or reservation checks — those are left to the job/toils at runtime.
+         */
+        private static Building_CryoRegenesis FindEmptyCryoRegenesisCasket(
+            Pawn targetPawn)
         {
-            Map map = carrier?.Map;
+            Map map = targetPawn?.MapHeld;
 
-            if (map == null || targetPawn == null)
+            if (map == null)
                 return null;
 
-            return GenClosest.ClosestThingReachable(
-                targetPawn.Position,
-                map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
-                PathEndMode.InteractionCell,
-                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
-                validator: thing =>
+            Building_CryoRegenesis best = null;
+            int bestDist = int.MaxValue;
+            IntVec3 pos = targetPawn.PositionHeld;
+
+            List<Thing> buildings = map.listerThings.ThingsInGroup(
+                ThingRequestGroup.BuildingArtificial);
+
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                if (buildings[i] is not Building_CryoRegenesis casket)
+                    continue;
+
+                if (casket.HasAnyContents)
+                    continue;
+
+                int dist = casket.Position.DistanceToSquared(pos);
+
+                if (dist < bestDist)
                 {
-                    if (thing is not Building_CryoRegenesis casket)
-                        return false;
-
-                    if (casket.HasAnyContents)
-                        return false;
-
-                    if (!carrier.CanReserve(casket))
-                        return false;
-
-                    return true;
+                    bestDist = dist;
+                    best = casket;
                 }
-            ) as Building_CryoRegenesis;
+            }
+
+            return best;
         }
     }
 }

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using BetterRimworlds.CryoRegenesis;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.AI;
+
+namespace CryoRegenesis.HarmonyPatches
+{
+    [HarmonyPatch(typeof(FloatMenuMakerMap), "AddHumanlikeOrders")]
+    public static class Patch_FloatMenuMakerMap_AddHumanlikeOrders_CryoRegenesis
+    {
+        public static void Postfix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
+        {
+            if (pawn?.Map == null)
+                return;
+
+            if (pawn.Downed || pawn.Dead || pawn.IsBurning())
+                return;
+
+            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
+
+            if (targetPawn == null)
+                return;
+
+            if (!ShouldAllowCryoRegenesisCarry(targetPawn))
+                return;
+
+            Building_CryptosleepCasket casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
+
+            string label = "Carry to CryoRegenesis casket";
+
+            if (casket == null)
+            {
+                opts.Add(new FloatMenuOption(
+                    label + ": " + "No reachable CryoRegenesis casket",
+                    null
+                ));
+
+                return;
+            }
+
+            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
+            {
+                opts.Add(new FloatMenuOption(
+                    label + ": " + "CannotReach".Translate(targetPawn.LabelShort),
+                    null
+                ));
+
+                return;
+            }
+
+            if (!pawn.CanReserve(casket))
+            {
+                opts.Add(new FloatMenuOption(
+                    label + ": " + "Reserved".Translate(casket.Label),
+                    null
+                ));
+
+                return;
+            }
+
+            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(
+                new FloatMenuOption(
+                    label,
+                    delegate
+                    {
+                        Job job = JobMaker.MakeJob(
+                            JobDefOf.CarryToCryptosleepCasket,
+                            targetPawn,
+                            casket
+                        );
+
+                        job.count = 1;
+                        pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
+                    },
+                    MenuOptionPriority.RescueOrCapture
+                ),
+                pawn,
+                targetPawn
+            ));
+        }
+
+        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
+        {
+            IntVec3 cell = IntVec3.FromVector3(clickPos);
+
+            if (!cell.InBounds(map))
+                return null;
+
+            return cell.GetThingList(map)
+                .OfType<Pawn>()
+                .FirstOrDefault(p => p.Downed && !p.Dead && p.RaceProps.Humanlike);
+        }
+
+
+        private static bool IsGuest(Pawn pawn)
+        {
+            #if RIMWORLD12
+            return pawn.guest != null
+                   && pawn.HostFaction != null
+                ;
+            #else
+            return (pawn.guest.GuestStatus == GuestStatus.Guest || pawn.guest.GuestStatus == GuestStatus.Prisoner);
+            #endif
+        }
+
+        private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
+        {
+            if (targetPawn == null || targetPawn.Dead || !targetPawn.Downed)
+                return false;
+
+            // Prisoners.
+            if (targetPawn.IsPrisoner)
+                return true;
+
+            // Royalty / hospitality / guest-style pawns.
+            if (IsGuest(targetPawn))
+                return true;
+
+            // Royalty quest lodgers.
+            // This exists in newer RimWorld versions. If compiling against an older
+            // version, wrap this in #if or reflection.
+            if (targetPawn.IsQuestLodger())
+                return true;
+
+            return false;
+        }
+
+        private static Building_CryptosleepCasket FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
+        {
+            Map map = carrier.Map;
+
+            return GenClosest.ClosestThingReachable(
+                targetPawn.Position,
+                map,
+                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
+                PathEndMode.InteractionCell,
+                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
+                validator: thing =>
+                {
+                    if (thing is not Building_CryptosleepCasket casket)
+                        return false;
+
+                    if (!IsCryoRegenesisCasket(casket))
+                        return false;
+
+                    if (casket.HasAnyContents)
+                        return false;
+
+                    if (!carrier.CanReserve(casket))
+                        return false;
+
+                    return true;
+                }
+            ) as Building_CryptosleepCasket;
+        }
+
+        private static bool IsCryoRegenesisCasket(Building_CryptosleepCasket casket)
+        {
+            // Best if your casket has a custom building class.
+            return (casket is Building_CryoRegenesis);
+        }
+    }
+}

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -1,3 +1,4 @@
+// ==== Source/AllowHostedGuestsPatch.cs ====
 using System.Collections.Generic;
 using System.Linq;
 using BetterRimworlds.CryoRegenesis;
@@ -17,10 +18,14 @@ namespace CryoRegenesis.HarmonyPatches
             if (pawn?.Map == null)
                 return;
 
+            // The acting pawn must be capable of receiving an ordered job.
             if (pawn.Downed || pawn.Dead || pawn.IsBurning())
                 return;
 
-            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
+            Pawn targetPawn = GetClickedDownedPawn(
+                clickPos,
+                pawn.Map
+            );
 
             if (targetPawn == null)
                 return;
@@ -28,69 +33,94 @@ namespace CryoRegenesis.HarmonyPatches
             if (!ShouldAllowCryoRegenesisCarry(targetPawn))
                 return;
 
-            Building_CryptosleepCasket casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
+            const string label = "Carry to CryoRegenesis casket";
 
-            string label = "Carry to CryoRegenesis casket";
+            Building_CryoRegenesis casket =
+                FindCryoRegenesisCasketFor(pawn, targetPawn);
 
             if (casket == null)
             {
-                opts.Add(new FloatMenuOption(
-                    label + ": " + "No reachable CryoRegenesis casket",
-                    null
-                ));
+                opts.Add(
+                    new FloatMenuOption(
+                        label + ": No reachable CryoRegenesis casket",
+                        null
+                    )
+                );
 
                 return;
             }
 
-            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
+            if (!pawn.CanReserveAndReach(
+                    targetPawn,
+                    PathEndMode.Touch,
+                    Danger.Deadly
+                ))
             {
-                opts.Add(new FloatMenuOption(
-                    label + ": " + "CannotReach".Translate(targetPawn.LabelShort),
-                    null
-                ));
+                opts.Add(
+                    new FloatMenuOption(
+                        label + ": " +
+                        "CannotReach".Translate(targetPawn.LabelShort),
+                        null
+                    )
+                );
 
                 return;
             }
 
             if (!pawn.CanReserve(casket))
             {
-                opts.Add(new FloatMenuOption(
-                    label + ": " + "Reserved".Translate(casket.Label),
-                    null
-                ));
+                opts.Add(
+                    new FloatMenuOption(
+                        label + ": " +
+                        "Reserved".Translate(casket.Label),
+                        null
+                    )
+                );
 
                 return;
             }
 
-            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(
-                new FloatMenuOption(
-                    label,
-                    delegate
-                    {
-                        Job job = JobMaker.MakeJob(
-                            JobDefOf.CarryToCryptosleepCasket,
-                            targetPawn,
-                            casket
-                        );
+            FloatMenuOption option = new FloatMenuOption(
+                label,
+                delegate
+                {
+                    Job job = JobMaker.MakeJob(
+                        CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
+                        targetPawn,
+                        casket
+                    );
 
-                        job.count = 1;
-                        pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
-                    },
-                    MenuOptionPriority.RescueOrCapture
-                ),
-                pawn,
-                targetPawn
-            ));
+                    job.count = 1;
+
+                    pawn.jobs.TryTakeOrderedJob(
+                        job,
+                        JobTag.Misc
+                    );
+                },
+                MenuOptionPriority.RescueOrCapture
+            );
+
+            opts.Add(
+                FloatMenuUtility.DecoratePrioritizedTask(
+                    option,
+                    pawn,
+                    targetPawn
+                )
+            );
         }
 
-        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
+        private static Pawn GetClickedDownedPawn(
+            Vector3 clickPos,
+            Map map
+        )
         {
             IntVec3 cell = IntVec3.FromVector3(clickPos);
 
             if (!cell.InBounds(map))
                 return null;
 
-            return cell.GetThingList(map)
+            return cell
+                .GetThingList(map)
                 .OfType<Pawn>()
                 .FirstOrDefault(p => p.Downed && !p.Dead && p.RaceProps.Humanlike);
         }
@@ -107,18 +137,15 @@ namespace CryoRegenesis.HarmonyPatches
             #endif
         }
 
-        private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
+        private static bool ShouldAllowCryoRegenesisCarry(
+            Pawn targetPawn
+        )
         {
-            if (targetPawn == null || targetPawn.Dead || !targetPawn.Downed)
+            if (targetPawn == null)
                 return false;
 
-            // Prisoners.
-            if (targetPawn.IsPrisoner)
-                return true;
-
-            // Royalty / hospitality / guest-style pawns.
-            if (IsGuest(targetPawn))
-                return true;
+            if (targetPawn.Dead || !targetPawn.Downed)
+                return false;
 
             // Royalty quest lodgers.
             // This exists in newer RimWorld versions. If compiling against an older
@@ -129,22 +156,32 @@ namespace CryoRegenesis.HarmonyPatches
             return false;
         }
 
-        private static Building_CryptosleepCasket FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
+        private static Building_CryoRegenesis
+            FindCryoRegenesisCasketFor(
+                Pawn carrier,
+                Pawn targetPawn
+            )
         {
-            Map map = carrier.Map;
+            Map map = carrier?.Map;
+
+            if (map == null || targetPawn == null)
+                return null;
 
             return GenClosest.ClosestThingReachable(
                 targetPawn.Position,
                 map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
+                ThingRequest.ForGroup(
+                    ThingRequestGroup.BuildingArtificial
+                ),
                 PathEndMode.InteractionCell,
-                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
+                TraverseParms.For(
+                    carrier,
+                    Danger.Deadly,
+                    TraverseMode.ByPawn
+                ),
                 validator: thing =>
                 {
-                    if (thing is not Building_CryptosleepCasket casket)
-                        return false;
-
-                    if (!IsCryoRegenesisCasket(casket))
+                    if (thing is not Building_CryoRegenesis casket)
                         return false;
 
                     if (casket.HasAnyContents)
@@ -155,13 +192,7 @@ namespace CryoRegenesis.HarmonyPatches
 
                     return true;
                 }
-            ) as Building_CryptosleepCasket;
-        }
-
-        private static bool IsCryoRegenesisCasket(Building_CryptosleepCasket casket)
-        {
-            // Best if your casket has a custom building class.
-            return (casket is Building_CryoRegenesis);
+            ) as Building_CryoRegenesis;
         }
     }
 }

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -22,10 +22,7 @@ namespace CryoRegenesis.HarmonyPatches
             if (pawn.Downed || pawn.Dead || pawn.IsBurning())
                 return;
 
-            Pawn targetPawn = GetClickedDownedPawn(
-                clickPos,
-                pawn.Map
-            );
+            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
 
             if (targetPawn == null)
                 return;
@@ -33,50 +30,25 @@ namespace CryoRegenesis.HarmonyPatches
             if (!ShouldAllowCryoRegenesisCarry(targetPawn))
                 return;
 
-            const string label = "Carry to CryoRegenesis casket";
+            string label = "CarryToCryoRegenesisCasket".Translate();
 
-            Building_CryoRegenesis casket =
-                FindCryoRegenesisCasketFor(pawn, targetPawn);
+            Building_CryoRegenesis casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
 
             if (casket == null)
             {
-                opts.Add(
-                    new FloatMenuOption(
-                        label + ": No reachable CryoRegenesis casket",
-                        null
-                    )
-                );
-
+                opts.Add(new FloatMenuOption(label + ": " + "NoReachableCryoRegenesis".Translate(), null));
                 return;
             }
 
-            if (!pawn.CanReserveAndReach(
-                    targetPawn,
-                    PathEndMode.Touch,
-                    Danger.Deadly
-                ))
+            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
             {
-                opts.Add(
-                    new FloatMenuOption(
-                        label + ": " +
-                        "CannotReach".Translate(targetPawn.LabelShort),
-                        null
-                    )
-                );
-
+                opts.Add(new FloatMenuOption(label + ": " + "CannotReach".Translate(targetPawn.LabelShort), null));
                 return;
             }
 
             if (!pawn.CanReserve(casket))
             {
-                opts.Add(
-                    new FloatMenuOption(
-                        label + ": " +
-                        "Reserved".Translate(casket.Label),
-                        null
-                    )
-                );
-
+                opts.Add(new FloatMenuOption(label + ": " + "Reserved".Translate(casket.Label), null));
                 return;
             }
 
@@ -84,35 +56,19 @@ namespace CryoRegenesis.HarmonyPatches
                 label,
                 delegate
                 {
-                    Job job = JobMaker.MakeJob(
-                        CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
-                        targetPawn,
-                        casket
-                    );
+                    Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, targetPawn, casket);
 
                     job.count = 1;
 
-                    pawn.jobs.TryTakeOrderedJob(
-                        job,
-                        JobTag.Misc
-                    );
+                    pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
                 },
                 MenuOptionPriority.RescueOrCapture
             );
 
-            opts.Add(
-                FloatMenuUtility.DecoratePrioritizedTask(
-                    option,
-                    pawn,
-                    targetPawn
-                )
-            );
+            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(option, pawn, targetPawn));
         }
 
-        private static Pawn GetClickedDownedPawn(
-            Vector3 clickPos,
-            Map map
-        )
+        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
         {
             IntVec3 cell = IntVec3.FromVector3(clickPos);
 
@@ -133,9 +89,7 @@ namespace CryoRegenesis.HarmonyPatches
                 );
         }
 
-        private static bool ShouldAllowCryoRegenesisCarry(
-            Pawn targetPawn
-        )
+        private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
         {
             if (targetPawn == null)
                 return false;
@@ -167,11 +121,7 @@ namespace CryoRegenesis.HarmonyPatches
             return false;
         }
 
-        private static Building_CryoRegenesis
-            FindCryoRegenesisCasketFor(
-                Pawn carrier,
-                Pawn targetPawn
-            )
+        private static Building_CryoRegenesis FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
         {
             Map map = carrier?.Map;
 
@@ -181,15 +131,9 @@ namespace CryoRegenesis.HarmonyPatches
             return GenClosest.ClosestThingReachable(
                 targetPawn.Position,
                 map,
-                ThingRequest.ForGroup(
-                    ThingRequestGroup.BuildingArtificial
-                ),
+                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
                 PathEndMode.InteractionCell,
-                TraverseParms.For(
-                    carrier,
-                    Danger.Deadly,
-                    TraverseMode.ByPawn
-                ),
+                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
                 validator: thing =>
                 {
                     if (thing is not Building_CryoRegenesis casket)

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -122,19 +122,15 @@ namespace CryoRegenesis.HarmonyPatches
             return cell
                 .GetThingList(map)
                 .OfType<Pawn>()
-                .FirstOrDefault(p => p.Downed && !p.Dead && p.RaceProps.Humanlike);
-        }
-
-
-        private static bool IsGuest(Pawn pawn)
-        {
-            #if RIMWORLD12
-            return pawn.guest != null
-                   && pawn.HostFaction != null
-                ;
-            #else
-            return (pawn.guest.GuestStatus == GuestStatus.Guest || pawn.guest.GuestStatus == GuestStatus.Prisoner);
-            #endif
+                .FirstOrDefault(
+                    candidate =>
+                        candidate.Downed &&
+                        !candidate.Dead &&
+                        (
+                            candidate.RaceProps.Humanlike ||
+                            candidate.RaceProps.Animal
+                        )
+                );
         }
 
         private static bool ShouldAllowCryoRegenesisCarry(
@@ -147,10 +143,25 @@ namespace CryoRegenesis.HarmonyPatches
             if (targetPawn.Dead || !targetPawn.Downed)
                 return false;
 
-            // Royalty quest lodgers.
-            // This exists in newer RimWorld versions. If compiling against an older
-            // version, wrap this in #if or reflection.
-            if (targetPawn.IsQuestLodger())
+            /*
+             * Animals.
+             *
+             * Restricted to the player's faction so the option isn't
+             * offered on wild or enemy fauna. Species-level petness is
+             * deliberately irrelevant — a tamed warg, thrumbo, or other
+             * non-pet species is still eligible when it belongs to the
+             * player's faction.
+             */
+            if (targetPawn.RaceProps.Animal)
+                return targetPawn.Faction == Faction.OfPlayer;
+
+            /*
+             * Any downed humanlike is eligible — colonists, slaves,
+             * prisoners, guests, quest lodgers, and downed hostiles alike.
+             * The click already required Downed && !Dead, so this covers
+             * every rescue/capture-style scenario, including sedated pawns.
+             */
+            if (targetPawn.RaceProps.Humanlike)
                 return true;
 
             return false;

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -242,10 +242,8 @@ namespace CryoRegenesis.HarmonyPatches
             };
         }
 
-        /// <summary>
         /// True when the pawn is carriable: Downed, Moving at 0%, or sedated
         /// and about to collapse. JobDriver waits for Downed after sedation.
-        /// </summary>
         private static bool IsCryoCarryTargetState(Pawn targetPawn)
         {
             if (targetPawn == null || targetPawn.Dead)

--- a/Source/CharacterCardAgePatch.cs
+++ b/Source/CharacterCardAgePatch.cs
@@ -102,7 +102,7 @@ internal static class CharacterCardAgePatch
             lineHeight = 24f;
         }
 
-        Rect lineRect = new Rect(rect.x, rect.y + 155f, 160, lineHeight);
+        Rect lineRect = new Rect(rect.x + 300f, rect.y + 55f, 160, lineHeight);
 
         Widgets.DrawBoxSolid(lineRect, CoverColor);
 

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -441,3 +441,16 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         else return base.GetInspectString();
     }
 }
+
+
+[DefOf]
+public static class CryoRegenesisDefOf
+{
+    public static HediffDef CryoRegenesisSedation;
+    public static JobDef CR_CarryToCryoRegenesis;
+
+    static CryoRegenesisDefOf()
+    {
+        DefOfHelper.EnsureInitializedInCtor(typeof(CryoRegenesisDefOf));
+    }
+}

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -62,25 +62,20 @@ public class CryoRegenesis: Mod
         Settings = GetSettings<Settings>() ?? new Settings();
 
         var harmony = new Harmony("FrontierDevelopments.DeadCryptosleep");
-        /*
-         * Apply each [HarmonyPatch] type independently. A single bad TargetMethod
-         * (version-mismatched signature) must not abort the rest — that used to
-         * silently kill the Carry-to-CryoRegenesis float menu on RimWorld 1.2.
-         */
+
         foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
         {
-            object[] attrs = type.GetCustomAttributes(typeof(HarmonyPatch), inherit: true);
-            if (attrs == null || attrs.Length == 0)
-                continue;
-
             try
             {
+                if (!type.IsDefined(typeof(HarmonyPatch), inherit: true))
+                    continue;
+
                 harmony.CreateClassProcessor(type).Patch();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
                 Log.Error(
-                    $"[CryoRegenesis] Harmony patch failed on {type.FullName}: {e.Message}\n{e.StackTrace}");
+                    $"[CryoRegenesis] Harmony patch failed on {type.FullName}: {ex}");
             }
         }
     }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -8,6 +8,40 @@
  *   https://github.com/BetterRimworlds/CryoRegenesis
  *
  * This file is licensed under the MIT License.
+ *
+ * =============================================================================
+ * HARMONY PATCH LOADING — DO NOT REGRESS
+ * =============================================================================
+ *
+ * Problem (RimWorld 1.2, 2026-07):
+ *   "Carry to CryoRegenesis casket" never appeared for unconscious / Downed
+ *   prisoners. Eligibility and float-menu code looked correct; the real failure
+ *   was that *no* Harmony patches in this assembly applied at all.
+ *
+ * Root cause:
+ *   Mod construction used a single `harmony.PatchAll(Assembly)`. One unrelated
+ *   patch (Patch_DoRecruit_RegenContract) resolved TargetMethod() against the
+ *   *1.3+* InteractionWorker_RecruitAttempt.DoRecruit signature. On 1.2 that
+ *   method still takes `float recruitChance`, so AccessTools returned null,
+ *   PatchAll threw, and the catch block only logged:
+ *     "Failed to load harmony patches: ..."
+ *   Every other patch — including FloatMenuMakerMap.AddHumanlikeOrders for the
+ *   carry option — died with it. Symptom looked like a carry-eligibility bug.
+ *
+ * How not to repeat this:
+ *   1. Never rely on one PatchAll for the whole assembly when any TargetMethod
+ *      is version-sensitive. Apply each [HarmonyPatch] type with
+ *      CreateClassProcessor(type).Patch() inside its own try/catch (see ctor).
+ *   2. When resolving vanilla methods by signature, probe *every* supported
+ *      RimWorld version (1.2 often differs). Prefer ordered AccessTools.Method
+ *      fallbacks; never assume 1.3+ is the only shape.
+ *   3. If a float-menu / job feature "does nothing" on one game version only,
+ *      check the player log first for Harmony load failures before rewriting
+ *      gameplay conditions (Downed, Moving %, beds, etc.).
+ *   4. After changing any TargetMethod / patch attribute, boot *each* target
+ *      version (or at least 1.2 and latest) and confirm no
+ *      "[CryoRegenesis] Harmony patch failed" lines at startup.
+ * =============================================================================
  */
 
 using RimWorld;
@@ -28,13 +62,26 @@ public class CryoRegenesis: Mod
         Settings = GetSettings<Settings>() ?? new Settings();
 
         var harmony = new Harmony("FrontierDevelopments.DeadCryptosleep");
-        try
+        /*
+         * Apply each [HarmonyPatch] type independently. A single bad TargetMethod
+         * (version-mismatched signature) must not abort the rest — that used to
+         * silently kill the Carry-to-CryoRegenesis float menu on RimWorld 1.2.
+         */
+        foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
         {
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
-        }
-        catch (Exception e)
-        {
-            Log.Error($"Failed to load harmony patches: {e.Message}\n{e.StackTrace}");
+            object[] attrs = type.GetCustomAttributes(typeof(HarmonyPatch), inherit: true);
+            if (attrs == null || attrs.Length == 0)
+                continue;
+
+            try
+            {
+                harmony.CreateClassProcessor(type).Patch();
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    $"[CryoRegenesis] Harmony patch failed on {type.FullName}: {e.Message}\n{e.StackTrace}");
+            }
         }
     }
 
@@ -448,6 +495,7 @@ public static class CryoRegenesisDefOf
 {
     public static HediffDef CryoRegenesisSedation;
     public static JobDef CR_CarryToCryoRegenesis;
+    public static RecipeDef CR_AdministerCryoRegenesisSedation;
 
     static CryoRegenesisDefOf()
     {

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -312,6 +312,17 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
         Pawn pawn = ContainedThing as Pawn;
         pawn.health.AddHediff(cryosickness);
 
+        // True Age ledger must update before body-positivity thoughts, which
+        // read lifetime years erased from the tracker.
+        int sessionYearsRemoved = 0;
+        if (pawn.ageTracker != null)
+        {
+            int currentAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
+            sessionYearsRemoved = this.regenesisCycle.OriginalAge - currentAge;
+        }
+
+        this.ApplyTrueAgeOnEject(pawn);
+
         if ((pawn.IsPrisoner == true || pawn.IsColonist) && pawn.NonHumanlikeOrWildMan() == false)
         {
             // Remove negative and now-irrelevant thoughts:
@@ -333,10 +344,8 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
             cosmetics.PossiblyChangeHairColor(pawn);
 
-            // Give them a positive thought.
-            int currentAge = Mathf.RoundToInt(pawn.ageTracker.AgeBiologicalYearsFloat);
-
-            RegenesisThoughts.AddBodyPositivityThought(pawn, this.regenesisCycle.OriginalAge, currentAge);
+            // Stackable regen mood; stage/duration from lifetime True Age removed.
+            RegenesisThoughts.AddBodyPositivityThought(pawn, sessionYearsRemoved);
         }
 
         pawn.needs.rest.SetInitialLevel();
@@ -347,7 +356,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             power.PowerOutput = 0;
         }
 
-        this.ApplyTrueAgeOnEject(pawn);
         base.EjectContents();
 
         this.ResetTrueAgeTracking();

--- a/Source/CryoRegenesisRecipeInjector.cs
+++ b/Source/CryoRegenesisRecipeInjector.cs
@@ -1,0 +1,43 @@
+// ==== Source/CryoRegenesisRecipeInjector.cs ====
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+[StaticConstructorOnStartup]
+public static class CryoRegenesisRecipeInjector
+{
+    static CryoRegenesisRecipeInjector()
+    {
+        RecipeDef recipe = DefDatabase<RecipeDef>.GetNamedSilentFail(
+            "CR_AdministerCryoRegenesisSedation"
+        );
+
+        if (recipe == null)
+        {
+            Log.Error(
+                "[CryoRegenesis] Could not find recipe " +
+                "CR_AdministerCryoRegenesisSedation."
+            );
+            return;
+        }
+
+        if (recipe.recipeUsers == null)
+            recipe.recipeUsers = new List<ThingDef>();
+
+        foreach (ThingDef thingDef in DefDatabase<ThingDef>.AllDefsListForReading)
+        {
+            RaceProperties race = thingDef.race;
+
+            if (race == null)
+                continue;
+
+            if (!race.Humanlike && !race.Animal)
+                continue;
+
+            if (!recipe.recipeUsers.Contains(thingDef))
+                recipe.recipeUsers.Add(thingDef);
+        }
+    }
+}

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -1,6 +1,4 @@
 // ==== Source/JobDriver_CarryToCryoRegenesis.cs ====
-using System.Collections.Generic;
-using RimWorld;
 using Verse;
 using Verse.AI;
 
@@ -24,23 +22,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
     public override bool TryMakePreToilReservations(bool errorOnFailed)
     {
-        return pawn.Reserve(
-                   Patient,
-                   job,
-                   1,
-                   -1,
-                   null,
-                   errorOnFailed
-               )
-               &&
-               pawn.Reserve(
-                   Casket,
-                   job,
-                   1,
-                   -1,
-                   null,
-                   errorOnFailed
-               );
+        return pawn.Reserve(Patient, job, 1, -1, null, errorOnFailed) &&
+               pawn.Reserve(Casket, job, 1, -1, null, errorOnFailed);
     }
 
     protected override IEnumerable<Toil> MakeNewToils()
@@ -54,16 +37,10 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
          * handles that window.
          */
         this.FailOn(() =>
-            Patient == null ||
-            Patient.Dead ||
-            Casket == null ||
-            Casket.HasAnyContents
+            Patient == null || Patient.Dead || Casket == null || Casket.HasAnyContents
         );
 
-        yield return Toils_Goto.GotoThing(
-            PatientIndex,
-            PathEndMode.Touch
-        );
+        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.Touch);
 
         /*
          * Sedation may take a few ticks to down a large pawn (humans have a
@@ -82,13 +59,17 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
         {
             // Already downed? Skip the wait entirely.
             if (Patient != null && Patient.Downed)
-                waitForDowned.actor.jobs.curDriver.ReadyForNextToil();
+            {
+                ReadyForNextToil();
+            }
         };
 
         waitForDowned.tickAction = () =>
         {
             if (Patient != null && Patient.Downed)
-                waitForDowned.actor.jobs.curDriver.ReadyForNextToil();
+            {
+                ReadyForNextToil();
+            }
         };
 
         waitForDowned.AddFailCondition(() =>
@@ -140,11 +121,12 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
             // pawn out of the carrier's ThingOwner itself.
             if (!casket.TryAcceptThing(patient))
             {
-                Log.Warning(
-                    "[CryoRegenesis] Casket refused patient "
-                    + patient.LabelShort
-                    + "; dropping carried pawn instead."
-                );
+                if (CryoRegenesis.Settings.debugMode)
+                {
+                    Log.Warning(
+                        "[CryoRegenesis] Casket refused patient " + patient.LabelShort + "; dropping carried pawn instead."
+                    );
+                }
 
                 // Fallback: don't strand the pawn inside the carrier.
                 if (actor.carryTracker?.CarriedThing == patient)

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -34,10 +34,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
     private Building_CryoRegenesis Casket =>
         job.GetTarget(CasketIndex).Thing as Building_CryoRegenesis;
 
-    /// <summary>
     /// Patient can be picked up when Downed or when Moving is 0%.
     /// Must stay aligned with AllowHostedGuestsPatch.IsCryoCarryTargetState.
-    /// </summary>
     private bool PatientIsImmobile()
     {
         Pawn patient = Patient;

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -1,0 +1,178 @@
+// ==== Source/JobDriver_CarryToCryoRegenesis.cs ====
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class JobDriver_CarryToCryoRegenesis : JobDriver
+{
+    private const TargetIndex PatientIndex = TargetIndex.A;
+    private const TargetIndex CasketIndex = TargetIndex.B;
+
+    /**
+     * How long (in ticks) to wait at the patient's side for sedation to
+     * down them before giving up. 600 ticks = ~10 in-game seconds.
+     */
+    private const int MaxWaitForDownedTicks = 600;
+
+    private Pawn Patient => job.GetTarget(PatientIndex).Pawn;
+
+    private Building_CryoRegenesis Casket =>
+        job.GetTarget(CasketIndex).Thing as Building_CryoRegenesis;
+
+    public override bool TryMakePreToilReservations(bool errorOnFailed)
+    {
+        return pawn.Reserve(
+                   Patient,
+                   job,
+                   1,
+                   -1,
+                   null,
+                   errorOnFailed
+               )
+               &&
+               pawn.Reserve(
+                   Casket,
+                   job,
+                   1,
+                   -1,
+                   null,
+                   errorOnFailed
+               );
+    }
+
+    protected override IEnumerable<Toil> MakeNewToils()
+    {
+        this.FailOnDestroyedNullOrForbidden(PatientIndex);
+        this.FailOnDestroyedNullOrForbidden(CasketIndex);
+
+        /*
+         * Deliberately no FailOn(!Patient.Downed) here: a freshly sedated
+         * human may still be standing for a few ticks. The wait toil below
+         * handles that window.
+         */
+        this.FailOn(() =>
+            Patient == null ||
+            Patient.Dead ||
+            Casket == null ||
+            Casket.HasAnyContents
+        );
+
+        yield return Toils_Goto.GotoThing(
+            PatientIndex,
+            PathEndMode.Touch
+        );
+
+        /*
+         * Sedation may take a few ticks to down a large pawn (humans have a
+         * higher effective consciousness threshold than small animals).
+         * Wait at the patient's side until they collapse, with a safety
+         * valve so the carrier doesn't stand there forever if the hediff
+         * never downs them.
+         */
+        Toil waitForDowned = new Toil
+        {
+            defaultCompleteMode = ToilCompleteMode.Never,
+            defaultDuration = MaxWaitForDownedTicks,
+        };
+
+        waitForDowned.initAction = () =>
+        {
+            // Already downed? Skip the wait entirely.
+            if (Patient != null && Patient.Downed)
+                waitForDowned.actor.jobs.curDriver.ReadyForNextToil();
+        };
+
+        waitForDowned.tickAction = () =>
+        {
+            if (Patient != null && Patient.Downed)
+                waitForDowned.actor.jobs.curDriver.ReadyForNextToil();
+        };
+
+        waitForDowned.AddFailCondition(() =>
+            waitForDowned.actor.jobs.curDriver.ticksLeftThisToil <= 0 &&
+            (Patient == null || !Patient.Downed)
+        );
+
+        yield return waitForDowned;
+
+        yield return Toils_Haul.StartCarryThing(
+            PatientIndex,
+            false,
+            false,
+            false
+        );
+
+        yield return Toils_Goto.GotoThing(
+            CasketIndex,
+            PathEndMode.InteractionCell
+        );
+
+        /*
+         * Deposit via the casket's own TryAcceptThing override rather than
+         * the generic DepositHauledThingInContainer toil.
+         *
+         * The vanilla deposit toil moves the pawn straight into the casket's
+         * ThingOwner without routing through Building_CryoRegenesis.
+         * TryAcceptThing — so BeginNewPawn()/ConfigureTargetAge() and the
+         * true-age snapshot never run, and the pawn inherits the previous
+         * occupant's stale cycle state (wrong OriginalAge/TargetAge, instant
+         * ejection). Calling TryAcceptThing explicitly guarantees the accept
+         * path — and cycle initialization — runs exactly once.
+         */
+        Toil deposit = new Toil
+        {
+            defaultCompleteMode = ToilCompleteMode.Instant,
+        };
+        deposit.initAction = () =>
+        {
+            Pawn actor = deposit.actor;
+            Building_CryoRegenesis casket = Casket;
+            Pawn patient = Patient;
+
+            if (casket == null || patient == null)
+                return;
+
+            // The carrier is currently holding the patient; hand them to the
+            // casket through its accept override. TryAcceptThing pulls the
+            // pawn out of the carrier's ThingOwner itself.
+            if (!casket.TryAcceptThing(patient))
+            {
+                Log.Warning(
+                    "[CryoRegenesis] Casket refused patient "
+                    + patient.LabelShort
+                    + "; dropping carried pawn instead."
+                );
+
+                // Fallback: don't strand the pawn inside the carrier.
+                if (actor.carryTracker?.CarriedThing == patient)
+                {
+                    actor.carryTracker.TryDropCarriedThing(
+                        actor.Position,
+                        ThingPlaceMode.Near,
+                        out _
+                    );
+                }
+            }
+        };
+        deposit.AddFinishAction(() =>
+        {
+            // If somehow the pawn is still carried after accept, drop them
+            // so they aren't lost inside the carrier.
+            Pawn actor = deposit.actor;
+            if (actor.carryTracker?.CarriedThing is Pawn stillCarried &&
+                stillCarried == Patient)
+            {
+                actor.carryTracker.TryDropCarriedThing(
+                    actor.Position,
+                    ThingPlaceMode.Near,
+                    out _
+                );
+            }
+        });
+
+        yield return deposit;
+    }
+}

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -1,4 +1,18 @@
 // ==== Source/JobDriver_CarryToCryoRegenesis.cs ====
+/*
+ * Ordered job: carry a patient into a CryoRegenesis casket.
+ *
+ * Immobility gate (do not narrow this):
+ *   PatientIsImmobile() is true when the pawn is Downed *or* Moving capacity
+ *   is 0%. Players treat "Unconscious / Moving 0%" as carriable; requiring only
+ *   `pawn.Downed` missed edge cases and disagreed with the float-menu check in
+ *   AllowHostedGuestsPatch (keep both in sync).
+ *
+ * If the carry *menu option* is missing entirely on one RW version, that is
+ * usually a Harmony load failure — not this driver. See CryoRegenesis.cs and
+ * Patch_DoRecruit_RegenContract docblocks.
+ */
+using RimWorld;
 using Verse;
 using Verse.AI;
 
@@ -20,6 +34,27 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
     private Building_CryoRegenesis Casket =>
         job.GetTarget(CasketIndex).Thing as Building_CryoRegenesis;
 
+    /// <summary>
+    /// Patient can be picked up when Downed or when Moving is 0%.
+    /// Must stay aligned with AllowHostedGuestsPatch.IsCryoCarryTargetState.
+    /// </summary>
+    private bool PatientIsImmobile()
+    {
+        Pawn patient = Patient;
+        if (patient == null || patient.Dead)
+            return false;
+
+        if (patient.Downed)
+            return true;
+
+        PawnCapacitiesHandler capacities = patient.health?.capacities;
+        if (capacities == null)
+            return false;
+
+        return !capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+               capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f;
+    }
+
     public override bool TryMakePreToilReservations(bool errorOnFailed)
     {
         return pawn.Reserve(Patient, job, 1, -1, null, errorOnFailed) &&
@@ -40,7 +75,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
             Patient == null || Patient.Dead || Casket == null || Casket.HasAnyContents
         );
 
-        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.Touch);
+        // OnCell matches vanilla CarryToCryptosleepCasket and reaches pawns in beds.
+        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.OnCell);
 
         /*
          * Sedation may take a few ticks to down a large pawn (humans have a
@@ -57,8 +93,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.initAction = () =>
         {
-            // Already downed? Skip the wait entirely.
-            if (Patient != null && Patient.Downed)
+            // Already immobile? Skip the wait entirely.
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -66,7 +102,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.tickAction = () =>
         {
-            if (Patient != null && Patient.Downed)
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -74,7 +110,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.AddFailCondition(() =>
             waitForDowned.actor.jobs.curDriver.ticksLeftThisToil <= 0 &&
-            (Patient == null || !Patient.Downed)
+            !PatientIsImmobile()
         );
 
         yield return waitForDowned;

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -33,32 +33,19 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
     }
 #endif
 
-    public override void ApplyOnPawn(
-        Pawn pawn,
-        BodyPartRecord part,
-        Pawn billDoer,
-        List<Thing> ingredients,
-        Bill bill
-    )
+    public override void ApplyOnPawn(Pawn pawn, BodyPartRecord part, Pawn billDoer, List<Thing> ingredients, Bill bill)
     {
         Hediff existing = pawn.health.hediffSet.GetFirstHediffOfDef(
             CryoRegenesisDefOf.CryoRegenesisSedation
         );
 
-        if (existing != null)
-        {
-            existing.Severity = existing.def.initialSeverity;
-        }
-        else
-        {
-            Hediff hediff = HediffMaker.MakeHediff(
-                CryoRegenesisDefOf.CryoRegenesisSedation,
-                pawn
-            );
+        Hediff hediff = HediffMaker.MakeHediff(
+            CryoRegenesisDefOf.CryoRegenesisSedation,
+            pawn
+        );
 
-            hediff.Severity = hediff.def.initialSeverity;
-            pawn.health.AddHediff(hediff);
-        }
+        hediff.Severity = hediff.def.initialSeverity;
+        pawn.health.AddHediff(hediff);
 
         // Immediately haul the sedated pawn to an empty casket.
         if (billDoer == null)
@@ -68,11 +55,7 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         if (casket == null)
             return;
 
-        Job job = JobMaker.MakeJob(
-            CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
-            pawn,
-            casket
-        );
+        Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, pawn, casket);
         job.count = 1;
 
         /*
@@ -84,7 +67,7 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
          * Enqueueing instead makes the carry job start the instant the bill
          * job finishes and releases its reservations.
          */
-        billDoer.jobs.jobQueue.EnqueueFirst(job, JobTag.Misc);
+        billDoer.jobs?.jobQueue?.EnqueueFirst(job, JobTag.Misc);
     }
 
     private static Building_CryoRegenesis FindEmptyCasket(Pawn pawn, Pawn carrier)

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -9,6 +9,8 @@ namespace BetterRimworlds.CryoRegenesis;
 
 public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
 {
+    private const string NoAvailableCasketKey = "BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket";
+
     public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
     {
         if (!CanSedatePawn(pawn))
@@ -20,7 +22,18 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         yield return null;
     }
 
-#if !RIMWORLD12
+#if RIMWORLD12
+    public override bool AvailableOnNow(Thing thing)
+    {
+        if (!base.AvailableOnNow(thing))
+            return false;
+
+        if (thing is not Pawn pawn)
+            return false;
+
+        return CanSedatePawn(pawn) && FindEmptyCasket(pawn, null) != null;
+    }
+#else
     public override bool AvailableOnNow(Thing thing, BodyPartRecord part = null)
     {
         if (!base.AvailableOnNow(thing, part))
@@ -35,9 +48,12 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
 
     public override void ApplyOnPawn(Pawn pawn, BodyPartRecord part, Pawn billDoer, List<Thing> ingredients, Bill bill)
     {
-        Hediff existing = pawn.health.hediffSet.GetFirstHediffOfDef(
-            CryoRegenesisDefOf.CryoRegenesisSedation
-        );
+        Building_CryoRegenesis casket = FindEmptyCasket(pawn, billDoer);
+        if (casket == null)
+        {
+            Messages.Message(NoAvailableCasketKey.Translate(), pawn, MessageTypeDefOf.RejectInput);
+            return;
+        }
 
         Hediff hediff = HediffMaker.MakeHediff(
             CryoRegenesisDefOf.CryoRegenesisSedation,
@@ -47,12 +63,8 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         hediff.Severity = hediff.def.initialSeverity;
         pawn.health.AddHediff(hediff);
 
-        // Immediately haul the sedated pawn to an empty casket.
+        // Immediately haul the sedated pawn to the casket we validated before sedation.
         if (billDoer == null)
-            return;
-
-        Building_CryoRegenesis casket = FindEmptyCasket(pawn, billDoer);
-        if (casket == null)
             return;
 
         Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, pawn, casket);

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -88,16 +88,24 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         if (map == null)
             return null;
 
+        /*
+         * Availability (carrier == null) must NOT require the patient to path
+         * to the casket. Prisoners, prison guests, and area-restricted guests
+         * often cannot leave their pen, and the whole point of sedation is that
+         * a doctor carries them. Only check that an empty colony casket exists.
+         *
+         * When applying (carrier != null), require the doctor to reserve/reach.
+         */
         return map.listerBuildings
             .AllBuildingsColonistOfClass<Building_CryoRegenesis>()
             .Where(c => !c.HasAnyContents)
             .OrderBy(c => c.Position.DistanceToSquared(pawn.PositionHeld))
             .FirstOrDefault(c =>
             {
-                if (carrier != null)
-                    return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                if (carrier == null)
+                    return true;
 
-                return pawn.CanReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
             });
     }
 

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -1,0 +1,132 @@
+// ==== Source/Recipe_AdministerCryoRegenesisSedation.cs ====
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
+{
+    public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
+    {
+        if (!CanSedatePawn(pawn))
+            yield break;
+
+        if (FindEmptyCasket(pawn, null) == null)
+            yield break;
+
+        yield return null;
+    }
+
+#if !RIMWORLD12
+    public override bool AvailableOnNow(Thing thing, BodyPartRecord part = null)
+    {
+        if (!base.AvailableOnNow(thing, part))
+            return false;
+
+        if (thing is not Pawn pawn)
+            return false;
+
+        return CanSedatePawn(pawn) && FindEmptyCasket(pawn, null) != null;
+    }
+#endif
+
+    public override void ApplyOnPawn(
+        Pawn pawn,
+        BodyPartRecord part,
+        Pawn billDoer,
+        List<Thing> ingredients,
+        Bill bill
+    )
+    {
+        Hediff existing = pawn.health.hediffSet.GetFirstHediffOfDef(
+            CryoRegenesisDefOf.CryoRegenesisSedation
+        );
+
+        if (existing != null)
+        {
+            existing.Severity = existing.def.initialSeverity;
+        }
+        else
+        {
+            Hediff hediff = HediffMaker.MakeHediff(
+                CryoRegenesisDefOf.CryoRegenesisSedation,
+                pawn
+            );
+
+            hediff.Severity = hediff.def.initialSeverity;
+            pawn.health.AddHediff(hediff);
+        }
+
+        // Immediately haul the sedated pawn to an empty casket.
+        if (billDoer == null)
+            return;
+
+        Building_CryoRegenesis casket = FindEmptyCasket(pawn, billDoer);
+        if (casket == null)
+            return;
+
+        Job job = JobMaker.MakeJob(
+            CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
+            pawn,
+            casket
+        );
+        job.count = 1;
+
+        /*
+         * Do NOT StartJob(InterruptForced) here: ApplyOnPawn runs inside the
+         * doctor's DoBill job, whose reservations on the patient are still
+         * held. Force-starting the carry job races those reservations and
+         * TryMakePreToilReservations can fail silently.
+         *
+         * Enqueueing instead makes the carry job start the instant the bill
+         * job finishes and releases its reservations.
+         */
+        billDoer.jobs.jobQueue.EnqueueFirst(job, JobTag.Misc);
+    }
+
+    private static Building_CryoRegenesis FindEmptyCasket(Pawn pawn, Pawn carrier)
+    {
+        Map map = pawn?.MapHeld;
+        if (map == null)
+            return null;
+
+        return map.listerBuildings
+            .AllBuildingsColonistOfClass<Building_CryoRegenesis>()
+            .Where(c => !c.HasAnyContents)
+            .OrderBy(c => c.Position.DistanceToSquared(pawn.PositionHeld))
+            .FirstOrDefault(c =>
+            {
+                if (carrier != null)
+                    return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+
+                return pawn.CanReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+            });
+    }
+
+    private static bool CanSedatePawn(Pawn pawn)
+    {
+        if (pawn == null)
+            return false;
+
+        if (pawn.Dead || pawn.Destroyed)
+            return false;
+
+        if (pawn.health == null || pawn.health.hediffSet == null)
+            return false;
+
+        // Humanlikes are always eligible; animals only if they're an owned
+        // colony pet (tamed, faction == player). Species-level "petness" is
+        // irrelevant here — wargs/thrumbos have petness 0 but can be pets.
+        if (!pawn.RaceProps.Humanlike &&
+            !(pawn.RaceProps.Animal && pawn.Faction == Faction.OfPlayer))
+            return false;
+
+        if (pawn.health.hediffSet.HasHediff(CryoRegenesisDefOf.CryoRegenesisSedation))
+            return false;
+
+        return true;
+    }
+}

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -226,6 +226,7 @@ public class RegenesisCycle
             "luciferium",
             "penoxycyline",
             "cryptosleep sickness",
+            "CryoRegenesis sedation",
         };
         this.hediffsToHeal = new List<Hediff>();
 

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -1,3 +1,4 @@
+// ==== Source/RegenesisCycle.cs ====
 /*
  * This file is part of CryoRegenesis, a Better Rimworlds Project.
  *
@@ -294,7 +295,6 @@ public class RegenesisCycle
     private int CalculateHealingTime(Pawn pawn)
     {
         int pawnAge = (int)(pawn.ageTracker.AgeBiologicalTicks / GenDate.TicksPerYear);
-
         if (pawnAge <= (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25))
         {
             return GenDate.TicksPerYear / this.rnd.Next(1, 4);
@@ -321,7 +321,30 @@ public class RegenesisCycle
 
     private void ConfigureTargetAge(Pawn pawn)
     {
-        if (pawn.def.defName == "Human")
+        if (CryoRegenesis.Settings.debugMode)
+        {
+            Log.Message("Pawn name: " + pawn.def.defName);
+            Log.Message("Race label: " + pawn.def.label); // human-readable race name
+            Log.Message("Humanlike: " + pawn.RaceProps.Humanlike);
+            Log.Message("Life expectancy: " + pawn.RaceProps.lifeExpectancy);
+            #if !RIMWORLD12 && !RIMWORLD13
+            Log.Message("Xenotype: " + (pawn.genes?.Xenotype?.defName ?? "none"));
+            #endif
+            Log.Message("Kind: " + pawn.kindDef?.defName); // e.g. Empire_Fighter, Refugee
+            Log.Message("Faction: " + (pawn.Faction?.Name ?? "none"));
+        }
+
+        // All humanlikes — baseline humans, xenotypes, and modded humanlike
+        // races alike — honor the user's configured target age. Only true
+        // animals fall back to a fraction of their species lifespan.
+        //
+        // Previously this gated on `pawn.def.defName == "Human"`, which
+        // silently routed every non-"Human" humanlike (Empire pawns, modded
+        // races, some xenotype defs) into lifespan-based targeting. For a
+        // long-lived race, 0.25 * lifeExpectancy could exceed the pawn's
+        // current age, making IsTargetAge() true on the first tick and
+        // ejecting them instantly with no regression.
+        if (pawn.RaceProps.Humanlike)
         {
             this.targetAge = CryoRegenesis.Settings.targetAge;
         }
@@ -330,8 +353,11 @@ public class RegenesisCycle
             this.targetAge = (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25);
         }
 
-        Log.Message("Pawn name: " + pawn.def.defName);
-        Log.Message("Life expectancy: " + pawn.RaceProps.lifeExpectancy);
-        Log.Message("Target age: " + this.targetAge);
+        if (CryoRegenesis.Settings.debugMode)
+        {
+            Log.Message("Pawn name: " + pawn.def.defName);
+            Log.Message("Life expectancy: " + pawn.RaceProps.lifeExpectancy);
+            Log.Message("Target age: " + this.targetAge);
+        }
     }
 }

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -128,9 +128,20 @@ public class RegenesisCycle
 
         Hediff hediff = this.hediffsToHeal[0];
         string hediffName = hediff.def.label;
+        BodyPartRecord inferiorProstheticPart = GetInferiorAddedPart(pawn, hediff.Part);
+        if (inferiorProstheticPart != null && !CryoRegenesis.Settings.healSimpleProsthetics)
+        {
+            this.DetermineCurableInjuries(pawn);
+            return false;
+        }
 
+        // Always remove only this hediff. RestorePart() would recursively clear the
+        // whole limb tree (hand, fingers, etc.) in one tick. Inferior prosthetics
+        // leave MissingBodyPart hediffs on their children when installed; those are
+        // healed one-by-one on later cycles after the prosthetic is removed.
         refuelable.ConsumeFuel(Math.Max(refuelable.FuelPercentOfMax * 0.10f, 10));
         pawn.health.RemoveHediff(hediff);
+
         this.hediffsToHeal.RemoveAt(0);
 
         this.restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks - GenDate.TicksPerYear;
@@ -147,6 +158,22 @@ public class RegenesisCycle
         // Re-scan because removing one hediff can expose new curable injuries.
         this.DetermineCurableInjuries(pawn);
         return true;
+    }
+
+    private static BodyPartRecord GetInferiorAddedPart(Pawn pawn, BodyPartRecord bodyPart)
+    {
+        for (BodyPartRecord currentPart = bodyPart; currentPart != null; currentPart = currentPart.parent)
+        {
+            Hediff addedPart = pawn.health.hediffSet.hediffs.FirstOrDefault(
+                h => h.Part == currentPart
+                     && IsInferiorAddedPart(h));
+            if (addedPart != null)
+            {
+                return currentPart;
+            }
+        }
+
+        return null;
     }
 
     public bool ShouldEjectAfterHealing(Pawn pawn)
@@ -181,34 +208,14 @@ public class RegenesisCycle
         return this.hediffsToHeal.Count - this.AgeHediffs();
     }
 
-    public static bool HasBionicParent(Pawn pawn, BodyPartRecord bodyPart)
+    public static bool HasBetterThanNaturalParent(Pawn pawn, BodyPartRecord bodyPart)
     {
-        List<BodyPartRecord> allParents = new List<BodyPartRecord>();
-
-        if (bodyPart.IsCorePart)
+        for (BodyPartRecord currentPart = bodyPart.parent; currentPart != null; currentPart = currentPart.parent)
         {
-            return false;
-        }
-
-        BodyPartRecord recursiveBodyPart = bodyPart.parent;
-        while (!recursiveBodyPart.IsCorePart)
-        {
-            allParents.Add(recursiveBodyPart);
-            recursiveBodyPart = recursiveBodyPart.parent;
-        }
-
-        if (allParents.NullOrEmpty())
-        {
-            return false;
-        }
-
-        foreach (BodyPartRecord currentParent in allParents)
-        {
-            IEnumerable<Hediff> matchingHediffs = pawn.health.hediffSet.hediffs.Where(
-                h => h.Part == currentParent
-                     && h.def.countsAsAddedPartOrImplant
-                     && (h.def.label.Contains("bionic") || h.def.label.Contains("archotech")));
-            if (!matchingHediffs.EnumerableNullOrEmpty())
+            if (pawn.health.hediffSet.hediffs.Any(
+                    h => h.Part == currentPart
+                         && h.def.countsAsAddedPartOrImplant
+                         && h.def.addedPartProps?.betterThanNatural == true))
             {
                 return true;
             }
@@ -238,6 +245,23 @@ public class RegenesisCycle
         foreach (Hediff hediff in pawn.health.hediffSet.GetHediffs<Hediff>().ToList())
         #endif
         {
+            BodyPartRecord inferiorProstheticPart = GetInferiorAddedPart(pawn, hediff.Part);
+            if (inferiorProstheticPart != null)
+            {
+                if (!CryoRegenesis.Settings.healSimpleProsthetics)
+                {
+                    continue;
+                }
+
+                // Only the prosthetic itself is eligible this scan. Child missing
+                // parts under it stay until the prosthetic is gone; otherwise a
+                // single heal would wipe or race the whole limb tree.
+                if (!IsInferiorAddedPart(hediff) || hediff.Part != inferiorProstheticPart)
+                {
+                    continue;
+                }
+            }
+
             if (hediffsToIgnore.Contains(hediff.def.label))
             {
                 continue;
@@ -268,18 +292,20 @@ public class RegenesisCycle
                 continue;
             }
 
-            if (hediff.def.label.Contains("bionic") || hediff.def.label.Contains("archotech"))
+            bool repairableProsthetic =
+                CryoRegenesis.Settings.healSimpleProsthetics && IsInferiorAddedPart(hediff);
+            if (hediff.def.addedPartProps?.betterThanNatural == true)
             {
                 continue;
             }
 
-            if (hediff.def.label == "missing body part" && HasBionicParent(pawn, hediff.Part))
+            if (hediff.def.label == "missing body part" && HasBetterThanNaturalParent(pawn, hediff.Part))
             {
                 continue;
             }
 
             // Skip non-bad hediffs like the GateTraveler implant.
-            if (!hediff.def.isBad)
+            if (!hediff.def.isBad && !repairableProsthetic)
             {
                 continue;
             }
@@ -292,6 +318,14 @@ public class RegenesisCycle
         }
 
         return this.hediffsToHeal.Count;
+    }
+
+    private static bool IsInferiorAddedPart(Hediff hediff)
+    {
+        return hediff is Hediff_AddedPart
+               && hediff.def.countsAsAddedPartOrImplant
+               && hediff.def.addedPartProps != null
+               && !hediff.def.addedPartProps.betterThanNatural;
     }
 
     private int CalculateHealingTime(Pawn pawn)

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -278,7 +278,8 @@ public class RegenesisCycle
                 continue;
             }
 
-            if (!CryoRegenesis.Settings.healNotBad && !hediff.def.isBad)
+            // Skip non-bad hediffs like the GateTraveler implant.
+            if (!hediff.def.isBad)
             {
                 continue;
             }

--- a/Source/RegenesisThoughts.cs
+++ b/Source/RegenesisThoughts.cs
@@ -10,7 +10,9 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
 using RimWorld;
+using UnityEngine;
 using Verse;
 // ReSharper disable All
 
@@ -18,30 +20,80 @@ namespace BetterRimworlds.CryoRegenesis;
 
 public static class RegenesisThoughts
 {
-    public static void AddBodyPositivityThought(Pawn pawn, int origAge, int newAge)
+    private const int YearsPerStack = 15;
+
+    /// <summary>
+    /// Grant stackable body-positivity memories after a CryoRegenesis eject that
+    /// actually de-aged the pawn. Stage, description years, and duration use
+    /// lifetime years erased from the True Age tracker (must be updated first).
+    /// Stack count scales with how many years this session removed.
+    /// </summary>
+    /// <param name="sessionYearsRemoved">Whole years of bio-age removed this eject (gate + multi-stack).</param>
+    public static void AddBodyPositivityThought(Pawn pawn, int sessionYearsRemoved)
     {
-        int yearsRegressed = origAge - newAge;
-        if (yearsRegressed <= 0) return;
+        if (pawn?.needs?.mood?.thoughts?.memories == null)
+        {
+            return;
+        }
 
-        // Get the def
-        var thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_BodyPositivity");
+        if (sessionYearsRemoved <= 0)
+        {
+            return;
+        }
 
-        // Create the thought instance manually so we can initialize it
-        var thought = ThoughtMaker.MakeThought(thoughtDef) as Thought_RegenesisBodyPositivity;
-        if (thought == null) return;
+        TrueAgeTracker tracker = pawn.health?.hediffSet?
+            .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+        if (tracker == null)
+        {
+            return;
+        }
 
-        // Set the years BEFORE adding it to the pawn
-        thought.SetYearsReversed(yearsRegressed);
+        int totalYearsErased = Mathf.RoundToInt(tracker.GetCryoRegenesisRemovedAgeYears());
+        if (totalYearsErased <= 0)
+        {
+            return;
+        }
 
-        // Add the initialized thought instance (not the def)
-        pawn.needs.mood?.thoughts.memories.TryGainMemory(thought);
+        ThoughtDef thoughtDef = DefDatabase<ThoughtDef>.GetNamed("CryoRegenesis_BodyPositivity");
+        if (thoughtDef == null)
+        {
+            return;
+        }
+
+        int stacksToAdd = Math.Max(1, (int)Math.Ceiling(sessionYearsRemoved / (double)YearsPerStack));
+        if (thoughtDef.stackLimit > 0)
+        {
+            stacksToAdd = Math.Min(stacksToAdd, thoughtDef.stackLimit);
+        }
+
+        Thought_RegenesisBodyPositivity lastThought = null;
+        for (int i = 0; i < stacksToAdd; i++)
+        {
+            // Set years before Init so CalculateDuration sees the True Age total.
+            var thought = (Thought_RegenesisBodyPositivity)Activator.CreateInstance(thoughtDef.thoughtClass);
+            thought.def = thoughtDef;
+            thought.SetYearsReversed(totalYearsErased);
+            thought.Init();
+
+            pawn.needs.mood.thoughts.memories.TryGainMemory(thought);
+            lastThought = thought;
+        }
 
         if (CryoRegenesis.Settings.debugMode)
-            Log.Warning($"Old age {origAge} | New age: {newAge} | Years reversed: {yearsRegressed} | Stage: {thought.CurStageIndex}");
+        {
+            Log.Warning(
+                $"Body positivity: session {sessionYearsRemoved}y | lifetime erased {totalYearsErased}y | " +
+                $"stacks +{stacksToAdd} | stage {lastThought?.CurStageIndex}");
+        }
+
+        if (lastThought == null)
+        {
+            return;
+        }
 
         // Use the thought's actual stage for the prisoner check
         #if !RIMWORLD12 && !RIMWORLD13
-        if (thought.CurStageIndex >= 2)
+        if (lastThought.CurStageIndex >= 2)
         {
             if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
             {

--- a/Source/Resurrector.cs
+++ b/Source/Resurrector.cs
@@ -36,9 +36,7 @@ public class Resurrector
     private Action onRejected;
     private Action<Pawn> onResurrected;
 
-    /// <summary>
     /// Wire up building components and ejection callbacks. Must be called from SpawnSetup.
-    /// </summary>
     public void Initialize(
         CompRefuelable refuelable,
         CompProperties_Refuelable fuelprops,
@@ -62,17 +60,15 @@ public class Resurrector
         ResurrectionProgress = 0f;
     }
 
-    /// <summary>Full reset when a new corpse is accepted.</summary>
+    /// Full reset when a new corpse is accepted.
     public void ResetForNewCorpse()
     {
         ResurrectionProgress = 0f;
         ResurrectionFuelReqs = new int[3] { REQ_URANIUM, REQ_GOLD, REQ_LUCIFERIUM };
     }
 
-    /// <summary>
     /// Drive the resurrection state machine for one tick cycle.
     /// Calls onRejected or onResurrected when the state resolves.
-    /// </summary>
     public void Process(Corpse corpse)
     {
         // Make sure that they have a brain. Everything else is optional.

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -18,7 +18,6 @@ public class Settings: ModSettings
     public int targetAge = 21;
     public bool regenUntilHealed = true;
     public bool healSimpleProsthetics = true;
-    public bool healNotBad = false;
 
     public bool debugMode = false;
 
@@ -27,7 +26,6 @@ public class Settings: ModSettings
         Scribe_Values.Look(ref targetAge,             "brw.cryoregenesis.targetAge", 21);
         Scribe_Values.Look(ref regenUntilHealed,      "brw.cryoregenesis.regenUntilHealed", true);
         Scribe_Values.Look(ref healSimpleProsthetics, "brw.cryoregenesis.healSimpleProsthetics", true);
-        Scribe_Values.Look(ref healNotBad,            "brw.cryoregenesis.healNotBad", false);
         Scribe_Values.Look(ref debugMode,             "brw.cryoregenesis.debugMode", false);
     }
 
@@ -40,7 +38,6 @@ public class Settings: ModSettings
             "Target age for regening Humans:",
             "Stop regenerating when a Human is fully healed? ",
             "Heal simple and wooden prosthetics?",
-            "Heal non-bad body mods?",
             "Print debug messages?",
         };
 
@@ -50,8 +47,7 @@ public class Settings: ModSettings
 
         listing_Standard.CheckboxLabeled(labels[1],  ref regenUntilHealed);
         listing_Standard.CheckboxLabeled(labels[2],  ref healSimpleProsthetics);
-        listing_Standard.CheckboxLabeled(labels[3],  ref healNotBad);
-        listing_Standard.CheckboxLabeled(labels[4],  ref debugMode);
+        listing_Standard.CheckboxLabeled(labels[3],  ref debugMode);
 
         listing_Standard.End();
 

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -10,6 +10,7 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
 using RimWorld;
 using Verse;
 
@@ -27,16 +28,25 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
 
     public override void Init()
     {
-        base.Init();
+        // Mood bonus before CalculateDuration so BodyPurist can scale it.
         this._moodBonus = BetterRandom.pick(-15, 15);
+        base.Init();
     }
 
+    /// <summary>
+    /// Always add a new stack; MemoryThoughtHandler drops the oldest past stackLimit.
+    /// Default Thought_Memory merge only Renew()s the oldest and discards new years/duration.
+    /// </summary>
+    public override bool TryMergeWithExistingMemory(out bool showBubble)
+    {
+        showBubble = true;
+        return false;
+    }
 
     public override int CurStageIndex
     {
         get
         {
-            // Messages.Message("Years Younger: " + this._yearsReversed, MessageTypeDefOf.PositiveEvent);
             if (_yearsReversed >= 60) return 4;
             if (_yearsReversed >= 40) return 3;
             if (_yearsReversed >= 20) return 2;
@@ -80,22 +90,34 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
             return;
         }
 
-        bool isBodyPurist = pawn.story?.traits?.HasTrait(TraitDefOf.BodyPurist) ?? false;
+        int years = Math.Max(0, _yearsReversed);
+        if (years <= 5)
+        {
+            DurationDays = BetterRandom.pick(5, 20);
+        }
+        else if (years <= 15)
+        {
+            DurationDays = BetterRandom.pick(15, 45);
+        }
+        else
+        {
+            // Cumulative True Age removed > 15 years: at least 30–60 days.
+            int minDays = BetterRandom.pick(30, 60);
+            int maxDays = Math.Min(300, Math.Max(minDays, years * 3));
+            DurationDays = BetterRandom.pick(minDays, maxDays);
+        }
 
+        bool isBodyPurist = pawn.story?.traits?.HasTrait(TraitDefOf.BodyPurist) ?? false;
         bool recentlyResurrected = pawn.health?.hediffSet?.HasHediff(HediffDefOf.ResurrectionSickness) ?? false;
 
         if (recentlyResurrected)
         {
-            DurationDays = BetterRandom.pick(60, 600);
+            DurationDays = Math.Max(DurationDays, BetterRandom.pick(60, 600));
         }
         else if (isBodyPurist)
         {
-            DurationDays = BetterRandom.pick(30, 300) * BetterRandom.pick(1, 3);
+            DurationDays *= BetterRandom.pick(1, 3);
             this._moodBonus *= BetterRandom.pick(1, 2);
-        }
-        else
-        {
-            DurationDays = BetterRandom.pick(30, 300);
         }
     }
 

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -25,7 +25,6 @@ public static class TrueAgeDefOf
     }
 }
 
-/// <summary>
 /// Invisible hediff that tracks a pawn's True Age independently of
 /// vanilla biological/chronological age. Added when a pawn first uses
 /// the CryoRegenesis Casket.
@@ -42,7 +41,6 @@ public static class TrueAgeDefOf
 ///   - In cryptosleep: pawn is despawned, Tick() never fires
 ///   - In Stargate buffer: pawn is in a timeless state
 ///   - In both cases, consciousAliveTicks simply stops incrementing
-/// </summary>
 public class TrueAgeTracker : HediffWithComps
 {
     public bool aliveYearsInitialized = false;
@@ -75,13 +73,11 @@ public class TrueAgeTracker : HediffWithComps
         this.consciousAliveTicks++;
     }
 
-    /// <summary>
     /// Initialize the ledger with the pawn's pre-CryoRegenesis biological age.
     /// Called once, when the hediff is first added.
     ///
     /// Before this moment, True Age = Bio Age, so the pawn's current
     /// biological age IS their lived time.
-    /// </summary>
     public void Initialize(long preRegenesisBioTicks)
     {
         if (this.aliveYearsInitialized)
@@ -93,11 +89,9 @@ public class TrueAgeTracker : HediffWithComps
         this.aliveYearsInitialized = true;
     }
 
-    /// <summary>
     /// Record that CryoRegenesis has removed biological age.
     /// This does NOT reduce consciousAliveTicks — the pawn still
     /// lived through that time.
-    /// </summary>
     public void RecordCryoRegenesisDeAging(long removedTicks)
     {
         if (removedTicks <= 0)

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ solutionPath="Source/${MOD}.sln"
 
 # Define an array of configurations
 configurations=("v1.2" "v1.3" "v1.4" "v1.5" "v1.6")
+#configurations=("v1.2")
 
 dotnet restore "$solutionPath"
 
@@ -75,16 +76,16 @@ if [ "$1" == "1" ]; then
     exit
 fi
 
-# Watch for changes to .cs and XML files in the directory and subdirectories
-inotifywait --recursive --monitor --format "%e %w%f" \
-    --exclude '/\.idea($|/)' \
-    --event modify,move,create,delete "$dir" "$MOD" |
-    while read event fullpath; do
-        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
-            echo "Running build for $fullpath"
-            build || echo "Build failed, skipping sync."
-        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
-            echo "Running sync_mod for $fullpath"
-            sync_mod
-        fi
-    done
+## Watch for changes to .cs and XML files in the directory and subdirectories
+#inotifywait --recursive --monitor --format "%e %w%f" \
+#    --exclude '/\.idea($|/)' \
+#    --event modify,move,create,delete "$dir" "$MOD" |
+#    while read event fullpath; do
+#        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
+#            echo "Running build for $fullpath"
+#            build || echo "Build failed, skipping sync."
+#        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
+#            echo "Running sync_mod for $fullpath"
+#            sync_mod
+#        fi
+#    done


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added short-acting CryoRegenesis sedation plus a surgery recipe that queues transport to an empty CryoRegenesis casket.
  * Added a “Carry to CryoRegenesis casket” option for eligible immobilized/downed pawns, including translated status when no suitable casket is available.
* **Bug Fixes**
  * Improved CryoRegenesis healing/prosthetic eligibility logic and corrected True Age/body-positivity thought timing and stacking.
  * Removed the “heal not-bad” setting.
* **Documentation**
  * Updated README with a Goa’uld sarcophagus inspiration section and feature comparison.
* **Other**
  * Added missing localization strings and ensured the CryoRegenesis casket is explicitly player-ejectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add sedation-and-carry support for CryoRegenesis caskets and fix humanlike age handling**

### What Changed
- Doctors can now use a no-cost sedation surgery and then carry the pawn into the nearest empty CryoRegenesis casket.
- The carry option now appears for all downed humanlikes, including prisoners, guests, quest lodgers, hostiles, and modded humanlike races.
- Tamed player animals can now also be sedated and moved to CryoRegenesis caskets.
- Humanlike pawns now keep the chosen target age instead of being ejected right away.
- The mod now loads its patches in a way that avoids one version-specific failure from breaking the rest of the features.

### Impact
`✅ Shorter CryoRegenesis setup`
`✅ Fewer missed carry options on downed pawns`
`✅ Correct regeneration timing for xenotypes and modded humanlikes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
