### PR TITLE
Cryo Carry: A system for sending injured, prisoners, and guests to the sarcophagus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ artifacts/
 *.pidb
 *.svclog
 *.scc
+*.zip
 
 # Chutzpah Test files
 _Chutzpah*

--- a/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
+++ b/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
+  <!-- Persistent parent chain quest. Created in code and kept Ongoing until success or abandoned. -->
   <QuestScriptDef>
     <defName>CR_RoyaltyRegenesisQuestChain</defName>
     <autoAccept>true</autoAccept>
@@ -8,9 +9,24 @@
     <questDescriptionAndNameRules>
       <rulesStrings>
         <li>questName->CryoRegenesis: Imperial Rejuvenation</li>
-        <li>questDescription->Imperial and planetary rulers begin sending clients to your colony for CryoRegenesis. Successive treatments may draw the attention of lower nobility, the Stellarch, and eventually the Emperor.</li>
+        <li>questDescription->Planetary factions and eventually the Empire send CryoRegenesis clients by shuttle with fixed return dates. Death or recruitment destroys trust and resets the chain.</li>
       </rulesStrings>
     </questDescriptionAndNameRules>
     <root Class="BetterRimworlds.CryoRegenesis.QuestNode_StartRoyaltyRegenesisChain" />
+  </QuestScriptDef>
+
+  <!-- Per-visit contract quest. Spawned in code for each shuttle delivery; parented to the chain. -->
+  <QuestScriptDef>
+    <defName>CR_RoyaltyRegenesisContract</defName>
+    <autoAccept>true</autoAccept>
+    <defaultChallengeRating>3</defaultChallengeRating>
+    <isRootSpecial>true</isRootSpecial>
+    <questDescriptionAndNameRules>
+      <rulesStrings>
+        <li>questName->CryoRegenesis contract</li>
+        <li>questDescription->Treat contracted clients in a CryoRegenesis casket and return them alive by shuttle before the deadline.</li>
+      </rulesStrings>
+    </questDescriptionAndNameRules>
+    <root Class="BetterRimworlds.CryoRegenesis.QuestNode_RoyaltyRegenesisContractPlaceholder" />
   </QuestScriptDef>
 </Defs>

--- a/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
+++ b/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+  <QuestScriptDef>
+    <defName>CR_RoyaltyRegenesisQuestChain</defName>
+    <autoAccept>true</autoAccept>
+    <defaultChallengeRating>4</defaultChallengeRating>
+    <isRootSpecial>true</isRootSpecial>
+    <questDescriptionAndNameRules>
+      <rulesStrings>
+        <li>questName->CryoRegenesis: Imperial Rejuvenation</li>
+        <li>questDescription->Imperial and planetary rulers begin sending clients to your colony for CryoRegenesis. Successive treatments may draw the attention of lower nobility, the Stellarch, and eventually the Emperor.</li>
+      </rulesStrings>
+    </questDescriptionAndNameRules>
+    <root Class="BetterRimworlds.CryoRegenesis.QuestNode_StartRoyaltyRegenesisChain" />
+  </QuestScriptDef>
+</Defs>

--- a/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
+++ b/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
@@ -34,6 +34,7 @@
 		<defaultPlacingRot>South</defaultPlacingRot>
 		<building>
 			<ai_chillDestination>false</ai_chillDestination>
+			<isPlayerEjectable>true</isPlayerEjectable>
 		</building>
 		<costList>
 			<Steel>250</Steel>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -23,5 +23,5 @@
     <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No available CryoRegenesis casket.</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
 
     <CarryToCryoRegenesisCasket>Carry to CryoRegenesis casket</CarryToCryoRegenesisCasket>
-    <NoReachableCryoRegenesis>No reachable CryoRegenesis casket</NoReachableCryoRegenesis>
+    <NoReachableCryoRegenesis>No available CryoRegenesis casket</NoReachableCryoRegenesis>
 </LanguageData>

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -1,6 +1,43 @@
 // ==== Source/AllowHostedGuestsPatch.cs ====
+/*
+ * Carry-to-CryoRegenesis float menu (FloatMenuMakerMap.AddHumanlikeOrders).
+ *
+ * =============================================================================
+ * INCIDENT: option missing for unconscious / Downed prisoners (RW 1.2)
+ * =============================================================================
+ *
+ * What players saw:
+ *   Right-click on an unconscious prisoner (Moving 0%, Downed) never offered
+ *   "Carry to CryoRegenesis casket", even though the feature was meant for every
+ *   immobilised humanlike / colony animal.
+ *
+ * What was *not* the primary bug (but still worth hardening):
+ *   - Cell-only GetThingList lookups miss bed occupants → use GenUI.TargetsAt
+ *     plus a small cell neighbourhood scan.
+ *   - Strict CanReserveAndReach without ignoreOtherReservations greys out
+ *     tended patients → do not gate the menu on path/reserve probes; let the
+ *     job fail at runtime if needed.
+ *   - Carriable state is broader than `pawn.Downed` alone: also treat Moving
+ *     capacity at 0% (and anesthetic / CryoRegenesis sedation) as eligible so
+ *     edge ticks and UI "Moving 0%" match player expectations.
+ *
+ * What *was* the primary bug:
+ *   This patch never ran on 1.2. Harmony PatchAll aborted because another
+ *   assembly patch targeted a DoRecruit signature that does not exist on 1.2.
+ *   See the Harmony loading docblock in CryoRegenesis.cs and TargetMethod
+ *   fallbacks on Patch_DoRecruit_RegenContract.
+ *
+ * How not to repeat this:
+ *   - If this option vanishes on one RW version only, verify the patch is
+ *     applied (log + Harmony) before changing IsCryoCarryTargetState again.
+ *   - Keep IsCryoCarryTargetState = Downed OR Moving <= 0% OR sedation hediffs.
+ *   - Keep casket lookup free of pathing/reservation requirements for the menu.
+ *   - Multi-version: AddHumanlikeOrders exists through 1.5; 1.6 uses a different
+ *     float-menu pipeline and needs a separate approach if support is required.
+ * =============================================================================
+ */
+
 using System.Collections.Generic;
-using System.Linq;
 using BetterRimworlds.CryoRegenesis;
 using HarmonyLib;
 using RimWorld;
@@ -13,7 +50,10 @@ namespace CryoRegenesis.HarmonyPatches
     [HarmonyPatch(typeof(FloatMenuMakerMap), "AddHumanlikeOrders")]
     public static class Patch_FloatMenuMakerMap_AddHumanlikeOrders_CryoRegenesis
     {
-        public static void Postfix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
+        public static void Postfix(
+            Vector3 clickPos,
+            Pawn pawn,
+            List<FloatMenuOption> opts)
         {
             if (pawn?.Map == null)
                 return;
@@ -22,71 +62,223 @@ namespace CryoRegenesis.HarmonyPatches
             if (pawn.Downed || pawn.Dead || pawn.IsBurning())
                 return;
 
-            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
-
-            if (targetPawn == null)
-                return;
-
-            if (!ShouldAllowCryoRegenesisCarry(targetPawn))
-                return;
-
-            string label = "CarryToCryoRegenesisCasket".Translate();
-
-            Building_CryoRegenesis casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
-
-            if (casket == null)
+            /*
+             * Collect candidate patients under the cursor.
+             *
+             * GenUI.TargetsAt finds multi-cell bed occupants that a single
+             * GetThingList(cell) can miss. A cell scan is kept as a fallback
+             * for edge cases (e.g. draw-pos slightly off the click).
+             *
+             * Intentionally NO pathing / CanReserveAndReach checks here.
+             * Prisoners in locked rooms, guests with area restrictions, and
+             * bed-bound patients often fail reachability probes even when a
+             * colonist can still walk over and carry them. The job/toils
+             * handle real pathing at runtime.
+             */
+            foreach (Pawn targetPawn in GetCryoCarryCandidates(clickPos, pawn))
             {
-                opts.Add(new FloatMenuOption(label + ": " + "NoReachableCryoRegenesis".Translate(), null));
-                return;
-            }
+                if (!ShouldAllowCryoRegenesisCarry(targetPawn))
+                    continue;
 
-            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "CannotReach".Translate(targetPawn.LabelShort), null));
-                return;
-            }
+                string label = "CarryToCryoRegenesisCasket".Translate();
 
-            if (!pawn.CanReserve(casket))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "Reserved".Translate(casket.Label), null));
-                return;
-            }
+                Building_CryoRegenesis casket =
+                    FindEmptyCryoRegenesisCasket(targetPawn);
 
-            FloatMenuOption option = new FloatMenuOption(
-                label,
-                delegate
+                if (casket == null)
                 {
-                    Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, targetPawn, casket);
+                    opts.Add(
+                        new FloatMenuOption(
+                            label
+                            + ": "
+                            + "NoReachableCryoRegenesis".Translate(),
+                            null));
 
-                    job.count = 1;
+                    continue;
+                }
 
-                    pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
-                },
-                MenuOptionPriority.RescueOrCapture
-            );
+                // Capture for the menu-option delegate.
+                Pawn patient = targetPawn;
 
-            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(option, pawn, targetPawn));
+                FloatMenuOption option = new FloatMenuOption(
+                    label,
+                    delegate
+                    {
+                        Building_CryoRegenesis chosen =
+                            FindEmptyCryoRegenesisCasket(patient);
+
+                        if (chosen == null)
+                        {
+                            Messages.Message(
+                                "NoReachableCryoRegenesis".Translate(),
+                                patient,
+                                MessageTypeDefOf.RejectInput,
+                                historical: false);
+
+                            return;
+                        }
+
+                        Job job = JobMaker.MakeJob(
+                            CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
+                            patient,
+                            chosen);
+
+                        job.count = 1;
+
+                        pawn.jobs.TryTakeOrderedJob(
+                            job,
+                            JobTag.Misc);
+                    },
+                    MenuOptionPriority.RescueOrCapture);
+
+                opts.Add(
+                    FloatMenuUtility.DecoratePrioritizedTask(
+                        option,
+                        pawn,
+                        targetPawn));
+            }
         }
 
-        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
+        private static IEnumerable<Pawn> GetCryoCarryCandidates(
+            Vector3 clickPos,
+            Pawn carrier)
         {
+            var seen = new HashSet<Pawn>();
+
+            TargetingParameters targetingParameters =
+                MakeCryoCarryTargetingParameters(carrier);
+
+#if RIMWORLD12
+            // RimWorld 1.2 prefers TargetsAt_NewTemp; TargetsAt is obsolete there.
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt_NewTemp(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#else
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#endif
+
+            foreach (LocalTargetInfo target in targets)
+            {
+                if (target.Thing is Pawn targetPawn && seen.Add(targetPawn))
+                    yield return targetPawn;
+            }
+
+            // Fallback: direct cell scan (covers some bed / multi-cell cases).
+            Map map = carrier.Map;
             IntVec3 cell = IntVec3.FromVector3(clickPos);
 
             if (!cell.InBounds(map))
-                return null;
+                yield break;
 
-            return cell
-                .GetThingList(map)
-                .OfType<Pawn>()
-                .FirstOrDefault(
-                    candidate =>
-                        candidate.Downed &&
-                        !candidate.Dead &&
-                        (
-                            candidate.RaceProps.Humanlike ||
-                            candidate.RaceProps.Animal
-                        )
-                );
+            for (int x = -1; x <= 1; x++)
+            {
+                for (int z = -1; z <= 1; z++)
+                {
+                    IntVec3 scanCell = new IntVec3(cell.x + x, cell.y, cell.z + z);
+
+                    if (!scanCell.InBounds(map))
+                        continue;
+
+                    List<Thing> things = scanCell.GetThingList(map);
+
+                    for (int i = 0; i < things.Count; i++)
+                    {
+                        if (things[i] is Pawn targetPawn &&
+                            seen.Add(targetPawn) &&
+                            IsCryoCarryTargetState(targetPawn))
+                        {
+                            yield return targetPawn;
+                        }
+                    }
+                }
+            }
+        }
+
+        /*
+         * Common-denominator replacement for TargetingParameters.ForRescue.
+         *
+         * Also accepts pawns under Anesthetic / CryoRegenesis sedation who may
+         * briefly not report as Downed (severity edge, just-applied hediff).
+         * ForRescue's onlyTargetIncapacitatedPawns would miss those.
+         */
+        private static TargetingParameters MakeCryoCarryTargetingParameters(
+            Pawn carrier)
+        {
+            return new TargetingParameters
+            {
+                canTargetLocations = false,
+                canTargetSelf = false,
+
+                canTargetPawns = true,
+                canTargetHumans = true,
+                canTargetAnimals = true,
+
+                canTargetBuildings = false,
+                canTargetItems = false,
+
+                // Do NOT set onlyTargetIncapacitatedPawns: anesthetized
+                // prisoners can fail that gate at certain severity edges.
+                // Our validator handles Downed + sedation explicitly.
+                onlyTargetIncapacitatedPawns = false,
+                mustBeSelectable = false,
+                mapObjectTargetsMustBeAutoAttackable = false,
+
+                validator = target =>
+                {
+                    if (!target.HasThing)
+                        return false;
+
+                    Pawn targetPawn = target.Thing as Pawn;
+
+                    return targetPawn != null
+                        && targetPawn != carrier
+                        && targetPawn.Spawned
+                        && IsCryoCarryTargetState(targetPawn);
+                }
+            };
+        }
+
+        /// <summary>
+        /// True when the pawn is carriable: Downed, Moving at 0%, or sedated
+        /// and about to collapse. JobDriver waits for Downed after sedation.
+        /// </summary>
+        private static bool IsCryoCarryTargetState(Pawn targetPawn)
+        {
+            if (targetPawn == null || targetPawn.Dead)
+                return false;
+
+            // Standard incapacitated flag (unconscious, pain shock, etc.).
+            if (targetPawn.Downed)
+                return true;
+
+            // Moving 0% — can't walk even if Downed hasn't flipped yet.
+            PawnCapacitiesHandler capacities = targetPawn.health?.capacities;
+            if (capacities != null &&
+                (!capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+                 capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f))
+            {
+                return true;
+            }
+
+            // Full Anesthetic or our cryo sedation (pending collapse).
+            if (targetPawn.health?.hediffSet == null)
+                return false;
+
+            if (targetPawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+                return true;
+
+            if (CryoRegenesisDefOf.CryoRegenesisSedation != null &&
+                targetPawn.health.hediffSet.HasHediff(
+                    CryoRegenesisDefOf.CryoRegenesisSedation))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
@@ -94,26 +286,24 @@ namespace CryoRegenesis.HarmonyPatches
             if (targetPawn == null)
                 return false;
 
-            if (targetPawn.Dead || !targetPawn.Downed)
+            if (!IsCryoCarryTargetState(targetPawn))
                 return false;
 
             /*
              * Animals.
              *
-             * Restricted to the player's faction so the option isn't
-             * offered on wild or enemy fauna. Species-level petness is
-             * deliberately irrelevant — a tamed warg, thrumbo, or other
-             * non-pet species is still eligible when it belongs to the
-             * player's faction.
+             * Restricted to the player's faction so the option isn't offered
+             * on wild or enemy fauna. Species-level petness is deliberately
+             * irrelevant: a tamed warg, thrumbo, or other non-pet species is
+             * still eligible when it belongs to the player's faction.
              */
             if (targetPawn.RaceProps.Animal)
                 return targetPawn.Faction == Faction.OfPlayer;
 
             /*
-             * Any downed humanlike is eligible — colonists, slaves,
-             * prisoners, guests, quest lodgers, and downed hostiles alike.
-             * The click already required Downed && !Dead, so this covers
-             * every rescue/capture-style scenario, including sedated pawns.
+             * Any qualifying humanlike is eligible: colonists, slaves,
+             * prisoners (including anesthetized quest prisoners), guests,
+             * quest lodgers, and downed hostiles alike.
              */
             if (targetPawn.RaceProps.Humanlike)
                 return true;
@@ -121,33 +311,43 @@ namespace CryoRegenesis.HarmonyPatches
             return false;
         }
 
-        private static Building_CryoRegenesis FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
+        /*
+         * Nearest empty colony CryoRegenesis casket. Intentionally no pathing
+         * or reservation checks — those are left to the job/toils at runtime.
+         */
+        private static Building_CryoRegenesis FindEmptyCryoRegenesisCasket(
+            Pawn targetPawn)
         {
-            Map map = carrier?.Map;
+            Map map = targetPawn?.MapHeld;
 
-            if (map == null || targetPawn == null)
+            if (map == null)
                 return null;
 
-            return GenClosest.ClosestThingReachable(
-                targetPawn.Position,
-                map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
-                PathEndMode.InteractionCell,
-                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
-                validator: thing =>
+            Building_CryoRegenesis best = null;
+            int bestDist = int.MaxValue;
+            IntVec3 pos = targetPawn.PositionHeld;
+
+            List<Thing> buildings = map.listerThings.ThingsInGroup(
+                ThingRequestGroup.BuildingArtificial);
+
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                if (buildings[i] is not Building_CryoRegenesis casket)
+                    continue;
+
+                if (casket.HasAnyContents)
+                    continue;
+
+                int dist = casket.Position.DistanceToSquared(pos);
+
+                if (dist < bestDist)
                 {
-                    if (thing is not Building_CryoRegenesis casket)
-                        return false;
-
-                    if (casket.HasAnyContents)
-                        return false;
-
-                    if (!carrier.CanReserve(casket))
-                        return false;
-
-                    return true;
+                    bestDist = dist;
+                    best = casket;
                 }
-            ) as Building_CryoRegenesis;
+            }
+
+            return best;
         }
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -476,6 +476,14 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             string bioTime = "AgeBiological".Translate((NamedArgument) years,
                 (NamedArgument) quadrums, (NamedArgument) days);
 
+            var trueAgeTracker = pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            if (trueAgeTracker != null && trueAgeTracker.underRegenContract && trueAgeTracker.desiredAgeTicks > 0)
+            {
+                bioTime += "\nContract target age: " + trueAgeTracker.GetContractTargetAgeYears().ToString("0.#")
+                    + " (" + trueAgeTracker.GetContractProgressPercent().ToString("0") + "% there)";
+            }
+
             if (this.regenesisCycle.HasCurableInjuries)
             {
                 return base.GetInspectString() + ", " + this.regenesisCycle.AgeHediffs() + " Age Disabilities, " + this.regenesisCycle.InjuryHediffs() + " Injuries\n" + bioTime + "\nTime To Heal: " + this.regenesisCycle.TtlToHeal;

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -230,7 +230,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                 this.EjectContents();
             }
 
-            if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
+            if (pawn.ageTracker.AgeBiologicalTicks > this.regenesisCycle.TargetAgeTicks)
             {
                 #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
                 power.PowerOutput = -props.PowerConsumption;
@@ -240,11 +240,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
                 if (power.PowerOn)
                 {
-                    if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
+                    if (pawn.ageTracker.AgeBiologicalTicks > this.regenesisCycle.TargetAgeTicks)
                     {
                         refuelable.ConsumeFuel(fuelConsumption * ((pawnAge - 10) * 0.1f));
 
-                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, GenDate.TicksPerYear * this.regenesisCycle.TargetAge);
+                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, this.regenesisCycle.TargetAgeTicks);
                     }
                 }
             }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -8,6 +8,40 @@
  *   https://github.com/BetterRimworlds/CryoRegenesis
  *
  * This file is licensed under the MIT License.
+ *
+ * =============================================================================
+ * HARMONY PATCH LOADING — DO NOT REGRESS
+ * =============================================================================
+ *
+ * Problem (RimWorld 1.2, 2026-07):
+ *   "Carry to CryoRegenesis casket" never appeared for unconscious / Downed
+ *   prisoners. Eligibility and float-menu code looked correct; the real failure
+ *   was that *no* Harmony patches in this assembly applied at all.
+ *
+ * Root cause:
+ *   Mod construction used a single `harmony.PatchAll(Assembly)`. One unrelated
+ *   patch (Patch_DoRecruit_RegenContract) resolved TargetMethod() against the
+ *   *1.3+* InteractionWorker_RecruitAttempt.DoRecruit signature. On 1.2 that
+ *   method still takes `float recruitChance`, so AccessTools returned null,
+ *   PatchAll threw, and the catch block only logged:
+ *     "Failed to load harmony patches: ..."
+ *   Every other patch — including FloatMenuMakerMap.AddHumanlikeOrders for the
+ *   carry option — died with it. Symptom looked like a carry-eligibility bug.
+ *
+ * How not to repeat this:
+ *   1. Never rely on one PatchAll for the whole assembly when any TargetMethod
+ *      is version-sensitive. Apply each [HarmonyPatch] type with
+ *      CreateClassProcessor(type).Patch() inside its own try/catch (see ctor).
+ *   2. When resolving vanilla methods by signature, probe *every* supported
+ *      RimWorld version (1.2 often differs). Prefer ordered AccessTools.Method
+ *      fallbacks; never assume 1.3+ is the only shape.
+ *   3. If a float-menu / job feature "does nothing" on one game version only,
+ *      check the player log first for Harmony load failures before rewriting
+ *      gameplay conditions (Downed, Moving %, beds, etc.).
+ *   4. After changing any TargetMethod / patch attribute, boot *each* target
+ *      version (or at least 1.2 and latest) and confirm no
+ *      "[CryoRegenesis] Harmony patch failed" lines at startup.
+ * =============================================================================
  */
 
 using RimWorld;
@@ -28,13 +62,26 @@ public class CryoRegenesis: Mod
         Settings = GetSettings<Settings>() ?? new Settings();
 
         var harmony = new Harmony("FrontierDevelopments.DeadCryptosleep");
-        try
+        /*
+         * Apply each [HarmonyPatch] type independently. A single bad TargetMethod
+         * (version-mismatched signature) must not abort the rest — that used to
+         * silently kill the Carry-to-CryoRegenesis float menu on RimWorld 1.2.
+         */
+        foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
         {
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
-        }
-        catch (Exception e)
-        {
-            Log.Error($"Failed to load harmony patches: {e.Message}\n{e.StackTrace}");
+            object[] attrs = type.GetCustomAttributes(typeof(HarmonyPatch), inherit: true);
+            if (attrs == null || attrs.Length == 0)
+                continue;
+
+            try
+            {
+                harmony.CreateClassProcessor(type).Patch();
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    $"[CryoRegenesis] Harmony patch failed on {type.FullName}: {e.Message}\n{e.StackTrace}");
+            }
         }
     }
 
@@ -448,6 +495,7 @@ public static class CryoRegenesisDefOf
 {
     public static HediffDef CryoRegenesisSedation;
     public static JobDef CR_CarryToCryoRegenesis;
+    public static RecipeDef CR_AdministerCryoRegenesisSedation;
 
     static CryoRegenesisDefOf()
     {

--- a/Source/Hediff_CryoRegenesisWithdrawal.cs
+++ b/Source/Hediff_CryoRegenesisWithdrawal.cs
@@ -1,0 +1,72 @@
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis
+{
+    public class Hediff_CryoRegenesisWithdrawal : HediffWithComps
+    {
+        // Stage cutoff points (severity is from 0 to 1)
+        // These three ranges mimic the nonlinear phases
+        private const float Stage1End = 0.70f;   // Acute Disintegration
+        private const float Stage2End = 0.40f;   // Aberrant Homeostasis
+        // Stage 3 runs to 0.00                   // Residual Cataclysm
+
+        public override void PostTick()
+        {
+            base.PostTick();
+
+            if (pawn == null || pawn.Dead)
+                return;
+
+            // Only run every 250 ticks (~4 times per hour)
+            if (Find.TickManager.TicksGame % 250 != 0)
+                return;
+
+            float decayAmount = GetDailySeverityLoss() / 240f; 
+            // 240 intervals per day (250 ticks * 240 ≈ 60k ticks)
+
+            Severity -= decayAmount;
+
+            // Clamp
+            if (Severity < 0f)
+                Severity = 0f;
+        }
+
+        private float GetDailySeverityLoss()
+        {
+            // Nonlinear decay based on severity stage
+
+            if (Severity >= Stage1End)
+            {
+                // Stage 1 — Acute Disintegration: fast crash (≈3–5 days)
+                return 0.06f;   // -6% per day
+            }
+            else if (Severity >= Stage2End)
+            {
+                // Stage 2 — Instability: medium decay (~20–30 days)
+                return 0.015f;  // -1.5% per day
+            }
+            else
+            {
+                // Stage 3 — Chronic Decay (~80–90 days)
+                return 0.005f;  // -0.5% per day
+            }
+        }
+
+        // public override bool CauseRemoved(Hediff cause)
+        // {
+        //     // Explicitly assure the engine this isn't an artificial body part.
+        //     // This prevents Body Purist debuffs.
+        //     return false;
+        // }
+
+        public override bool Visible => true;
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            // Nothing custom to save right now.
+        }
+    }
+}
+

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -1,4 +1,18 @@
 // ==== Source/JobDriver_CarryToCryoRegenesis.cs ====
+/*
+ * Ordered job: carry a patient into a CryoRegenesis casket.
+ *
+ * Immobility gate (do not narrow this):
+ *   PatientIsImmobile() is true when the pawn is Downed *or* Moving capacity
+ *   is 0%. Players treat "Unconscious / Moving 0%" as carriable; requiring only
+ *   `pawn.Downed` missed edge cases and disagreed with the float-menu check in
+ *   AllowHostedGuestsPatch (keep both in sync).
+ *
+ * If the carry *menu option* is missing entirely on one RW version, that is
+ * usually a Harmony load failure — not this driver. See CryoRegenesis.cs and
+ * Patch_DoRecruit_RegenContract docblocks.
+ */
+using RimWorld;
 using Verse;
 using Verse.AI;
 
@@ -20,6 +34,27 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
     private Building_CryoRegenesis Casket =>
         job.GetTarget(CasketIndex).Thing as Building_CryoRegenesis;
 
+    /// <summary>
+    /// Patient can be picked up when Downed or when Moving is 0%.
+    /// Must stay aligned with AllowHostedGuestsPatch.IsCryoCarryTargetState.
+    /// </summary>
+    private bool PatientIsImmobile()
+    {
+        Pawn patient = Patient;
+        if (patient == null || patient.Dead)
+            return false;
+
+        if (patient.Downed)
+            return true;
+
+        PawnCapacitiesHandler capacities = patient.health?.capacities;
+        if (capacities == null)
+            return false;
+
+        return !capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+               capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f;
+    }
+
     public override bool TryMakePreToilReservations(bool errorOnFailed)
     {
         return pawn.Reserve(Patient, job, 1, -1, null, errorOnFailed) &&
@@ -40,7 +75,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
             Patient == null || Patient.Dead || Casket == null || Casket.HasAnyContents
         );
 
-        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.Touch);
+        // OnCell matches vanilla CarryToCryptosleepCasket and reaches pawns in beds.
+        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.OnCell);
 
         /*
          * Sedation may take a few ticks to down a large pawn (humans have a
@@ -57,8 +93,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.initAction = () =>
         {
-            // Already downed? Skip the wait entirely.
-            if (Patient != null && Patient.Downed)
+            // Already immobile? Skip the wait entirely.
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -66,7 +102,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.tickAction = () =>
         {
-            if (Patient != null && Patient.Downed)
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -74,7 +110,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.AddFailCondition(() =>
             waitForDowned.actor.jobs.curDriver.ticksLeftThisToil <= 0 &&
-            (Patient == null || !Patient.Downed)
+            !PatientIsImmobile()
         );
 
         yield return waitForDowned;

--- a/Source/Patch_CryoSedationSurgeryReady.cs
+++ b/Source/Patch_CryoSedationSurgeryReady.cs
@@ -1,0 +1,65 @@
+// ==== Source/Patch_CryoSedationSurgeryReady.cs ====
+using BetterRimworlds.CryoRegenesis;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace CryoRegenesis.HarmonyPatches;
+
+/**
+ * Vanilla surgery bills only proceed when the patient is InBed()
+ * (Pawn.CurrentlyUsableForBills → "not ready for surgery").
+ *
+ * CryoRegenesis sedation is a sedate-and-carry protocol, not hospital surgery.
+ * Prisoners, prison guests, and area-restricted guests often never path into a
+ * medical bed (or arrive already downed on the floor), so the bill stalls forever.
+ *
+ * Allow our specific bill to run in place: the doctor walks to the patient,
+ * sedates them, then enqueues the carry-to-casket job.
+ */
+[HarmonyPatch(typeof(Pawn), nameof(Pawn.CurrentlyUsableForBills))]
+public static class Patch_Pawn_CurrentlyUsableForBills_CryoSedation
+{
+    public static void Postfix(Pawn __instance, ref bool __result)
+    {
+        if (__result)
+            return;
+
+        if (__instance == null || __instance.Dead || !__instance.Spawned)
+            return;
+
+        if (!HasPendingCryoSedationBill(__instance))
+            return;
+
+        // Free-standing humanlikes resolve InteractionCell to an adjacent standable cell.
+        if (!__instance.InteractionCell.IsValid)
+            return;
+
+        __result = true;
+        JobFailReason.Clear();
+    }
+
+    private static bool HasPendingCryoSedationBill(Pawn pawn)
+    {
+        BillStack bills = pawn.health?.surgeryBills;
+        if (bills == null || bills.Count == 0)
+            return false;
+
+        RecipeDef sedationRecipe = CryoRegenesisDefOf.CR_AdministerCryoRegenesisSedation;
+        if (sedationRecipe == null)
+            return false;
+
+        for (int i = 0; i < bills.Count; i++)
+        {
+            Bill bill = bills[i];
+            if (bill == null || bill.deleted || bill.suspended)
+                continue;
+
+            if (bill.recipe == sedationRecipe)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -88,16 +88,24 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         if (map == null)
             return null;
 
+        /*
+         * Availability (carrier == null) must NOT require the patient to path
+         * to the casket. Prisoners, prison guests, and area-restricted guests
+         * often cannot leave their pen, and the whole point of sedation is that
+         * a doctor carries them. Only check that an empty colony casket exists.
+         *
+         * When applying (carrier != null), require the doctor to reserve/reach.
+         */
         return map.listerBuildings
             .AllBuildingsColonistOfClass<Building_CryoRegenesis>()
             .Where(c => !c.HasAnyContents)
             .OrderBy(c => c.Position.DistanceToSquared(pawn.PositionHeld))
             .FirstOrDefault(c =>
             {
-                if (carrier != null)
-                    return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                if (carrier == null)
+                    return true;
 
-                return pawn.CanReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
             });
     }
 

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -26,6 +26,7 @@ public class RegenesisCycle
     private bool enteredHealthy;
     private long restoreCoolDown = NoRegenesisInProgress;
     private int targetAge;
+    private long targetAgeTicks;
     private string ttlToHeal;
     private int origAge;
 
@@ -33,6 +34,7 @@ public class RegenesisCycle
     public bool HasCurableInjuries => this.hediffsToHeal.Any();
     public int OriginalAge => this.origAge;
     public int TargetAge => this.targetAge;
+    public long TargetAgeTicks => this.targetAgeTicks;
     public string TtlToHeal => this.ttlToHeal;
 
     public void ExposeData()
@@ -61,7 +63,7 @@ public class RegenesisCycle
 
     public bool IsTargetAge(Pawn pawn, int rate)
     {
-        return pawn.ageTracker.AgeBiologicalTicks <= ((GenDate.TicksPerYear * this.targetAge) + rate);
+        return pawn.ageTracker.AgeBiologicalTicks <= (this.targetAgeTicks + rate);
     }
 
     public void UpdateHealingEta(Pawn pawn, int rate)
@@ -349,10 +351,21 @@ public class RegenesisCycle
         if (pawn.RaceProps.Humanlike)
         {
             this.targetAge = CryoRegenesis.Settings.targetAge;
+            this.targetAgeTicks = GenDate.TicksPerYear * (long)this.targetAge;
         }
         else
         {
             this.targetAge = (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25);
+            this.targetAgeTicks = GenDate.TicksPerYear * (long)this.targetAge;
+        }
+
+        TrueAgeTracker tracker =
+            pawn.health?.hediffSet?.GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+
+        if (tracker?.desiredAgeTicks > 0)
+        {
+            this.targetAgeTicks = tracker.desiredAgeTicks;
+            this.targetAge = (int)Math.Ceiling((double)this.targetAgeTicks / GenDate.TicksPerYear);
         }
 
         if (CryoRegenesis.Settings.debugMode)

--- a/Source/RegenesisThoughts.cs
+++ b/Source/RegenesisThoughts.cs
@@ -43,7 +43,13 @@ public static class RegenesisThoughts
         #if !RIMWORLD12 && !RIMWORLD13
         if (thought.CurStageIndex >= 2)
         {
-            if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
+            // Regen-quest contract clients must never become voluntarily recruitable.
+            TrueAgeTracker tracker = pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            bool underContract = (tracker != null && tracker.underRegenContract)
+                || RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(pawn);
+
+            if (!underContract && pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
             {
                 pawn.guest.Recruitable = true;
                 Messages.Message("Grateful to be so much younger, " + pawn.Name + " is now recruitable.", pawn, MessageTypeDefOf.PositiveEvent);

--- a/Source/RoyaltyRegenesisQuestParts.cs
+++ b/Source/RoyaltyRegenesisQuestParts.cs
@@ -1,0 +1,182 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// <summary>
+/// Live progress text for the persistent chain quest in the Quests tab.
+/// </summary>
+public class QuestPart_RoyaltyRegenesisChainStatus : QuestPart
+{
+    public override string DescriptionPart
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            return system != null ? system.GetChainProgressDescription() : string.Empty;
+        }
+    }
+}
+
+/// <summary>
+/// Live progress text for an individual CryoRegenesis contract quest.
+/// </summary>
+public class QuestPart_RoyaltyRegenesisContractStatus : QuestPart
+{
+    public override string DescriptionPart
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            return system != null ? system.GetContractProgressDescription() : string.Empty;
+        }
+    }
+
+    public override IEnumerable<GlobalTargetInfo> QuestLookTargets
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            if (system == null)
+            {
+                yield break;
+            }
+
+            foreach (RoyaltyRegenesisClient client in system.ActiveClients)
+            {
+                if (client?.pawn != null && !client.pawn.Destroyed)
+                {
+                    yield return client.pawn;
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Creates and maintains RimWorld Quest objects for the Regenesis campaign.
+/// </summary>
+public static class RoyaltyRegenesisQuestFactory
+{
+    public const string ChainQuestDefName = "CR_RoyaltyRegenesisQuestChain";
+    public const string ContractQuestDefName = "CR_RoyaltyRegenesisContract";
+
+    public static Quest MakeChainQuest()
+    {
+        Quest quest = Quest.MakeRaw();
+        quest.name = "CryoRegenesis: Imperial Rejuvenation";
+        quest.description = BuildChainDescriptionBody();
+        quest.root = DefDatabase<QuestScriptDef>.GetNamedSilentFail(ChainQuestDefName);
+        quest.challengeRating = 4;
+        quest.AddPart(new QuestPart_RoyaltyRegenesisChainStatus());
+        Find.QuestManager.Add(quest);
+        quest.Accept(null);
+        return quest;
+    }
+
+    public static Quest MakeContractQuest(string title, string description, Quest parentChain)
+    {
+        Quest quest = Quest.MakeRaw();
+        quest.name = title;
+        quest.description = description;
+        quest.root = DefDatabase<QuestScriptDef>.GetNamedSilentFail(ContractQuestDefName);
+        quest.challengeRating = 3;
+#if !RIMWORLD12
+        if (parentChain != null)
+        {
+            quest.parent = parentChain;
+        }
+#endif
+        quest.AddPart(new QuestPart_RoyaltyRegenesisContractStatus());
+        Find.QuestManager.Add(quest);
+        quest.Accept(null);
+        return quest;
+    }
+
+    public static void EndQuestSafe(Quest quest, QuestEndOutcome outcome, bool sendLetter = true)
+    {
+        if (quest == null || quest.Historical)
+        {
+            return;
+        }
+
+        quest.End(outcome, sendLetter);
+    }
+
+    public static string BuildChainDescriptionBody()
+    {
+        return
+            "Planetary factions will send CryoRegenesis clients by shuttle with fixed return dates. " +
+            "Complete enough foreign contracts and the Empire takes notice — lower nobility, then the Stellarch, then the Emperor.\n\n" +
+            "Rules:\n" +
+            "• Clients arrive and leave by shuttle.\n" +
+            "• Never recruit them (recruitment destroys trust).\n" +
+            "• If a client dies under contract, trust collapses and progress resets.\n\n" +
+            "Track live stage progress below.";
+    }
+
+    public static string BuildContractDescription(
+        string roleSummary,
+        Faction sender,
+        bool isPrisoner,
+        int returnByTick,
+        IEnumerable<Pawn> clients)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(roleSummary);
+        sb.AppendLine();
+        if (sender != null)
+        {
+            sb.AppendLine("Sending faction: " + sender.Name);
+        }
+
+        sb.AppendLine(isPrisoner
+            ? "Status: prisoners under contract (do not recruit)."
+            : "Status: guests under contract (do not recruit).");
+        sb.AppendLine("Return shuttle arrives: " + FormatGameTickDate(returnByTick));
+        sb.AppendLine();
+        sb.AppendLine("Clients:");
+        foreach (Pawn pawn in clients.Where(p => p != null))
+        {
+            sb.AppendLine("• " + pawn.Name.ToStringFull + " (bio age " + pawn.ageTracker.AgeBiologicalYears + ")");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Objectives:");
+        sb.AppendLine("1. Place clients in a CryoRegenesis casket.");
+        sb.AppendLine("2. Reach their requested regression age before the return shuttle.");
+        sb.AppendLine("3. Return them alive by shuttle — death or recruitment resets the whole chain.");
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Formats a <see cref="TickManager.TicksGame"/> value as a calendar date.
+    /// GenDate expects absolute ticks, so convert from game ticks first.
+    /// </summary>
+    public static string FormatGameTickDate(int ticksGame)
+    {
+        int tile = Find.CurrentMap?.Tile ?? Find.AnyPlayerHomeMap?.Tile ?? 0;
+        int delta = ticksGame - Find.TickManager.TicksGame;
+        int absTick = Find.TickManager.TicksAbs + delta;
+        return GenDate.DateFullStringAt(absTick, Find.WorldGrid.LongLatOf(tile));
+    }
+
+    public static string FormatTickDate(int absoluteTick)
+    {
+        int tile = Find.CurrentMap?.Tile ?? Find.AnyPlayerHomeMap?.Tile ?? 0;
+        return GenDate.DateFullStringAt(absoluteTick, Find.WorldGrid.LongLatOf(tile));
+    }
+}

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -11,6 +11,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using HarmonyLib;
 using RimWorld;
 using RimWorld.QuestGen;
 using Verse;
@@ -25,6 +27,12 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 {
     private const int CheckIntervalTicks = 2500;
     private const int HalfYearTicks = GenDate.TicksPerYear / 2;
+    private const int RecruitGoodwillPenalty = -35;
+    private const int DeathTrustGoodwillPenalty = -75;
+    private const int MinContractDays = 3;
+    private const int MaxContractDays = 30;
+    private const int MajorResetMinDays = 60;
+    private const int MajorResetMaxDays = 90;
 
     private RoyaltyRegenesisStage stage = RoyaltyRegenesisStage.NotStarted;
     private RoyaltyRegenesisStage activeContractStage = RoyaltyRegenesisStage.NotStarted;
@@ -33,10 +41,40 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     private int leaderContractsCompleted;
     private int nobleContractsCompleted;
     private bool royalAscentTriggered;
+    private int trustBreaks;
+    private string lastTrustBreakReason = string.Empty;
     private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
+    private Quest chainQuest;
+    private Quest activeContractQuest;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
+    }
+
+    public IReadOnlyList<RoyaltyRegenesisClient> ActiveClients => this.activeClients;
+
+    public static RoyaltyRegenesisQuestSystem CurrentSystem =>
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>();
+
+    public static bool IsActiveRegenContractPawn(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return false;
+        }
+
+        RoyaltyRegenesisQuestSystem system = CurrentSystem;
+        return system != null && system.activeClients.Any(client => client?.pawn == pawn);
+    }
+
+    public static RoyaltyRegenesisClient GetActiveClient(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return null;
+        }
+
+        return CurrentSystem?.activeClients.FirstOrDefault(client => client?.pawn == pawn);
     }
 
     public override void ExposeData()
@@ -50,11 +88,23 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.leaderContractsCompleted, "crRoyalLeaderContractsCompleted", 0);
         Scribe_Values.Look(ref this.nobleContractsCompleted, "crRoyalNobleContractsCompleted", 0);
         Scribe_Values.Look(ref this.royalAscentTriggered, "crRoyalAscentTriggered", false);
+        Scribe_Values.Look(ref this.trustBreaks, "crRoyalTrustBreaks", 0);
+        Scribe_Values.Look(ref this.lastTrustBreakReason, "crRoyalLastTrustBreakReason");
         Scribe_Collections.Look(ref this.activeClients, "crRoyalActiveClients", LookMode.Deep);
+        Scribe_References.Look(ref this.chainQuest, "crRoyalChainQuest");
+        Scribe_References.Look(ref this.activeContractQuest, "crRoyalActiveContractQuest");
 
-        if (Scribe.mode == LoadSaveMode.PostLoadInit && this.activeClients == null)
+        if (Scribe.mode == LoadSaveMode.PostLoadInit)
         {
-            this.activeClients = new List<RoyaltyRegenesisClient>();
+            if (this.activeClients == null)
+            {
+                this.activeClients = new List<RoyaltyRegenesisClient>();
+            }
+
+            if (this.lastTrustBreakReason == null)
+            {
+                this.lastTrustBreakReason = string.Empty;
+            }
         }
     }
 
@@ -87,8 +137,15 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         int ticksGame = Find.TickManager.TicksGame;
         if (this.stage == RoyaltyRegenesisStage.NotStarted)
         {
+            // Other planetary factions send clients first. The Empire only
+            // notices after those contracts succeed.
             this.stage = RoyaltyRegenesisStage.RulerPrisoners;
             this.nextEventTick = ticksGame + Rand.RangeInclusive(3, 8) * GenDate.TicksPerDay;
+            this.EnsureChainQuest();
+        }
+        else if (this.stage != RoyaltyRegenesisStage.Completed)
+        {
+            this.EnsureChainQuest();
         }
 
         if (this.stage != RoyaltyRegenesisStage.Completed && ticksGame >= this.nextEventTick)
@@ -169,10 +226,12 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
         this.activeClients.Clear();
         this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
         this.stage = debugStage;
         this.nextEventTick = Find.TickManager.TicksGame;
+        this.EnsureChainQuest();
         this.AdvanceCampaign();
     }
 
@@ -196,81 +255,194 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
     private void StartRulerPrisonerContract(Map map)
     {
-        Faction sender = this.RandomNonPlayerFaction() ?? this.EmpireFaction();
+        Faction sender = this.RandomPlanetarySenderFaction();
+        if (sender == null)
+        {
+            this.ScheduleRetry(
+                "No eligible factions",
+                "No non-Empire, non-Ancient planetary factions are available to send CryoRegenesis prisoners. Retrying later.");
+            return;
+        }
+
         int pawnCount = Rand.RangeInclusive(1, 2);
         List<Pawn> pawns = new List<Pawn>();
+        int contractDays = 0;
 
         for (int i = 0; i < pawnCount; i++)
         {
-            Pawn pawn = this.GeneratePawn(this.CommonPawnKind(), sender, Rand.RangeInclusive(24, 70));
+            Pawn pawn = this.GeneratePawn(this.CommonPawnKind(sender), sender, Rand.RangeInclusive(24, 70));
             int duration = Rand.Element(HalfYearTicks, GenDate.TicksPerYear, GenDate.TicksPerYear * 2);
             long targetTicks = Math.Max(18L * GenDate.TicksPerYear, pawn.ageTracker.AgeBiologicalTicks - duration);
-            this.PrepareClient(pawn, targetTicks, "foreign prisoner");
+            int days = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
+            contractDays = Math.Max(contractDays, days);
+            this.PrepareClient(pawn, targetTicks, "foreign prisoner", sender, isPrisoner: true, contractDays: days);
             pawns.Add(pawn);
         }
 
         this.activeContractStage = RoyaltyRegenesisStage.RulerPrisoners;
-        this.DropClients(map, pawns, "CryoRegenesis contract: prisoners",
-            $"{(sender?.Name ?? "A planetary ruler")} has sent prisoners and dependents for a trial CryoRegenesis contract. Their requested regression is six months, one year, or two years.");
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"{sender.Name} has sent prisoners for a trial CryoRegenesis contract. " +
+            $"Their requested regression is six months, one year, or two years. " +
+            $"They arrive and depart by shuttle and must be returned by {returnText}. " +
+            "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            pawns,
+            sender,
+            "CryoRegenesis contract: prisoners",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Prisoner trial",
+            letterBody,
+            sender,
+            isPrisoner: true);
     }
 
     private void StartLeaderContract(Map map)
     {
-        Faction sender = this.RandomNonPlayerFaction() ?? this.EmpireFaction();
-        Pawn leader = this.GeneratePawn(this.NoblePawnKind(), sender, Rand.RangeInclusive(35, 82));
+        Faction sender = this.RandomPlanetarySenderFaction();
+        if (sender == null)
+        {
+            this.ScheduleRetry(
+                "No eligible factions",
+                "No non-Empire, non-Ancient planetary leaders are available for a CryoRegenesis stay. Retrying later.");
+            return;
+        }
+
+        Pawn leader = this.GeneratePawn(this.NoblePawnKind(sender), sender, Rand.RangeInclusive(35, 82));
         int yearsToRemove = Rand.RangeInclusive(2, 18);
         long targetTicks = Math.Max(30L * GenDate.TicksPerYear, leader.ageTracker.AgeBiologicalTicks - yearsToRemove * GenDate.TicksPerYear);
+        int contractDays = this.CalculateContractDays(leader.ageTracker.AgeBiologicalTicks - targetTicks);
 
-        this.PrepareClient(leader, targetTicks, "planetary ruler");
+        // Leaders come as guests (not prisoners) with a hard return time.
+        this.PrepareClient(leader, targetTicks, "planetary ruler", sender, isPrisoner: false, contractDays: contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.Leaders;
-        this.DropClients(map, new List<Pawn> { leader }, "CryoRegenesis contract: ruler",
-            $"{leader.Name.ToStringShort}, a ruler over the age of 30, has arrived for a privately negotiated CryoRegenesis stay.");
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"{leader.Name.ToStringShort} of {sender.Name}, a ruler over the age of 30, has arrived by shuttle " +
+            $"for a privately negotiated CryoRegenesis stay. The shuttle returns on {returnText}. " +
+            "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            new List<Pawn> { leader },
+            sender,
+            "CryoRegenesis contract: ruler",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Planetary ruler",
+            letterBody,
+            sender,
+            isPrisoner: false);
     }
 
     private void StartLowerNobilityContract(Map map)
     {
         Faction empire = this.EmpireFaction();
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the lower nobility contract.");
+            return;
+        }
+
         Pawn pawn = this.GeneratePawn(this.LowerNoblePawnKind(), empire, Rand.RangeInclusive(31, 72));
         int targetAge = Rand.RangeInclusive(21, 40);
+        long targetTicks = targetAge * (long)GenDate.TicksPerYear;
+        int contractDays = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
 
-        this.PrepareClient(pawn, targetAge * (long)GenDate.TicksPerYear, "lower imperial noble");
+        this.PrepareClient(pawn, targetTicks, "lower imperial noble", empire, isPrisoner: false, contractDays: contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.LowerNobility;
-        this.DropClients(map, new List<Pawn> { pawn }, "Imperial CryoRegenesis contract",
-            $"The Empire has sent {pawn.Name.ToStringShort}, a lower noble, to verify your CryoRegenesis process.");
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Empire has sent {pawn.Name.ToStringShort}, a lower noble, by shuttle to verify your CryoRegenesis process. " +
+            $"They must return by {returnText}. Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            new List<Pawn> { pawn },
+            empire,
+            "Imperial CryoRegenesis contract",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Imperial noble",
+            letterBody,
+            empire,
+            isPrisoner: false);
     }
 
     private void StartStellarchContract(Map map)
     {
         Faction empire = this.EmpireFaction();
-        Pawn stellarch = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind()), empire, Rand.RangeInclusive(45, 85));
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the Stellarch contract.");
+            return;
+        }
+
+        Pawn stellarch = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(45, 85));
         this.TrySetRoyalTitle(stellarch, empire, "Stellarch");
 
         int targetAge = Rand.RangeInclusive(21, 35);
+        long targetTicks = targetAge * (long)GenDate.TicksPerYear;
         List<Pawn> party = new List<Pawn> { stellarch };
-        this.PrepareClient(stellarch, targetAge * (long)GenDate.TicksPerYear, "stellarch");
-        party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion"));
+        int contractDays = this.CalculateContractDays(stellarch.ageTracker.AgeBiologicalTicks - targetTicks);
+        this.PrepareClient(stellarch, targetTicks, "stellarch", empire, isPrisoner: false, contractDays: contractDays);
+        party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
 
         this.activeContractStage = RoyaltyRegenesisStage.StellarchArrival;
-        this.DropClients(map, party, "The Stellarch has arrived",
-            $"The Stellarch has arrived for CryoRegenesis and has chosen to regress to age {targetAge}. Any spouses or lovers in the party have chosen age 30.");
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Stellarch has arrived by shuttle for CryoRegenesis and has chosen to regress to age {targetAge}. " +
+            $"Any spouses or lovers in the party have chosen age 30. The imperial shuttle returns on {returnText}.";
+        this.DeliverClientsByShuttle(
+            map,
+            party,
+            empire,
+            "The Stellarch has arrived",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Stellarch",
+            letterBody,
+            empire,
+            isPrisoner: false);
     }
 
     private void StartEmperorContract(Map map)
     {
         Faction empire = this.EmpireFaction();
-        Pawn emperor = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind()), empire, Rand.RangeInclusive(60, 100));
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the Emperor contract.");
+            return;
+        }
+
+        Pawn emperor = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(60, 100));
         this.TrySetRoyalTitle(emperor, empire, "Emperor");
 
         List<Pawn> party = new List<Pawn> { emperor };
-        this.PrepareClient(emperor, 20L * GenDate.TicksPerYear, "emperor", triggerRoyalAscent: true);
-        party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion"));
+        long targetTicks = 20L * GenDate.TicksPerYear;
+        int contractDays = this.CalculateContractDays(emperor.ageTracker.AgeBiologicalTicks - targetTicks);
+        this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
+        party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
 
         this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
-        this.DropClients(map, party, "The Emperor has arrived",
-            "The Emperor has arrived for CryoRegenesis and will regress to age 20. Any spouses or lovers in the party have chosen age 21.");
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Emperor has arrived by shuttle for CryoRegenesis and will regress to age 20. " +
+            $"Any spouses or lovers in the party have chosen age 21. The imperial shuttle returns on {returnText}.";
+        this.DeliverClientsByShuttle(
+            map,
+            party,
+            empire,
+            "The Emperor has arrived",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: The Emperor",
+            letterBody,
+            empire,
+            isPrisoner: false);
     }
 
-    private List<Pawn> GetOrGeneratePartners(Pawn noble, Faction faction, int targetAge, string role)
+    private List<Pawn> GetOrGeneratePartners(Pawn noble, Faction faction, int targetAge, string role, bool isPrisoner, int contractDays)
     {
         List<Pawn> partners = noble.relations?.DirectRelations
             ?.Where(relation =>
@@ -284,7 +456,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (!partners.Any() && Rand.Chance(0.65f))
         {
-            Pawn spouse = this.GeneratePawn(this.NoblePawnKind(), faction, Rand.RangeInclusive(35, 80));
+            Pawn spouse = this.GeneratePawn(this.NoblePawnKind(faction), faction, Rand.RangeInclusive(35, 80));
             noble.relations.AddDirectRelation(PawnRelationDefOf.Spouse, spouse);
             partners.Add(spouse);
         }
@@ -296,25 +468,38 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
                 partner.ageTracker.AgeBiologicalTicks = Rand.RangeInclusive(targetAge + 10, targetAge + 45) * (long)GenDate.TicksPerYear;
             }
 
-            this.PrepareClient(partner, targetAge * (long)GenDate.TicksPerYear, role);
+            this.PrepareClient(partner, targetAge * (long)GenDate.TicksPerYear, role, faction, isPrisoner, contractDays);
         }
 
         return partners;
     }
 
-    private void PrepareClient(Pawn pawn, long desiredAgeTicks, string role, bool triggerRoyalAscent = false)
+    private void PrepareClient(
+        Pawn pawn,
+        long desiredAgeTicks,
+        string role,
+        Faction sourceFaction,
+        bool isPrisoner,
+        int contractDays,
+        bool triggerRoyalAscent = false)
     {
         desiredAgeTicks = Math.Max(0, Math.Min(desiredAgeTicks, pawn.ageTracker.AgeBiologicalTicks));
         TrueAgeTracker tracker = RegenesisThoughts.GetOrAddTrueAgeTracker(pawn, pawn.ageTracker.AgeBiologicalTicks);
         if (tracker != null)
         {
             tracker.desiredAgeTicks = desiredAgeTicks;
+            tracker.underRegenContract = true;
         }
 
-        if (!pawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+        this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner);
+        this.LockRecruitment(pawn);
+
+        if (isPrisoner && !pawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
         {
             pawn.health.AddHediff(HediffDefOf.Anesthetic);
         }
+
+        int returnByTick = Find.TickManager.TicksGame + Math.Max(MinContractDays, contractDays) * GenDate.TicksPerDay;
 
         this.activeClients.Add(new RoyaltyRegenesisClient
         {
@@ -322,14 +507,250 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             desiredAgeTicks = desiredAgeTicks,
             role = role,
             triggerRoyalAscent = triggerRoyalAscent,
+            returnByTick = returnByTick,
+            isPrisoner = isPrisoner,
+            sourceFaction = sourceFaction,
         });
     }
 
-    private void DropClients(Map map, List<Pawn> pawns, string label, string text)
+    private void ApplyGuestOrPrisonerStatus(Pawn pawn, bool isPrisoner)
     {
-        IntVec3 cell = DropCellFinder.RandomDropSpot(map);
-        DropPodUtility.DropThingsNear(cell, map, pawns.Cast<Thing>());
+        if (pawn?.guest == null)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        pawn.guest.SetGuestStatus(Faction.OfPlayer, isPrisoner);
+#else
+        pawn.guest.SetGuestStatus(Faction.OfPlayer, isPrisoner ? GuestStatus.Prisoner : GuestStatus.Guest);
+#endif
+
+        if (isPrisoner)
+        {
+#if RIMWORLD12 || RIMWORLD13 || RIMWORLD14
+            pawn.guest.interactionMode = PrisonerInteractionModeDefOf.NoInteraction;
+#else
+            // 1.5+: exclusive interaction modes; block recruitment attempts.
+            pawn.guest.SetNoInteraction();
+#endif
+#if !RIMWORLD12 && !RIMWORLD13
+            // Keep resistance high so they never "break" into recruitability.
+            if (pawn.guest.resistance < 50f)
+            {
+                pawn.guest.resistance = 99f;
+            }
+#endif
+        }
+    }
+
+    private void LockRecruitment(Pawn pawn)
+    {
+        if (pawn?.guest == null)
+        {
+            return;
+        }
+
+#if !RIMWORLD12 && !RIMWORLD13
+        pawn.guest.Recruitable = false;
+#endif
+    }
+
+    private int CalculateContractDays(long bioTicksToRemove)
+    {
+        // Treatment is fast in-casket, but contracts are narrative stays with a hard pickup.
+        double years = Math.Max(0.25, (double)bioTicksToRemove / GenDate.TicksPerYear);
+        int days = (int)Math.Ceiling(8 + years * 4);
+        return Math.Max(MinContractDays, Math.Min(MaxContractDays, days));
+    }
+
+    private string FormatReturnDeadline(int contractDays)
+    {
+        int returnTick = Find.TickManager.TicksGame + contractDays * GenDate.TicksPerDay;
+        return GenDate.DateFullStringAt(returnTick, Find.WorldGrid.LongLatOf(Find.CurrentMap?.Tile ?? 0));
+    }
+
+    private void DeliverClientsByShuttle(Map map, List<Pawn> pawns, Faction faction, string label, string text)
+    {
+        if (map == null || pawns == null || !pawns.Any())
+        {
+            return;
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+
+#if RIMWORLD12
+        this.DeliverByLegacyShuttle(map, pawns, faction, cell);
+#else
+        this.DeliverByTransportShip(map, pawns, faction, cell);
+#endif
+
         Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent, new LookTargets(pawns));
+    }
+
+#if RIMWORLD12
+    private void DeliverByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    {
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        if (transporter != null)
+        {
+            transporter.innerContainer.TryAddRangeOrTransfer(pawns.Cast<Thing>().ToList(), true, true);
+        }
+
+        if (compShuttle != null)
+        {
+            compShuttle.dropEverythingOnArrival = true;
+            compShuttle.leaveAfterTicks = GenDate.TicksPerHour;
+        }
+
+        Skyfaller skyfaller = SkyfallerMaker.MakeSkyfaller(ThingDefOf.ShuttleIncoming, shuttle);
+        GenPlace.TryPlaceThing(skyfaller, cell, map, ThingPlaceMode.Near);
+    }
+
+    private void DepartByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction)
+    {
+        this.EjectClientsFromCaskets(map, pawns);
+
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+        GenPlace.TryPlaceThing(shuttle, cell, map, ThingPlaceMode.Near);
+
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        foreach (Pawn pawn in pawns.Where(p => p != null && !p.Destroyed))
+        {
+            this.TransferPawnIntoTransporter(pawn, transporter);
+        }
+
+        if (compShuttle != null)
+        {
+            if (transporter != null && !transporter.LoadingInProgressOrReadyToLaunch)
+            {
+                TransporterUtility.InitiateLoading(Gen.YieldSingle(transporter));
+            }
+
+            compShuttle.Send();
+        }
+    }
+#else
+    private void DeliverByTransportShip(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    {
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        TransportShip ship = TransportShipMaker.MakeTransportShip(
+            TransportShipDefOf.Ship_Shuttle,
+            pawns.Cast<Thing>(),
+            shuttle);
+        ship.ArriveAt(cell, map.Parent);
+        ship.AddJobs(ShipJobDefOf.Unload, ShipJobDefOf.FlyAway);
+    }
+
+    private void DepartByTransportShip(Map map, List<Pawn> pawns, Faction faction)
+    {
+        this.EjectClientsFromCaskets(map, pawns);
+
+        List<Pawn> living = pawns.Where(p => p != null && !p.Destroyed && !p.Dead).ToList();
+        if (!living.Any())
+        {
+            return;
+        }
+
+        // Collect clients into the shuttle immediately so pickup is guaranteed.
+        List<Thing> cargo = new List<Thing>();
+        foreach (Pawn pawn in living)
+        {
+            if (pawn.Spawned)
+            {
+                pawn.DeSpawn(DestroyMode.Vanish);
+            }
+            else if (pawn.ParentHolder is Building_CryoRegenesis casket)
+            {
+                casket.EjectContents();
+                if (pawn.Spawned)
+                {
+                    pawn.DeSpawn(DestroyMode.Vanish);
+                }
+            }
+            else if (pawn.ParentHolder is IThingHolder holder && holder != Find.WorldPawns)
+            {
+                // Leave other holders if transfer fails later.
+            }
+
+            cargo.Add(pawn);
+        }
+
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+        TransportShip ship = TransportShipMaker.MakeTransportShip(
+            TransportShipDefOf.Ship_Shuttle,
+            cargo,
+            shuttle);
+        ship.ArriveAt(cell, map.Parent);
+        // Already loaded: do not unload; leave immediately.
+        ship.AddJob(ShipJobDefOf.FlyAway);
+    }
+#endif
+
+    private void EjectClientsFromCaskets(Map map, List<Pawn> pawns)
+    {
+        if (map == null)
+        {
+            return;
+        }
+
+        foreach (Building_CryoRegenesis casket in map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>())
+        {
+            if (casket.ContainedThing is Pawn contained && pawns.Contains(contained))
+            {
+                casket.EjectContents();
+            }
+        }
+    }
+
+    private void TransferPawnIntoTransporter(Pawn pawn, CompTransporter transporter)
+    {
+        if (pawn == null || transporter == null)
+        {
+            return;
+        }
+
+        if (pawn.Spawned)
+        {
+            pawn.DeSpawn(DestroyMode.Vanish);
+        }
+
+        transporter.innerContainer.TryAddOrTransfer(pawn, true);
+    }
+
+    private IntVec3 FindShuttleLandingCell(Map map, Faction faction)
+    {
+        Faction landingFaction = faction ?? Faction.OfPlayer;
+#if RIMWORLD12
+        return DropCellFinder.TradeDropSpot(map);
+#else
+        return DropCellFinder.GetBestShuttleLandingSpot(map, landingFaction);
+#endif
     }
 
     private void CheckActiveClients()
@@ -342,34 +763,118 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.activeClients.RemoveAll(client => client?.pawn == null || client.pawn.Destroyed);
         if (!this.activeClients.Any())
         {
-            this.ScheduleRetry("CryoRegenesis contract lost", "The active CryoRegenesis client could no longer be found.");
+            this.MajorTrustReset(
+                "CryoRegenesis clients vanished under contract. Trust is lost — the chain resets.",
+                null,
+                "Contract clients lost");
             return;
+        }
+
+        // Keep recruitment locked for the entire stay.
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            this.LockRecruitment(client.pawn);
+            if (client.pawn?.guest != null && client.isPrisoner && !client.pawn.IsPrisoner)
+            {
+                this.ApplyGuestOrPrisonerStatus(client.pawn, isPrisoner: true);
+            }
         }
 
         if (this.activeClients.Any(client => client.pawn.Dead))
         {
-            this.activeClients.Clear();
-            this.ScheduleRetry("CryoRegenesis contract failed", "A Royalty CryoRegenesis client died before the requested age regression was completed.");
+            Pawn dead = this.activeClients.First(client => client.pawn.Dead).pawn;
+            Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction;
+            List<Pawn> survivors = this.activeClients
+                .Where(client => client.pawn != null && !client.pawn.Dead)
+                .Select(client => client.pawn)
+                .ToList();
+            Map map = survivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+            if (map != null && survivors.Any())
+            {
+                this.DepartClients(map, survivors, sender);
+            }
+
+            this.MajorTrustReset(
+                $"{dead.Name.ToStringShort} died under a CryoRegenesis return contract. " +
+                "Trust is shattered — all progress is lost and the chain restarts from the beginning.",
+                sender,
+                "Client died under contract");
             return;
         }
 
-        if (this.activeClients.Any(client => !this.ClientReachedDesiredAge(client)))
+        bool allDone = this.activeClients.All(this.ClientReachedDesiredAge);
+        bool deadlineReached = this.activeClients.Any(client => Find.TickManager.TicksGame >= client.returnByTick);
+
+        if (!allDone && !deadlineReached)
         {
             return;
         }
 
         bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
+        List<Pawn> departing = this.activeClients.Select(client => client.pawn).Where(p => p != null).ToList();
+        Faction sourceFaction = this.activeClients.FirstOrDefault()?.sourceFaction;
+        Map targetMap = departing.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+
+        bool success = allDone;
+        this.ClearContractFlags(this.activeClients);
+
+        if (targetMap != null && departing.Any())
+        {
+            this.DepartClients(targetMap, departing, sourceFaction);
+        }
+
         this.activeClients.Clear();
 
-        if (triggerEndgame)
+        if (triggerEndgame && success)
         {
+            this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.stage = RoyaltyRegenesisStage.Completed;
             this.royalAscentTriggered = true;
+            this.CompleteChainQuest();
             this.TryMakeRoyalAscentAvailable();
             return;
         }
 
-        this.CompleteActiveContract();
+        if (success)
+        {
+            this.EndActiveContractQuest(QuestEndOutcome.Success);
+            this.CompleteActiveContract();
+        }
+        else
+        {
+            // Soft failure: contract fails, stage progress kept, no full chain reset.
+            this.EndActiveContractQuest(QuestEndOutcome.Fail);
+            this.ScheduleRetry(
+                "CryoRegenesis contract expired",
+                "The pickup shuttle returned before the requested regression was finished. The clients have left. Another attempt may come later.");
+        }
+    }
+
+    private void DepartClients(Map map, List<Pawn> pawns, Faction faction)
+    {
+#if RIMWORLD12
+        this.DepartByLegacyShuttle(map, pawns, faction);
+#else
+        this.DepartByTransportShip(map, pawns, faction);
+#endif
+    }
+
+    private void ClearContractFlags(IEnumerable<RoyaltyRegenesisClient> clients)
+    {
+        foreach (RoyaltyRegenesisClient client in clients)
+        {
+            if (client?.pawn == null)
+            {
+                continue;
+            }
+
+            TrueAgeTracker tracker = client.pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            if (tracker != null)
+            {
+                tracker.underRegenContract = false;
+            }
+        }
     }
 
     private bool ClientReachedDesiredAge(RoyaltyRegenesisClient client)
@@ -403,6 +908,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
                 }
                 else
                 {
+                    // Only after other factions succeed does the Empire take interest.
                     this.stage = RoyaltyRegenesisStage.LowerNobility;
                     this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
                 }
@@ -429,7 +935,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
         Find.LetterStack.ReceiveLetter(
             "CryoRegenesis contract complete",
-            "The Royalty CryoRegenesis client has reached the requested regression age.",
+            "The CryoRegenesis clients reached the requested regression age and have departed by shuttle. Check the Quests tab for chain progress.",
             LetterDefOf.PositiveEvent);
     }
 
@@ -437,11 +943,308 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     {
         Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NegativeEvent);
         this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
     }
 
     private void SendTravelNotice(string label, string text)
     {
         Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent);
+        this.EnsureChainQuest();
+    }
+
+    public void NotifyClientRecruited(Pawn recruitee)
+    {
+        RoyaltyRegenesisClient client = this.activeClients.FirstOrDefault(c => c?.pawn == recruitee);
+        if (client == null)
+        {
+            return;
+        }
+
+        Faction faction = client.sourceFaction;
+
+        // Return any remaining contracted clients; the recruited one stays as a colonist.
+        List<Pawn> survivors = this.activeClients
+            .Where(c => c?.pawn != null && c.pawn != recruitee && !c.pawn.Dead)
+            .Select(c => c.pawn)
+            .ToList();
+        Map map = survivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+        if (map != null && survivors.Any())
+        {
+            this.DepartClients(map, survivors, faction);
+        }
+
+        this.MajorTrustReset(
+            $"{recruitee.Name.ToStringShort} was recruited while under a CryoRegenesis return contract. " +
+            $"{(faction?.Name ?? "Their faction")} considers this a betrayal — trust is lost and the chain resets.",
+            faction,
+            "Contract client recruited");
+    }
+
+    public string GetChainProgressDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(this.GetStageLabel(this.stage));
+        sb.AppendLine();
+        sb.AppendLine("Progress:");
+        sb.AppendLine("• Prisoner trials: " + this.rulerContractsCompleted + " / 3");
+        sb.AppendLine("• Planetary rulers: " + this.leaderContractsCompleted + " / 2");
+        sb.AppendLine("• Imperial nobles: " + this.nobleContractsCompleted + " / 2");
+        sb.AppendLine("• Stellarch: " + (this.stage > RoyaltyRegenesisStage.StellarchArrival || this.stage == RoyaltyRegenesisStage.Completed ? "done" : "pending"));
+        sb.AppendLine("• Emperor: " + (this.stage == RoyaltyRegenesisStage.Completed ? "done" : "pending"));
+
+        if (this.trustBreaks > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Trust breaks: " + this.trustBreaks);
+            if (!this.lastTrustBreakReason.NullOrEmpty())
+            {
+                sb.AppendLine("Last setback: " + this.lastTrustBreakReason);
+            }
+        }
+
+        if (this.activeClients.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("Active contract clients: " + this.activeClients.Count);
+            int earliestReturn = this.activeClients.Min(c => c.returnByTick);
+            sb.AppendLine("Next return deadline: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn));
+        }
+        else if (this.stage != RoyaltyRegenesisStage.Completed && this.nextEventTick > Find.TickManager.TicksGame)
+        {
+            int days = (this.nextEventTick - Find.TickManager.TicksGame + GenDate.TicksPerDay - 1) / GenDate.TicksPerDay;
+            sb.AppendLine();
+            sb.AppendLine("Next event in about " + days + " day(s).");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public string GetContractProgressDescription()
+    {
+        if (!this.activeClients.Any())
+        {
+            return "No active CryoRegenesis clients on this contract.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        int earliestReturn = this.activeClients.Min(c => c.returnByTick);
+        int ticksLeft = Math.Max(0, earliestReturn - Find.TickManager.TicksGame);
+        sb.AppendLine("Return shuttle: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn)
+            + " (" + ticksLeft.ToStringTicksToPeriod() + " remaining)");
+        sb.AppendLine();
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client?.pawn == null)
+            {
+                continue;
+            }
+
+            Pawn pawn = client.pawn;
+            int currentYears = pawn.ageTracker.AgeBiologicalYears;
+            int targetYears = (int)(client.desiredAgeTicks / GenDate.TicksPerYear);
+            bool done = this.ClientReachedDesiredAge(client);
+            string location = pawn.ParentHolder is Building_CryoRegenesis
+                ? "in CryoRegenesis"
+                : (pawn.Spawned ? "on map" : "held");
+
+            sb.AppendLine("• " + pawn.Name.ToStringShort
+                + " — bio " + currentYears + " → " + targetYears
+                + (done ? " [ready]" : " [treating]")
+                + " (" + location + ")");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine(this.activeClients.All(this.ClientReachedDesiredAge)
+            ? "All clients ready for return."
+            : "Keep treating until each client reaches their target age before pickup.");
+        return sb.ToString().TrimEnd();
+    }
+
+    private void EnsureChainQuest()
+    {
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            return;
+        }
+
+        // Recover an existing ongoing chain quest after load if needed.
+        Quest existing = Find.QuestManager.QuestsListForReading.FirstOrDefault(q =>
+            q != null &&
+            !q.Historical &&
+            q.root != null &&
+            q.root.defName == RoyaltyRegenesisQuestFactory.ChainQuestDefName);
+
+        if (existing != null)
+        {
+            this.chainQuest = existing;
+            return;
+        }
+
+        this.chainQuest = RoyaltyRegenesisQuestFactory.MakeChainQuest();
+    }
+
+    private void BeginContractQuest(string title, string roleSummary, Faction sender, bool isPrisoner)
+    {
+        this.EnsureChainQuest();
+        this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
+
+        int returnByTick = this.activeClients.Any()
+            ? this.activeClients.Max(c => c.returnByTick)
+            : Find.TickManager.TicksGame + MinContractDays * GenDate.TicksPerDay;
+
+        string description = RoyaltyRegenesisQuestFactory.BuildContractDescription(
+            roleSummary,
+            sender,
+            isPrisoner,
+            returnByTick,
+            this.activeClients.Select(c => c.pawn));
+
+        this.activeContractQuest = RoyaltyRegenesisQuestFactory.MakeContractQuest(
+            title,
+            description,
+            this.chainQuest);
+    }
+
+    private void EndActiveContractQuest(QuestEndOutcome outcome, bool sendLetter = true)
+    {
+        RoyaltyRegenesisQuestFactory.EndQuestSafe(this.activeContractQuest, outcome, sendLetter);
+        this.activeContractQuest = null;
+    }
+
+    private void CompleteChainQuest()
+    {
+        this.EnsureChainQuest();
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            this.chainQuest.description =
+                RoyaltyRegenesisQuestFactory.BuildChainDescriptionBody()
+                + "\n\nThe Emperor has been rejuvenated. The Imperial Rejuvenation chain is complete.";
+            RoyaltyRegenesisQuestFactory.EndQuestSafe(this.chainQuest, QuestEndOutcome.Success);
+        }
+
+        this.chainQuest = null;
+    }
+
+    /// <summary>
+    /// Death, recruitment, or loss of clients: fail the contract, wipe chain progress,
+    /// and force a long cooldown before anyone will trust you again.
+    /// </summary>
+    private void MajorTrustReset(string letterText, Faction offendedFaction, string shortReason)
+    {
+        this.EndActiveContractQuest(QuestEndOutcome.Fail);
+
+        this.ClearContractFlags(this.activeClients);
+        this.activeClients.Clear();
+
+        this.trustBreaks++;
+        this.lastTrustBreakReason = shortReason;
+        this.rulerContractsCompleted = 0;
+        this.leaderContractsCompleted = 0;
+        this.nobleContractsCompleted = 0;
+        this.royalAscentTriggered = false;
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+        this.nextEventTick = Find.TickManager.TicksGame
+            + Rand.RangeInclusive(MajorResetMinDays, MajorResetMaxDays) * GenDate.TicksPerDay;
+
+        if (offendedFaction != null && offendedFaction != Faction.OfPlayer)
+        {
+            this.ApplyTrustBreakGoodwillPenalty(offendedFaction);
+        }
+
+        this.EnsureChainQuest();
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            this.chainQuest.description =
+                RoyaltyRegenesisQuestFactory.BuildChainDescriptionBody()
+                + "\n\nTRUST BROKEN: " + shortReason
+                + "\nAll stage progress has been reset. Foreign and imperial patrons will only return after a long cooling-off period.";
+        }
+
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis trust lost",
+            letterText + "\n\nThe Quests tab shows the chain restarting from the beginning.",
+            LetterDefOf.NegativeEvent);
+    }
+
+    private string GetStageLabel(RoyaltyRegenesisStage current)
+    {
+        switch (current)
+        {
+            case RoyaltyRegenesisStage.NotStarted:
+                return "Stage: not started";
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                return "Stage: foreign prisoner trials (before Empire notice)";
+            case RoyaltyRegenesisStage.Leaders:
+                return "Stage: planetary rulers (before Empire notice)";
+            case RoyaltyRegenesisStage.LowerNobility:
+                return "Stage: Empire lower nobility";
+            case RoyaltyRegenesisStage.StellarchNotice:
+                return "Stage: Stellarch en route";
+            case RoyaltyRegenesisStage.StellarchArrival:
+                return "Stage: Stellarch contract";
+            case RoyaltyRegenesisStage.EmperorNotice:
+                return "Stage: Emperor en route";
+            case RoyaltyRegenesisStage.EmperorArrival:
+                return "Stage: Emperor contract";
+            case RoyaltyRegenesisStage.Completed:
+                return "Stage: complete";
+            default:
+                return "Stage: " + current;
+        }
+    }
+
+    private void ApplyTrustBreakGoodwillPenalty(Faction faction)
+    {
+        if (faction == null || faction == Faction.OfPlayer)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            DeathTrustGoodwillPenalty,
+            true,
+            true,
+            "CryoRegenesis trust broken",
+            null);
+#else
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            DeathTrustGoodwillPenalty,
+            true,
+            true,
+            HistoryEventDefOf.MemberKilled,
+            null);
+#endif
+    }
+
+    private void ApplyRecruitmentGoodwillPenalty(Faction faction, Pawn pawn)
+    {
+        if (faction == null || faction == Faction.OfPlayer)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            RecruitGoodwillPenalty,
+            true,
+            true,
+            "Recruited CryoRegenesis contract client",
+            pawn);
+#else
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            RecruitGoodwillPenalty,
+            true,
+            true,
+            HistoryEventDefOf.MemberCaptured,
+            pawn);
+#endif
     }
 
     private Pawn GeneratePawn(PawnKindDef kind, Faction faction, int biologicalAge)
@@ -452,21 +1255,32 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return PawnGenerator.GeneratePawn(request);
     }
 
-    private PawnKindDef CommonPawnKind()
+    private PawnKindDef CommonPawnKind(Faction faction = null)
     {
+        if (faction?.def?.basicMemberKind != null)
+        {
+            return faction.def.basicMemberKind;
+        }
+
         return this.NamedPawnKind("Empire_Common_Lodger", this.AnyHumanPawnKind());
     }
 
-    private PawnKindDef NoblePawnKind()
+    private PawnKindDef NoblePawnKind(Faction faction = null)
     {
-        return this.NamedPawnKind("Empire_Royal_NobleWimp", this.CommonPawnKind());
+        if (faction != null && !this.IsEmpire(faction) && faction.def.basicMemberKind != null)
+        {
+            // Prefer the faction's own member kinds for non-Empire leaders.
+            return faction.def.basicMemberKind;
+        }
+
+        return this.NamedPawnKind("Empire_Royal_NobleWimp", this.CommonPawnKind(faction));
     }
 
     private PawnKindDef LowerNoblePawnKind()
     {
         return this.NamedPawnKind(
             Rand.Element("Empire_Royal_Yeoman", "Empire_Royal_Esquire", "Empire_Royal_Knight"),
-            this.NoblePawnKind());
+            this.NoblePawnKind(this.EmpireFaction()));
     }
 
     private PawnKindDef NamedPawnKind(string defName, PawnKindDef fallback)
@@ -492,19 +1306,93 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             }
         }
 
-        return this.RandomNonPlayerFaction();
+        return null;
     }
 
-    private Faction RandomNonPlayerFaction()
+    /// <summary>
+    /// Other planetary factions only — never Ancients, never Empire.
+    /// Empire contracts begin only after these succeed.
+    /// </summary>
+    private Faction RandomPlanetarySenderFaction()
     {
         return Find.FactionManager.AllFactionsListForReading
-            .Where(faction =>
-                faction != null &&
-                faction != Faction.OfPlayer &&
-                !faction.defeated &&
-                !faction.HostileTo(Faction.OfPlayer) &&
-                faction.def.humanlikeFaction)
+            .Where(this.IsEligiblePlanetarySender)
             .RandomElementWithFallback(null);
+    }
+
+    private bool IsEligiblePlanetarySender(Faction faction)
+    {
+        if (faction == null || faction == Faction.OfPlayer || faction.defeated)
+        {
+            return false;
+        }
+
+        if (!faction.def.humanlikeFaction)
+        {
+            return false;
+        }
+
+        if (faction.HostileTo(Faction.OfPlayer))
+        {
+            return false;
+        }
+
+        if (faction.Hidden)
+        {
+            return false;
+        }
+
+        if (this.IsEmpire(faction) || this.IsAncient(faction))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsEmpire(Faction faction)
+    {
+        if (faction?.def == null)
+        {
+            return false;
+        }
+
+        if (faction.def.defName == "Empire")
+        {
+            return true;
+        }
+
+        try
+        {
+            return faction.def == FactionDefOf.Empire;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool IsAncient(Faction faction)
+    {
+        if (faction?.def == null)
+        {
+            return false;
+        }
+
+        string defName = faction.def.defName;
+        if (defName == "Ancients" || defName == "AncientsHostile")
+        {
+            return true;
+        }
+
+        try
+        {
+            return faction.def == FactionDefOf.Ancients || faction.def == FactionDefOf.AncientsHostile;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private void TrySetRoyalTitle(Pawn pawn, Faction faction, string titleDefName)
@@ -569,7 +1457,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     {
         Find.LetterStack.ReceiveLetter(
             "Imperial CryoRegenesis complete",
-            "The Emperor has reached age 20. Royal Ascent shuttle endgame protocols are now being activated.",
+            "The Emperor has reached age 20 and departed by shuttle. Royal Ascent endgame protocols are now being activated.",
             LetterDefOf.PositiveEvent);
 
         QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");
@@ -652,6 +1540,9 @@ public class RoyaltyRegenesisClient : IExposable
     public long desiredAgeTicks;
     public string role;
     public bool triggerRoyalAscent;
+    public int returnByTick;
+    public bool isPrisoner;
+    public Faction sourceFaction;
 
     public void ExposeData()
     {
@@ -659,6 +1550,9 @@ public class RoyaltyRegenesisClient : IExposable
         Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
         Scribe_Values.Look(ref this.role, "role");
         Scribe_Values.Look(ref this.triggerRoyalAscent, "triggerRoyalAscent", false);
+        Scribe_Values.Look(ref this.returnByTick, "returnByTick", 0);
+        Scribe_Values.Look(ref this.isPrisoner, "isPrisoner", false);
+        Scribe_References.Look(ref this.sourceFaction, "sourceFaction");
     }
 }
 
@@ -715,15 +1609,74 @@ public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
 
     protected override void RunInt()
     {
-        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
-            ?.DebugStartAt(RoyaltyRegenesisStage.RulerPrisoners);
-
-        QuestPart_QuestEnd endPart = new QuestPart_QuestEnd
+        // Prefer the GameComponent path; this node exists so the script def is valid
+        // if generated by the storyteller. The persistent quest is created by the system.
+        RoyaltyRegenesisQuestSystem system = Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>();
+        if (system == null)
         {
-            inSignal = QuestGen.quest.InitiateSignal,
-            outcome = QuestEndOutcome.Success,
-            sendLetter = false,
-        };
-        QuestGen.quest.AddPart(endPart);
+            return;
+        }
+
+        system.DebugStartAt(RoyaltyRegenesisStage.RulerPrisoners);
+    }
+}
+
+/// <summary>
+/// Placeholder root for per-contract quest script defs. Real contract quests are built in code.
+/// </summary>
+public class QuestNode_RoyaltyRegenesisContractPlaceholder : QuestNode
+{
+    protected override bool TestRunInt(Slate slate)
+    {
+        return true;
+    }
+
+    protected override void RunInt()
+    {
+    }
+}
+
+/// <summary>
+/// Regen-contract pawns never recruit voluntarily. If recruitment still happens,
+/// punish relations with their sending faction.
+/// </summary>
+[HarmonyPatch]
+public static class Patch_DoRecruit_RegenContract
+{
+    private static MethodBase TargetMethod()
+    {
+        // Prefer the full overload used by all recruit paths.
+        MethodInfo full = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[]
+            {
+                typeof(Pawn),
+                typeof(Pawn),
+                typeof(string).MakeByRefType(),
+                typeof(string).MakeByRefType(),
+                typeof(bool),
+                typeof(bool),
+            });
+
+        if (full != null)
+        {
+            return full;
+        }
+
+        return AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[] { typeof(Pawn), typeof(Pawn), typeof(bool) });
+    }
+
+    public static void Prefix(Pawn recruiter, Pawn recruitee)
+    {
+        if (!RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(recruitee))
+        {
+            return;
+        }
+
+        RoyaltyRegenesisQuestSystem.CurrentSystem?.NotifyClientRecruited(recruitee);
     }
 }

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1641,11 +1641,56 @@ public class QuestNode_RoyaltyRegenesisContractPlaceholder : QuestNode
 /// punish relations with their sending faction.
 /// </summary>
 [HarmonyPatch]
+/*
+ * CRITICAL — TargetMethod() MUST resolve on EVERY supported RimWorld version
+ * or this patch (and historically the whole assembly) fails to apply.
+ *
+ * Incident (2026-07, RW 1.2):
+ *   This patch originally looked up only the 1.3+ DoRecruit overloads
+ *   (no float recruitChance). On 1.2, AccessTools.Method returned null,
+ *   harmony.PatchAll() threw, and *all* mod Harmony patches failed to apply —
+ *   including Carry-to-CryoRegenesis float menu orders.
+ *
+ * Signature shapes:
+ *   1.2:     DoRecruit(Pawn, Pawn, float recruitChance, out string, out string, bool, bool)
+ *            DoRecruit(Pawn, Pawn, float recruitChance, bool)
+ *   1.3–1.6: DoRecruit(Pawn, Pawn, out string, out string, bool, bool)
+ *            DoRecruit(Pawn, Pawn, bool)
+ *
+ * Rules:
+ *   - Always try the 1.2 (float) overloads first, then 1.3+ shapes.
+ *   - Never return null from TargetMethod without a compile-time version gate;
+ *     a null target aborts batch PatchAll (mitigated in CryoRegenesis ctor by
+ *     per-type CreateClassProcessor, but a null target still means THIS patch
+ *     never runs).
+ *   - After any DoRecruit / recruit API change, boot RW 1.2 and confirm no
+ *     "[CryoRegenesis] Harmony patch failed on ...Patch_DoRecruit_RegenContract".
+ */
 public static class Patch_DoRecruit_RegenContract
 {
     private static MethodBase TargetMethod()
     {
-        // Prefer the full overload used by all recruit paths.
+        // RimWorld 1.2: DoRecruit(..., float recruitChance, out string, out string, bool, bool)
+        MethodInfo rw12 = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[]
+            {
+                typeof(Pawn),
+                typeof(Pawn),
+                typeof(float),
+                typeof(string).MakeByRefType(),
+                typeof(string).MakeByRefType(),
+                typeof(bool),
+                typeof(bool),
+            });
+
+        if (rw12 != null)
+        {
+            return rw12;
+        }
+
+        // RimWorld 1.3+: recruitChance argument was removed.
         MethodInfo full = AccessTools.Method(
             typeof(InteractionWorker_RecruitAttempt),
             nameof(InteractionWorker_RecruitAttempt.DoRecruit),
@@ -1662,6 +1707,17 @@ public static class Patch_DoRecruit_RegenContract
         if (full != null)
         {
             return full;
+        }
+
+        // Last-resort short overloads.
+        MethodInfo short12 = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[] { typeof(Pawn), typeof(Pawn), typeof(float), typeof(bool) });
+
+        if (short12 != null)
+        {
+            return short12;
         }
 
         return AccessTools.Method(

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1,0 +1,729 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using RimWorld;
+using RimWorld.QuestGen;
+using Verse;
+
+#if RIMWORLD15 || RIMWORLD16
+using LudeonTK;
+#endif
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class RoyaltyRegenesisQuestSystem : GameComponent
+{
+    private const int CheckIntervalTicks = 2500;
+    private const int HalfYearTicks = GenDate.TicksPerYear / 2;
+
+    private RoyaltyRegenesisStage stage = RoyaltyRegenesisStage.NotStarted;
+    private RoyaltyRegenesisStage activeContractStage = RoyaltyRegenesisStage.NotStarted;
+    private int nextEventTick = -1;
+    private int rulerContractsCompleted;
+    private int leaderContractsCompleted;
+    private int nobleContractsCompleted;
+    private bool royalAscentTriggered;
+    private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
+
+    public RoyaltyRegenesisQuestSystem(Game game)
+    {
+    }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+
+        Scribe_Values.Look(ref this.stage, "crRoyalStage", RoyaltyRegenesisStage.NotStarted);
+        Scribe_Values.Look(ref this.activeContractStage, "crRoyalActiveContractStage", RoyaltyRegenesisStage.NotStarted);
+        Scribe_Values.Look(ref this.nextEventTick, "crRoyalNextEventTick", -1);
+        Scribe_Values.Look(ref this.rulerContractsCompleted, "crRoyalRulerContractsCompleted", 0);
+        Scribe_Values.Look(ref this.leaderContractsCompleted, "crRoyalLeaderContractsCompleted", 0);
+        Scribe_Values.Look(ref this.nobleContractsCompleted, "crRoyalNobleContractsCompleted", 0);
+        Scribe_Values.Look(ref this.royalAscentTriggered, "crRoyalAscentTriggered", false);
+        Scribe_Collections.Look(ref this.activeClients, "crRoyalActiveClients", LookMode.Deep);
+
+        if (Scribe.mode == LoadSaveMode.PostLoadInit && this.activeClients == null)
+        {
+            this.activeClients = new List<RoyaltyRegenesisClient>();
+        }
+    }
+
+    public override void GameComponentTick()
+    {
+        base.GameComponentTick();
+
+        if (!ModsConfig.RoyaltyActive)
+        {
+            return;
+        }
+
+        if (Find.TickManager.TicksGame % CheckIntervalTicks != 0)
+        {
+            return;
+        }
+
+        if (!this.CanRunCampaign())
+        {
+            return;
+        }
+
+        this.CheckActiveClients();
+
+        if (this.activeClients.Any())
+        {
+            return;
+        }
+
+        int ticksGame = Find.TickManager.TicksGame;
+        if (this.stage == RoyaltyRegenesisStage.NotStarted)
+        {
+            this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+            this.nextEventTick = ticksGame + Rand.RangeInclusive(3, 8) * GenDate.TicksPerDay;
+        }
+
+        if (this.stage != RoyaltyRegenesisStage.Completed && ticksGame >= this.nextEventTick)
+        {
+            this.AdvanceCampaign();
+        }
+    }
+
+    private bool CanRunCampaign()
+    {
+        return Find.Maps.Any(map =>
+            map.IsPlayerHome &&
+            map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any());
+    }
+
+    private Map GetTargetMap()
+    {
+        return Find.Maps.FirstOrDefault(map =>
+            map.IsPlayerHome &&
+            map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any());
+    }
+
+    private void AdvanceCampaign()
+    {
+        Map map = this.GetTargetMap();
+        if (map == null)
+        {
+            this.nextEventTick = Find.TickManager.TicksGame + GenDate.TicksPerDay;
+            return;
+        }
+
+        switch (this.stage)
+        {
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                this.StartRulerPrisonerContract(map);
+                break;
+            case RoyaltyRegenesisStage.Leaders:
+                this.StartLeaderContract(map);
+                break;
+            case RoyaltyRegenesisStage.LowerNobility:
+                this.StartLowerNobilityContract(map);
+                break;
+            case RoyaltyRegenesisStage.StellarchNotice:
+                this.SendTravelNotice(
+                    "The Stellarch has taken notice",
+                    "Reports of successful CryoRegenesis treatments have reached the Stellarch. An imperial shuttle has departed. It should arrive in several days.");
+                this.stage = RoyaltyRegenesisStage.StellarchArrival;
+                this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(3, 8) * GenDate.TicksPerDay;
+                break;
+            case RoyaltyRegenesisStage.StellarchArrival:
+                this.StartStellarchContract(map);
+                break;
+            case RoyaltyRegenesisStage.EmperorNotice:
+                int years = Rand.RangeInclusive(1, 10);
+                this.SendTravelNotice(
+                    "The Emperor is coming",
+                    $"The restored Stellarch's report has reached the Emperor. The imperial household has committed to the journey, but interstellar travel will take {years} year(s).");
+                this.stage = RoyaltyRegenesisStage.EmperorArrival;
+                this.nextEventTick = Find.TickManager.TicksGame + years * GenDate.TicksPerYear;
+                break;
+            case RoyaltyRegenesisStage.EmperorArrival:
+                this.StartEmperorContract(map);
+                break;
+        }
+    }
+
+    public void DebugStartAt(RoyaltyRegenesisStage debugStage)
+    {
+        if (!ModsConfig.RoyaltyActive)
+        {
+            Messages.Message("CryoRegenesis Royalty quest chain requires the Royalty DLC.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        if (this.GetTargetMap() == null)
+        {
+            Messages.Message("Build a CryoRegenesis casket on a player home map before starting the Royalty quest chain.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        this.activeClients.Clear();
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = debugStage;
+        this.nextEventTick = Find.TickManager.TicksGame;
+        this.AdvanceCampaign();
+    }
+
+    public void DebugTriggerNextEvent()
+    {
+        if (!ModsConfig.RoyaltyActive)
+        {
+            Messages.Message("CryoRegenesis Royalty quest chain requires the Royalty DLC.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        if (this.GetTargetMap() == null)
+        {
+            Messages.Message("Build a CryoRegenesis casket on a player home map before triggering the next Royalty quest event.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        this.nextEventTick = Find.TickManager.TicksGame;
+        this.AdvanceCampaign();
+    }
+
+    private void StartRulerPrisonerContract(Map map)
+    {
+        Faction sender = this.RandomNonPlayerFaction() ?? this.EmpireFaction();
+        int pawnCount = Rand.RangeInclusive(1, 2);
+        List<Pawn> pawns = new List<Pawn>();
+
+        for (int i = 0; i < pawnCount; i++)
+        {
+            Pawn pawn = this.GeneratePawn(this.CommonPawnKind(), sender, Rand.RangeInclusive(24, 70));
+            int duration = Rand.Element(HalfYearTicks, GenDate.TicksPerYear, GenDate.TicksPerYear * 2);
+            long targetTicks = Math.Max(18L * GenDate.TicksPerYear, pawn.ageTracker.AgeBiologicalTicks - duration);
+            this.PrepareClient(pawn, targetTicks, "foreign prisoner");
+            pawns.Add(pawn);
+        }
+
+        this.activeContractStage = RoyaltyRegenesisStage.RulerPrisoners;
+        this.DropClients(map, pawns, "CryoRegenesis contract: prisoners",
+            $"{(sender?.Name ?? "A planetary ruler")} has sent prisoners and dependents for a trial CryoRegenesis contract. Their requested regression is six months, one year, or two years.");
+    }
+
+    private void StartLeaderContract(Map map)
+    {
+        Faction sender = this.RandomNonPlayerFaction() ?? this.EmpireFaction();
+        Pawn leader = this.GeneratePawn(this.NoblePawnKind(), sender, Rand.RangeInclusive(35, 82));
+        int yearsToRemove = Rand.RangeInclusive(2, 18);
+        long targetTicks = Math.Max(30L * GenDate.TicksPerYear, leader.ageTracker.AgeBiologicalTicks - yearsToRemove * GenDate.TicksPerYear);
+
+        this.PrepareClient(leader, targetTicks, "planetary ruler");
+        this.activeContractStage = RoyaltyRegenesisStage.Leaders;
+        this.DropClients(map, new List<Pawn> { leader }, "CryoRegenesis contract: ruler",
+            $"{leader.Name.ToStringShort}, a ruler over the age of 30, has arrived for a privately negotiated CryoRegenesis stay.");
+    }
+
+    private void StartLowerNobilityContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        Pawn pawn = this.GeneratePawn(this.LowerNoblePawnKind(), empire, Rand.RangeInclusive(31, 72));
+        int targetAge = Rand.RangeInclusive(21, 40);
+
+        this.PrepareClient(pawn, targetAge * (long)GenDate.TicksPerYear, "lower imperial noble");
+        this.activeContractStage = RoyaltyRegenesisStage.LowerNobility;
+        this.DropClients(map, new List<Pawn> { pawn }, "Imperial CryoRegenesis contract",
+            $"The Empire has sent {pawn.Name.ToStringShort}, a lower noble, to verify your CryoRegenesis process.");
+    }
+
+    private void StartStellarchContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        Pawn stellarch = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind()), empire, Rand.RangeInclusive(45, 85));
+        this.TrySetRoyalTitle(stellarch, empire, "Stellarch");
+
+        int targetAge = Rand.RangeInclusive(21, 35);
+        List<Pawn> party = new List<Pawn> { stellarch };
+        this.PrepareClient(stellarch, targetAge * (long)GenDate.TicksPerYear, "stellarch");
+        party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion"));
+
+        this.activeContractStage = RoyaltyRegenesisStage.StellarchArrival;
+        this.DropClients(map, party, "The Stellarch has arrived",
+            $"The Stellarch has arrived for CryoRegenesis and has chosen to regress to age {targetAge}. Any spouses or lovers in the party have chosen age 30.");
+    }
+
+    private void StartEmperorContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        Pawn emperor = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind()), empire, Rand.RangeInclusive(60, 100));
+        this.TrySetRoyalTitle(emperor, empire, "Emperor");
+
+        List<Pawn> party = new List<Pawn> { emperor };
+        this.PrepareClient(emperor, 20L * GenDate.TicksPerYear, "emperor", triggerRoyalAscent: true);
+        party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion"));
+
+        this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
+        this.DropClients(map, party, "The Emperor has arrived",
+            "The Emperor has arrived for CryoRegenesis and will regress to age 20. Any spouses or lovers in the party have chosen age 21.");
+    }
+
+    private List<Pawn> GetOrGeneratePartners(Pawn noble, Faction faction, int targetAge, string role)
+    {
+        List<Pawn> partners = noble.relations?.DirectRelations
+            ?.Where(relation =>
+                relation.def == PawnRelationDefOf.Spouse ||
+                relation.def == PawnRelationDefOf.Lover ||
+                relation.def == PawnRelationDefOf.Fiance)
+            .Select(relation => relation.otherPawn)
+            .Where(pawn => pawn != null && !pawn.Dead)
+            .Distinct()
+            .ToList() ?? new List<Pawn>();
+
+        if (!partners.Any() && Rand.Chance(0.65f))
+        {
+            Pawn spouse = this.GeneratePawn(this.NoblePawnKind(), faction, Rand.RangeInclusive(35, 80));
+            noble.relations.AddDirectRelation(PawnRelationDefOf.Spouse, spouse);
+            partners.Add(spouse);
+        }
+
+        foreach (Pawn partner in partners)
+        {
+            if (partner.ageTracker.AgeBiologicalYears < targetAge + 5)
+            {
+                partner.ageTracker.AgeBiologicalTicks = Rand.RangeInclusive(targetAge + 10, targetAge + 45) * (long)GenDate.TicksPerYear;
+            }
+
+            this.PrepareClient(partner, targetAge * (long)GenDate.TicksPerYear, role);
+        }
+
+        return partners;
+    }
+
+    private void PrepareClient(Pawn pawn, long desiredAgeTicks, string role, bool triggerRoyalAscent = false)
+    {
+        desiredAgeTicks = Math.Max(0, Math.Min(desiredAgeTicks, pawn.ageTracker.AgeBiologicalTicks));
+        TrueAgeTracker tracker = RegenesisThoughts.GetOrAddTrueAgeTracker(pawn, pawn.ageTracker.AgeBiologicalTicks);
+        if (tracker != null)
+        {
+            tracker.desiredAgeTicks = desiredAgeTicks;
+        }
+
+        if (!pawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+        {
+            pawn.health.AddHediff(HediffDefOf.Anesthetic);
+        }
+
+        this.activeClients.Add(new RoyaltyRegenesisClient
+        {
+            pawn = pawn,
+            desiredAgeTicks = desiredAgeTicks,
+            role = role,
+            triggerRoyalAscent = triggerRoyalAscent,
+        });
+    }
+
+    private void DropClients(Map map, List<Pawn> pawns, string label, string text)
+    {
+        IntVec3 cell = DropCellFinder.RandomDropSpot(map);
+        DropPodUtility.DropThingsNear(cell, map, pawns.Cast<Thing>());
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent, new LookTargets(pawns));
+    }
+
+    private void CheckActiveClients()
+    {
+        if (!this.activeClients.Any())
+        {
+            return;
+        }
+
+        this.activeClients.RemoveAll(client => client?.pawn == null || client.pawn.Destroyed);
+        if (!this.activeClients.Any())
+        {
+            this.ScheduleRetry("CryoRegenesis contract lost", "The active CryoRegenesis client could no longer be found.");
+            return;
+        }
+
+        if (this.activeClients.Any(client => client.pawn.Dead))
+        {
+            this.activeClients.Clear();
+            this.ScheduleRetry("CryoRegenesis contract failed", "A Royalty CryoRegenesis client died before the requested age regression was completed.");
+            return;
+        }
+
+        if (this.activeClients.Any(client => !this.ClientReachedDesiredAge(client)))
+        {
+            return;
+        }
+
+        bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
+        this.activeClients.Clear();
+
+        if (triggerEndgame)
+        {
+            this.stage = RoyaltyRegenesisStage.Completed;
+            this.royalAscentTriggered = true;
+            this.TryMakeRoyalAscentAvailable();
+            return;
+        }
+
+        this.CompleteActiveContract();
+    }
+
+    private bool ClientReachedDesiredAge(RoyaltyRegenesisClient client)
+    {
+        return client.pawn.ageTracker.AgeBiologicalTicks <= client.desiredAgeTicks + CheckIntervalTicks;
+    }
+
+    private void CompleteActiveContract()
+    {
+        switch (this.activeContractStage)
+        {
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                this.rulerContractsCompleted++;
+                if (this.rulerContractsCompleted < 3)
+                {
+                    this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(15, 35) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    this.stage = RoyaltyRegenesisStage.Leaders;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(25, 45) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.Leaders:
+                this.leaderContractsCompleted++;
+                if (this.leaderContractsCompleted < 2)
+                {
+                    this.stage = RoyaltyRegenesisStage.Leaders;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    this.stage = RoyaltyRegenesisStage.LowerNobility;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.LowerNobility:
+                this.nobleContractsCompleted++;
+                if (this.nobleContractsCompleted < 2)
+                {
+                    this.stage = RoyaltyRegenesisStage.LowerNobility;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    this.stage = RoyaltyRegenesisStage.StellarchNotice;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(15, 30) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.StellarchArrival:
+                this.stage = RoyaltyRegenesisStage.EmperorNotice;
+                this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 90) * GenDate.TicksPerDay;
+                break;
+        }
+
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis contract complete",
+            "The Royalty CryoRegenesis client has reached the requested regression age.",
+            LetterDefOf.PositiveEvent);
+    }
+
+    private void ScheduleRetry(string label, string text)
+    {
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NegativeEvent);
+        this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+    }
+
+    private void SendTravelNotice(string label, string text)
+    {
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent);
+    }
+
+    private Pawn GeneratePawn(PawnKindDef kind, Faction faction, int biologicalAge)
+    {
+        PawnGenerationRequest request = new PawnGenerationRequest(kind, faction);
+        request.FixedBiologicalAge = biologicalAge;
+        request.FixedChronologicalAge = biologicalAge;
+        return PawnGenerator.GeneratePawn(request);
+    }
+
+    private PawnKindDef CommonPawnKind()
+    {
+        return this.NamedPawnKind("Empire_Common_Lodger", this.AnyHumanPawnKind());
+    }
+
+    private PawnKindDef NoblePawnKind()
+    {
+        return this.NamedPawnKind("Empire_Royal_NobleWimp", this.CommonPawnKind());
+    }
+
+    private PawnKindDef LowerNoblePawnKind()
+    {
+        return this.NamedPawnKind(
+            Rand.Element("Empire_Royal_Yeoman", "Empire_Royal_Esquire", "Empire_Royal_Knight"),
+            this.NoblePawnKind());
+    }
+
+    private PawnKindDef NamedPawnKind(string defName, PawnKindDef fallback)
+    {
+        return DefDatabase<PawnKindDef>.GetNamedSilentFail(defName) ?? fallback;
+    }
+
+    private PawnKindDef AnyHumanPawnKind()
+    {
+        return DefDatabase<PawnKindDef>.AllDefsListForReading
+            .FirstOrDefault(def => def.race != null && def.race.race != null && def.race.race.Humanlike);
+    }
+
+    private Faction EmpireFaction()
+    {
+        FactionDef empireDef = DefDatabase<FactionDef>.GetNamedSilentFail("Empire");
+        if (empireDef != null)
+        {
+            Faction empire = Find.FactionManager.FirstFactionOfDef(empireDef);
+            if (empire != null)
+            {
+                return empire;
+            }
+        }
+
+        return this.RandomNonPlayerFaction();
+    }
+
+    private Faction RandomNonPlayerFaction()
+    {
+        return Find.FactionManager.AllFactionsListForReading
+            .Where(faction =>
+                faction != null &&
+                faction != Faction.OfPlayer &&
+                !faction.defeated &&
+                !faction.HostileTo(Faction.OfPlayer) &&
+                faction.def.humanlikeFaction)
+            .RandomElementWithFallback(null);
+    }
+
+    private void TrySetRoyalTitle(Pawn pawn, Faction faction, string titleDefName)
+    {
+        RoyalTitleDef title = DefDatabase<RoyalTitleDef>.GetNamedSilentFail(titleDefName);
+        if (title == null || pawn == null || faction == null)
+        {
+            return;
+        }
+
+        object royalty = pawn.GetType().GetField("royalty")?.GetValue(pawn)
+            ?? pawn.GetType().GetProperty("royalty")?.GetValue(pawn, null);
+
+        if (royalty == null)
+        {
+            return;
+        }
+
+        MethodInfo method = royalty.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate =>
+                candidate.Name == "SetTitle" &&
+                candidate.GetParameters().Any(parameter => parameter.ParameterType == typeof(RoyalTitleDef)));
+
+        if (method == null)
+        {
+            return;
+        }
+
+        object[] args = method.GetParameters()
+            .Select<ParameterInfo, object>(parameter =>
+            {
+                if (parameter.ParameterType == typeof(Faction))
+                {
+                    return faction;
+                }
+
+                if (parameter.ParameterType == typeof(RoyalTitleDef))
+                {
+                    return title;
+                }
+
+                if (parameter.ParameterType == typeof(bool))
+                {
+                    return false;
+                }
+
+                return null;
+            })
+            .ToArray();
+
+        try
+        {
+            method.Invoke(royalty, args);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"[CryoRegenesis] Failed to set Royalty title {titleDefName} for {pawn.Name}: {ex.Message}");
+        }
+    }
+
+    private void TryMakeRoyalAscentAvailable()
+    {
+        Find.LetterStack.ReceiveLetter(
+            "Imperial CryoRegenesis complete",
+            "The Emperor has reached age 20. Royal Ascent shuttle endgame protocols are now being activated.",
+            LetterDefOf.PositiveEvent);
+
+        QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");
+        object questManager = Find.QuestManager;
+
+        if (questDef == null || questManager == null)
+        {
+            Log.Warning("[CryoRegenesis] Could not activate Royal Ascent: EndGame_RoyalAscent or QuestManager was unavailable.");
+            return;
+        }
+
+        foreach (MethodInfo method in questManager.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (method.Name != "GenerateAndAddQuest" && method.Name != "GenerateQuestAndMakeAvailable")
+            {
+                continue;
+            }
+
+            object[] args = this.BuildQuestManagerArgs(method, questDef);
+            if (args == null)
+            {
+                continue;
+            }
+
+            try
+            {
+                method.Invoke(questManager, args);
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[CryoRegenesis] Royal Ascent activation via {method.Name} failed: {ex.Message}");
+            }
+        }
+
+        Log.Warning("[CryoRegenesis] Could not find a compatible Royal Ascent quest generation method.");
+    }
+
+    private object[] BuildQuestManagerArgs(MethodInfo method, QuestScriptDef questDef)
+    {
+        ParameterInfo[] parameters = method.GetParameters();
+        object[] args = new object[parameters.Length];
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            Type parameterType = parameters[i].ParameterType;
+            if (parameterType == typeof(QuestScriptDef))
+            {
+                args[i] = questDef;
+            }
+            else if (!parameterType.IsValueType)
+            {
+                args[i] = null;
+            }
+            else if (parameterType == typeof(int))
+            {
+                args[i] = 0;
+            }
+            else if (parameterType == typeof(float))
+            {
+                args[i] = 0f;
+            }
+            else if (parameterType == typeof(bool))
+            {
+                args[i] = false;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return args.Any(arg => arg == questDef) ? args : null;
+    }
+}
+
+public class RoyaltyRegenesisClient : IExposable
+{
+    public Pawn pawn;
+    public long desiredAgeTicks;
+    public string role;
+    public bool triggerRoyalAscent;
+
+    public void ExposeData()
+    {
+        Scribe_References.Look(ref this.pawn, "pawn");
+        Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
+        Scribe_Values.Look(ref this.role, "role");
+        Scribe_Values.Look(ref this.triggerRoyalAscent, "triggerRoyalAscent", false);
+    }
+}
+
+public enum RoyaltyRegenesisStage
+{
+    NotStarted,
+    RulerPrisoners,
+    Leaders,
+    LowerNobility,
+    StellarchNotice,
+    StellarchArrival,
+    EmperorNotice,
+    EmperorArrival,
+    Completed,
+}
+
+public static class RoyaltyRegenesisDebugActions
+{
+    [DebugAction("CryoRegenesis", "Start Royalty chain")]
+    public static void StartRoyaltyChain()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.RulerPrisoners);
+    }
+
+    [DebugAction("CryoRegenesis", "Start Stellarch arrival")]
+    public static void StartStellarchArrival()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.StellarchArrival);
+    }
+
+    [DebugAction("CryoRegenesis", "Start Emperor arrival")]
+    public static void StartEmperorArrival()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.EmperorArrival);
+    }
+
+    [DebugAction("CryoRegenesis", "Trigger next Royalty event")]
+    public static void TriggerNextRoyaltyEvent()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugTriggerNextEvent();
+    }
+}
+
+public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
+{
+    protected override bool TestRunInt(Slate slate)
+    {
+        return ModsConfig.RoyaltyActive;
+    }
+
+    protected override void RunInt()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.RulerPrisoners);
+
+        QuestPart_QuestEnd endPart = new QuestPart_QuestEnd
+        {
+            inSignal = QuestGen.quest.InitiateSignal,
+            outcome = QuestEndOutcome.Success,
+            sendLetter = false,
+        };
+        QuestGen.quest.AddPart(endPart);
+    }
+}

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -489,6 +489,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         {
             tracker.desiredAgeTicks = desiredAgeTicks;
             tracker.underRegenContract = true;
+            tracker.contractStartAgeTicks = pawn.ageTracker.AgeBiologicalTicks;
         }
 
         this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner);

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -9,6 +9,8 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
+using System.Text;
 using RimWorld;
 using Verse;
 
@@ -56,6 +58,12 @@ public class TrueAgeTracker : HediffWithComps
     /// </summary>
     public bool underRegenContract = false;
 
+    /// <summary>
+    /// Biological age (ticks) when the current regen contract began.
+    /// Used to compute regression progress toward <see cref="desiredAgeTicks"/>.
+    /// </summary>
+    public long contractStartAgeTicks = 0;
+
     public override void ExposeData()
     {
         base.ExposeData();
@@ -65,6 +73,7 @@ public class TrueAgeTracker : HediffWithComps
         Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
         Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
         Scribe_Values.Look(ref this.underRegenContract, "underRegenContract", false);
+        Scribe_Values.Look(ref this.contractStartAgeTicks, "contractStartAgeTicks", 0L);
     }
 
     public override void Tick()
@@ -137,5 +146,88 @@ public class TrueAgeTracker : HediffWithComps
         return (float)ticks / 3600000f;
     }
 
-    public override bool Visible => false;
+    private bool UnderActiveContract =>
+        this.underRegenContract && this.desiredAgeTicks > 0 && this.pawn?.ageTracker != null;
+
+    public float GetContractTargetAgeYears()
+    {
+        return AgeTicksToYears(this.desiredAgeTicks);
+    }
+
+    /// <summary>
+    /// 0–100% of the contracted regression completed (100 once at/below the target age).
+    /// Falls back to 0 when no contract start age was recorded (pre-existing saves).
+    /// </summary>
+    public float GetContractProgressPercent()
+    {
+        if (!this.UnderActiveContract)
+        {
+            return 0f;
+        }
+
+        long currentTicks = this.pawn.ageTracker.AgeBiologicalTicks;
+        if (currentTicks <= this.desiredAgeTicks)
+        {
+            return 100f;
+        }
+
+        if (this.contractStartAgeTicks <= this.desiredAgeTicks)
+        {
+            return 0f;
+        }
+
+        float progress = (this.contractStartAgeTicks - currentTicks)
+            / (float)(this.contractStartAgeTicks - this.desiredAgeTicks) * 100f;
+        return Math.Max(0f, Math.Min(100f, progress));
+    }
+
+    /// <summary>
+    /// Only shown on the Health tab while under an active Regenesis contract, so the
+    /// player can see the contracted target age and how close the pawn is to it.
+    /// </summary>
+    public override bool Visible => this.UnderActiveContract;
+
+    public override string LabelBase => this.UnderActiveContract ? "Regenesis contract" : base.LabelBase;
+
+    public override string LabelInBrackets
+    {
+        get
+        {
+            if (!this.UnderActiveContract)
+            {
+                return base.LabelInBrackets;
+            }
+
+            return "target age " + this.GetContractTargetAgeYears().ToString("0.#")
+                + ", " + this.GetContractProgressPercent().ToString("0") + "% there";
+        }
+    }
+
+    public override string TipStringExtra
+    {
+        get
+        {
+            string baseTip = base.TipStringExtra;
+            if (!this.UnderActiveContract)
+            {
+                return baseTip;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            if (!baseTip.NullOrEmpty())
+            {
+                sb.AppendLine(baseTip.TrimEnd());
+            }
+
+            float currentYears = this.pawn.ageTracker.AgeBiologicalYearsFloat;
+            float targetYears = this.GetContractTargetAgeYears();
+            sb.AppendLine("Current biological age: " + currentYears.ToString("0.00"));
+            sb.AppendLine("Contracted target age: " + targetYears.ToString("0.00"));
+            sb.AppendLine("Regression progress: " + this.GetContractProgressPercent().ToString("0.0") + "%");
+            sb.AppendLine(currentYears > targetYears
+                ? "Years left to remove: " + (currentYears - targetYears).ToString("0.00")
+                : "Target age reached — ready to board the shuttle home.");
+            return sb.ToString().TrimEnd();
+        }
+    }
 }

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -50,6 +50,12 @@ public class TrueAgeTracker : HediffWithComps
     public long cryoRegenesisRemovedAgeTicks = 0;
     public long desiredAgeTicks = 0;
 
+    /// <summary>
+    /// True while this pawn is under an active Royalty Regenesis return contract.
+    /// Contract clients must not become voluntarily recruitable.
+    /// </summary>
+    public bool underRegenContract = false;
+
     public override void ExposeData()
     {
         base.ExposeData();
@@ -58,6 +64,7 @@ public class TrueAgeTracker : HediffWithComps
         Scribe_Values.Look(ref this.consciousAliveTicks, "consciousAliveTicks", 0L);
         Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
         Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
+        Scribe_Values.Look(ref this.underRegenContract, "underRegenContract", false);
     }
 
     public override void Tick()

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -48,6 +48,7 @@ public class TrueAgeTracker : HediffWithComps
     public bool aliveYearsInitialized = false;
     public long consciousAliveTicks = 0;
     public long cryoRegenesisRemovedAgeTicks = 0;
+    public long desiredAgeTicks = 0;
 
     public override void ExposeData()
     {
@@ -56,6 +57,7 @@ public class TrueAgeTracker : HediffWithComps
         Scribe_Values.Look(ref this.aliveYearsInitialized, "aliveYearsInitialized", false);
         Scribe_Values.Look(ref this.consciousAliveTicks, "consciousAliveTicks", 0L);
         Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
+        Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
     }
 
     public override void Tick()

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ solutionPath="Source/${MOD}.sln"
 
 # Define an array of configurations
 configurations=("v1.2" "v1.3" "v1.4" "v1.5" "v1.6")
+#configurations=("v1.2")
 
 dotnet restore "$solutionPath"
 
@@ -75,16 +76,16 @@ if [ "$1" == "1" ]; then
     exit
 fi
 
-# Watch for changes to .cs and XML files in the directory and subdirectories
-inotifywait --recursive --monitor --format "%e %w%f" \
-    --exclude '/\.idea($|/)' \
-    --event modify,move,create,delete "$dir" "$MOD" |
-    while read event fullpath; do
-        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
-            echo "Running build for $fullpath"
-            build || echo "Build failed, skipping sync."
-        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
-            echo "Running sync_mod for $fullpath"
-            sync_mod
-        fi
-    done
+## Watch for changes to .cs and XML files in the directory and subdirectories
+#inotifywait --recursive --monitor --format "%e %w%f" \
+#    --exclude '/\.idea($|/)' \
+#    --event modify,move,create,delete "$dir" "$MOD" |
+#    while read event fullpath; do
+#        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
+#            echo "Running build for $fullpath"
+#            build || echo "Build failed, skipping sync."
+#        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
+#            echo "Running sync_mod for $fullpath"
+#            sync_mod
+#        fi
+#    done


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Let doctors sedate and carry eligible pawns into CryoRegenesis caskets**

### What Changed
- Added a doctor action that sedates eligible pawns and then automatically carries them to the nearest empty CryoRegenesis casket
- Expanded carry support to all downed humanlike pawns, including prisoners, guests, lodgers, hostile humanlikes, and modded humanlike races
- Added support for tamed player animals, even when they are not “pet” species
- Fixed humanlike pawns with non-standard races from being ejected immediately by making target age tracking apply to all humanlikes
- Added a Royalty quest chain that sends contracted guests and prisoners by shuttle, tracks their progress, and shows live status in the Quests and Health tabs

### Impact
`✅ Fewer failed rescue-and-carry attempts`
`✅ Can use CryoRegenesis on prisoners, guests, and tamed animals`
`✅ Clearer progress for Royalty contract pawns`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CryoRegenesis sedation, medical administration, and transport to available caskets.
  * Added Royalty Regenesis quest chain with contracts, progression stages, client returns, deadlines, and notifications.
  * Added contract progress details, target ages, and completion status to pawn and casket information.
  * Caskets can now be manually ejected by players.
* **Bug Fixes**
  * Improved compatibility when loading patches across RimWorld versions.
  * Corrected age-target progression and healing behavior.
* **Localization**
  * Added sedation and casket transport messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->