### PR TITLE
Cryo Carry: A system for sending injured, prisoners, and guests to the sarcophagus

### DIFF
--- a/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
+++ b/CryoRegenesis/Defs/ThingDefs_Buildings/Buildings_CryoRenesis.xml
@@ -34,6 +34,7 @@
 		<defaultPlacingRot>South</defaultPlacingRot>
 		<building>
 			<ai_chillDestination>false</ai_chillDestination>
+			<isPlayerEjectable>true</isPlayerEjectable>
 		</building>
 		<costList>
 			<Steel>250</Steel>

--- a/CryoRegenesis/Languages/English/Keyed/English.xml
+++ b/CryoRegenesis/Languages/English/Keyed/English.xml
@@ -23,5 +23,5 @@
     <BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>No available CryoRegenesis casket.</BetterRimworlds.CryoRegenesis.Sedation.NoAvailableCasket>
 
     <CarryToCryoRegenesisCasket>Carry to CryoRegenesis casket</CarryToCryoRegenesisCasket>
-    <NoReachableCryoRegenesis>No reachable CryoRegenesis casket</NoReachableCryoRegenesis>
+    <NoReachableCryoRegenesis>No available CryoRegenesis casket</NoReachableCryoRegenesis>
 </LanguageData>

--- a/Source/AllowHostedGuestsPatch.cs
+++ b/Source/AllowHostedGuestsPatch.cs
@@ -1,6 +1,43 @@
 // ==== Source/AllowHostedGuestsPatch.cs ====
+/*
+ * Carry-to-CryoRegenesis float menu (FloatMenuMakerMap.AddHumanlikeOrders).
+ *
+ * =============================================================================
+ * INCIDENT: option missing for unconscious / Downed prisoners (RW 1.2)
+ * =============================================================================
+ *
+ * What players saw:
+ *   Right-click on an unconscious prisoner (Moving 0%, Downed) never offered
+ *   "Carry to CryoRegenesis casket", even though the feature was meant for every
+ *   immobilised humanlike / colony animal.
+ *
+ * What was *not* the primary bug (but still worth hardening):
+ *   - Cell-only GetThingList lookups miss bed occupants → use GenUI.TargetsAt
+ *     plus a small cell neighbourhood scan.
+ *   - Strict CanReserveAndReach without ignoreOtherReservations greys out
+ *     tended patients → do not gate the menu on path/reserve probes; let the
+ *     job fail at runtime if needed.
+ *   - Carriable state is broader than `pawn.Downed` alone: also treat Moving
+ *     capacity at 0% (and anesthetic / CryoRegenesis sedation) as eligible so
+ *     edge ticks and UI "Moving 0%" match player expectations.
+ *
+ * What *was* the primary bug:
+ *   This patch never ran on 1.2. Harmony PatchAll aborted because another
+ *   assembly patch targeted a DoRecruit signature that does not exist on 1.2.
+ *   See the Harmony loading docblock in CryoRegenesis.cs and TargetMethod
+ *   fallbacks on Patch_DoRecruit_RegenContract.
+ *
+ * How not to repeat this:
+ *   - If this option vanishes on one RW version only, verify the patch is
+ *     applied (log + Harmony) before changing IsCryoCarryTargetState again.
+ *   - Keep IsCryoCarryTargetState = Downed OR Moving <= 0% OR sedation hediffs.
+ *   - Keep casket lookup free of pathing/reservation requirements for the menu.
+ *   - Multi-version: AddHumanlikeOrders exists through 1.5; 1.6 uses a different
+ *     float-menu pipeline and needs a separate approach if support is required.
+ * =============================================================================
+ */
+
 using System.Collections.Generic;
-using System.Linq;
 using BetterRimworlds.CryoRegenesis;
 using HarmonyLib;
 using RimWorld;
@@ -13,7 +50,10 @@ namespace CryoRegenesis.HarmonyPatches
     [HarmonyPatch(typeof(FloatMenuMakerMap), "AddHumanlikeOrders")]
     public static class Patch_FloatMenuMakerMap_AddHumanlikeOrders_CryoRegenesis
     {
-        public static void Postfix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
+        public static void Postfix(
+            Vector3 clickPos,
+            Pawn pawn,
+            List<FloatMenuOption> opts)
         {
             if (pawn?.Map == null)
                 return;
@@ -22,71 +62,223 @@ namespace CryoRegenesis.HarmonyPatches
             if (pawn.Downed || pawn.Dead || pawn.IsBurning())
                 return;
 
-            Pawn targetPawn = GetClickedDownedPawn(clickPos, pawn.Map);
-
-            if (targetPawn == null)
-                return;
-
-            if (!ShouldAllowCryoRegenesisCarry(targetPawn))
-                return;
-
-            string label = "CarryToCryoRegenesisCasket".Translate();
-
-            Building_CryoRegenesis casket = FindCryoRegenesisCasketFor(pawn, targetPawn);
-
-            if (casket == null)
+            /*
+             * Collect candidate patients under the cursor.
+             *
+             * GenUI.TargetsAt finds multi-cell bed occupants that a single
+             * GetThingList(cell) can miss. A cell scan is kept as a fallback
+             * for edge cases (e.g. draw-pos slightly off the click).
+             *
+             * Intentionally NO pathing / CanReserveAndReach checks here.
+             * Prisoners in locked rooms, guests with area restrictions, and
+             * bed-bound patients often fail reachability probes even when a
+             * colonist can still walk over and carry them. The job/toils
+             * handle real pathing at runtime.
+             */
+            foreach (Pawn targetPawn in GetCryoCarryCandidates(clickPos, pawn))
             {
-                opts.Add(new FloatMenuOption(label + ": " + "NoReachableCryoRegenesis".Translate(), null));
-                return;
-            }
+                if (!ShouldAllowCryoRegenesisCarry(targetPawn))
+                    continue;
 
-            if (!pawn.CanReserveAndReach(targetPawn, PathEndMode.Touch, Danger.Deadly))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "CannotReach".Translate(targetPawn.LabelShort), null));
-                return;
-            }
+                string label = "CarryToCryoRegenesisCasket".Translate();
 
-            if (!pawn.CanReserve(casket))
-            {
-                opts.Add(new FloatMenuOption(label + ": " + "Reserved".Translate(casket.Label), null));
-                return;
-            }
+                Building_CryoRegenesis casket =
+                    FindEmptyCryoRegenesisCasket(targetPawn);
 
-            FloatMenuOption option = new FloatMenuOption(
-                label,
-                delegate
+                if (casket == null)
                 {
-                    Job job = JobMaker.MakeJob(CryoRegenesisDefOf.CR_CarryToCryoRegenesis, targetPawn, casket);
+                    opts.Add(
+                        new FloatMenuOption(
+                            label
+                            + ": "
+                            + "NoReachableCryoRegenesis".Translate(),
+                            null));
 
-                    job.count = 1;
+                    continue;
+                }
 
-                    pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc);
-                },
-                MenuOptionPriority.RescueOrCapture
-            );
+                // Capture for the menu-option delegate.
+                Pawn patient = targetPawn;
 
-            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(option, pawn, targetPawn));
+                FloatMenuOption option = new FloatMenuOption(
+                    label,
+                    delegate
+                    {
+                        Building_CryoRegenesis chosen =
+                            FindEmptyCryoRegenesisCasket(patient);
+
+                        if (chosen == null)
+                        {
+                            Messages.Message(
+                                "NoReachableCryoRegenesis".Translate(),
+                                patient,
+                                MessageTypeDefOf.RejectInput,
+                                historical: false);
+
+                            return;
+                        }
+
+                        Job job = JobMaker.MakeJob(
+                            CryoRegenesisDefOf.CR_CarryToCryoRegenesis,
+                            patient,
+                            chosen);
+
+                        job.count = 1;
+
+                        pawn.jobs.TryTakeOrderedJob(
+                            job,
+                            JobTag.Misc);
+                    },
+                    MenuOptionPriority.RescueOrCapture);
+
+                opts.Add(
+                    FloatMenuUtility.DecoratePrioritizedTask(
+                        option,
+                        pawn,
+                        targetPawn));
+            }
         }
 
-        private static Pawn GetClickedDownedPawn(Vector3 clickPos, Map map)
+        private static IEnumerable<Pawn> GetCryoCarryCandidates(
+            Vector3 clickPos,
+            Pawn carrier)
         {
+            var seen = new HashSet<Pawn>();
+
+            TargetingParameters targetingParameters =
+                MakeCryoCarryTargetingParameters(carrier);
+
+#if RIMWORLD12
+            // RimWorld 1.2 prefers TargetsAt_NewTemp; TargetsAt is obsolete there.
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt_NewTemp(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#else
+            IEnumerable<LocalTargetInfo> targets = GenUI.TargetsAt(
+                clickPos,
+                targetingParameters,
+                thingsOnly: true);
+#endif
+
+            foreach (LocalTargetInfo target in targets)
+            {
+                if (target.Thing is Pawn targetPawn && seen.Add(targetPawn))
+                    yield return targetPawn;
+            }
+
+            // Fallback: direct cell scan (covers some bed / multi-cell cases).
+            Map map = carrier.Map;
             IntVec3 cell = IntVec3.FromVector3(clickPos);
 
             if (!cell.InBounds(map))
-                return null;
+                yield break;
 
-            return cell
-                .GetThingList(map)
-                .OfType<Pawn>()
-                .FirstOrDefault(
-                    candidate =>
-                        candidate.Downed &&
-                        !candidate.Dead &&
-                        (
-                            candidate.RaceProps.Humanlike ||
-                            candidate.RaceProps.Animal
-                        )
-                );
+            for (int x = -1; x <= 1; x++)
+            {
+                for (int z = -1; z <= 1; z++)
+                {
+                    IntVec3 scanCell = new IntVec3(cell.x + x, cell.y, cell.z + z);
+
+                    if (!scanCell.InBounds(map))
+                        continue;
+
+                    List<Thing> things = scanCell.GetThingList(map);
+
+                    for (int i = 0; i < things.Count; i++)
+                    {
+                        if (things[i] is Pawn targetPawn &&
+                            seen.Add(targetPawn) &&
+                            IsCryoCarryTargetState(targetPawn))
+                        {
+                            yield return targetPawn;
+                        }
+                    }
+                }
+            }
+        }
+
+        /*
+         * Common-denominator replacement for TargetingParameters.ForRescue.
+         *
+         * Also accepts pawns under Anesthetic / CryoRegenesis sedation who may
+         * briefly not report as Downed (severity edge, just-applied hediff).
+         * ForRescue's onlyTargetIncapacitatedPawns would miss those.
+         */
+        private static TargetingParameters MakeCryoCarryTargetingParameters(
+            Pawn carrier)
+        {
+            return new TargetingParameters
+            {
+                canTargetLocations = false,
+                canTargetSelf = false,
+
+                canTargetPawns = true,
+                canTargetHumans = true,
+                canTargetAnimals = true,
+
+                canTargetBuildings = false,
+                canTargetItems = false,
+
+                // Do NOT set onlyTargetIncapacitatedPawns: anesthetized
+                // prisoners can fail that gate at certain severity edges.
+                // Our validator handles Downed + sedation explicitly.
+                onlyTargetIncapacitatedPawns = false,
+                mustBeSelectable = false,
+                mapObjectTargetsMustBeAutoAttackable = false,
+
+                validator = target =>
+                {
+                    if (!target.HasThing)
+                        return false;
+
+                    Pawn targetPawn = target.Thing as Pawn;
+
+                    return targetPawn != null
+                        && targetPawn != carrier
+                        && targetPawn.Spawned
+                        && IsCryoCarryTargetState(targetPawn);
+                }
+            };
+        }
+
+        /// <summary>
+        /// True when the pawn is carriable: Downed, Moving at 0%, or sedated
+        /// and about to collapse. JobDriver waits for Downed after sedation.
+        /// </summary>
+        private static bool IsCryoCarryTargetState(Pawn targetPawn)
+        {
+            if (targetPawn == null || targetPawn.Dead)
+                return false;
+
+            // Standard incapacitated flag (unconscious, pain shock, etc.).
+            if (targetPawn.Downed)
+                return true;
+
+            // Moving 0% — can't walk even if Downed hasn't flipped yet.
+            PawnCapacitiesHandler capacities = targetPawn.health?.capacities;
+            if (capacities != null &&
+                (!capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+                 capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f))
+            {
+                return true;
+            }
+
+            // Full Anesthetic or our cryo sedation (pending collapse).
+            if (targetPawn.health?.hediffSet == null)
+                return false;
+
+            if (targetPawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+                return true;
+
+            if (CryoRegenesisDefOf.CryoRegenesisSedation != null &&
+                targetPawn.health.hediffSet.HasHediff(
+                    CryoRegenesisDefOf.CryoRegenesisSedation))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool ShouldAllowCryoRegenesisCarry(Pawn targetPawn)
@@ -94,26 +286,24 @@ namespace CryoRegenesis.HarmonyPatches
             if (targetPawn == null)
                 return false;
 
-            if (targetPawn.Dead || !targetPawn.Downed)
+            if (!IsCryoCarryTargetState(targetPawn))
                 return false;
 
             /*
              * Animals.
              *
-             * Restricted to the player's faction so the option isn't
-             * offered on wild or enemy fauna. Species-level petness is
-             * deliberately irrelevant — a tamed warg, thrumbo, or other
-             * non-pet species is still eligible when it belongs to the
-             * player's faction.
+             * Restricted to the player's faction so the option isn't offered
+             * on wild or enemy fauna. Species-level petness is deliberately
+             * irrelevant: a tamed warg, thrumbo, or other non-pet species is
+             * still eligible when it belongs to the player's faction.
              */
             if (targetPawn.RaceProps.Animal)
                 return targetPawn.Faction == Faction.OfPlayer;
 
             /*
-             * Any downed humanlike is eligible — colonists, slaves,
-             * prisoners, guests, quest lodgers, and downed hostiles alike.
-             * The click already required Downed && !Dead, so this covers
-             * every rescue/capture-style scenario, including sedated pawns.
+             * Any qualifying humanlike is eligible: colonists, slaves,
+             * prisoners (including anesthetized quest prisoners), guests,
+             * quest lodgers, and downed hostiles alike.
              */
             if (targetPawn.RaceProps.Humanlike)
                 return true;
@@ -121,33 +311,43 @@ namespace CryoRegenesis.HarmonyPatches
             return false;
         }
 
-        private static Building_CryoRegenesis FindCryoRegenesisCasketFor(Pawn carrier, Pawn targetPawn)
+        /*
+         * Nearest empty colony CryoRegenesis casket. Intentionally no pathing
+         * or reservation checks — those are left to the job/toils at runtime.
+         */
+        private static Building_CryoRegenesis FindEmptyCryoRegenesisCasket(
+            Pawn targetPawn)
         {
-            Map map = carrier?.Map;
+            Map map = targetPawn?.MapHeld;
 
-            if (map == null || targetPawn == null)
+            if (map == null)
                 return null;
 
-            return GenClosest.ClosestThingReachable(
-                targetPawn.Position,
-                map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
-                PathEndMode.InteractionCell,
-                TraverseParms.For(carrier, Danger.Deadly, TraverseMode.ByPawn),
-                validator: thing =>
+            Building_CryoRegenesis best = null;
+            int bestDist = int.MaxValue;
+            IntVec3 pos = targetPawn.PositionHeld;
+
+            List<Thing> buildings = map.listerThings.ThingsInGroup(
+                ThingRequestGroup.BuildingArtificial);
+
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                if (buildings[i] is not Building_CryoRegenesis casket)
+                    continue;
+
+                if (casket.HasAnyContents)
+                    continue;
+
+                int dist = casket.Position.DistanceToSquared(pos);
+
+                if (dist < bestDist)
                 {
-                    if (thing is not Building_CryoRegenesis casket)
-                        return false;
-
-                    if (casket.HasAnyContents)
-                        return false;
-
-                    if (!carrier.CanReserve(casket))
-                        return false;
-
-                    return true;
+                    bestDist = dist;
+                    best = casket;
                 }
-            ) as Building_CryoRegenesis;
+            }
+
+            return best;
         }
     }
 }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -8,6 +8,40 @@
  *   https://github.com/BetterRimworlds/CryoRegenesis
  *
  * This file is licensed under the MIT License.
+ *
+ * =============================================================================
+ * HARMONY PATCH LOADING — DO NOT REGRESS
+ * =============================================================================
+ *
+ * Problem (RimWorld 1.2, 2026-07):
+ *   "Carry to CryoRegenesis casket" never appeared for unconscious / Downed
+ *   prisoners. Eligibility and float-menu code looked correct; the real failure
+ *   was that *no* Harmony patches in this assembly applied at all.
+ *
+ * Root cause:
+ *   Mod construction used a single `harmony.PatchAll(Assembly)`. One unrelated
+ *   patch (Patch_DoRecruit_RegenContract) resolved TargetMethod() against the
+ *   *1.3+* InteractionWorker_RecruitAttempt.DoRecruit signature. On 1.2 that
+ *   method still takes `float recruitChance`, so AccessTools returned null,
+ *   PatchAll threw, and the catch block only logged:
+ *     "Failed to load harmony patches: ..."
+ *   Every other patch — including FloatMenuMakerMap.AddHumanlikeOrders for the
+ *   carry option — died with it. Symptom looked like a carry-eligibility bug.
+ *
+ * How not to repeat this:
+ *   1. Never rely on one PatchAll for the whole assembly when any TargetMethod
+ *      is version-sensitive. Apply each [HarmonyPatch] type with
+ *      CreateClassProcessor(type).Patch() inside its own try/catch (see ctor).
+ *   2. When resolving vanilla methods by signature, probe *every* supported
+ *      RimWorld version (1.2 often differs). Prefer ordered AccessTools.Method
+ *      fallbacks; never assume 1.3+ is the only shape.
+ *   3. If a float-menu / job feature "does nothing" on one game version only,
+ *      check the player log first for Harmony load failures before rewriting
+ *      gameplay conditions (Downed, Moving %, beds, etc.).
+ *   4. After changing any TargetMethod / patch attribute, boot *each* target
+ *      version (or at least 1.2 and latest) and confirm no
+ *      "[CryoRegenesis] Harmony patch failed" lines at startup.
+ * =============================================================================
  */
 
 using RimWorld;
@@ -28,13 +62,26 @@ public class CryoRegenesis: Mod
         Settings = GetSettings<Settings>() ?? new Settings();
 
         var harmony = new Harmony("FrontierDevelopments.DeadCryptosleep");
-        try
+        /*
+         * Apply each [HarmonyPatch] type independently. A single bad TargetMethod
+         * (version-mismatched signature) must not abort the rest — that used to
+         * silently kill the Carry-to-CryoRegenesis float menu on RimWorld 1.2.
+         */
+        foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
         {
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
-        }
-        catch (Exception e)
-        {
-            Log.Error($"Failed to load harmony patches: {e.Message}\n{e.StackTrace}");
+            object[] attrs = type.GetCustomAttributes(typeof(HarmonyPatch), inherit: true);
+            if (attrs == null || attrs.Length == 0)
+                continue;
+
+            try
+            {
+                harmony.CreateClassProcessor(type).Patch();
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    $"[CryoRegenesis] Harmony patch failed on {type.FullName}: {e.Message}\n{e.StackTrace}");
+            }
         }
     }
 
@@ -448,6 +495,7 @@ public static class CryoRegenesisDefOf
 {
     public static HediffDef CryoRegenesisSedation;
     public static JobDef CR_CarryToCryoRegenesis;
+    public static RecipeDef CR_AdministerCryoRegenesisSedation;
 
     static CryoRegenesisDefOf()
     {

--- a/Source/JobDriver_CarryToCryoRegenesis.cs
+++ b/Source/JobDriver_CarryToCryoRegenesis.cs
@@ -1,4 +1,18 @@
 // ==== Source/JobDriver_CarryToCryoRegenesis.cs ====
+/*
+ * Ordered job: carry a patient into a CryoRegenesis casket.
+ *
+ * Immobility gate (do not narrow this):
+ *   PatientIsImmobile() is true when the pawn is Downed *or* Moving capacity
+ *   is 0%. Players treat "Unconscious / Moving 0%" as carriable; requiring only
+ *   `pawn.Downed` missed edge cases and disagreed with the float-menu check in
+ *   AllowHostedGuestsPatch (keep both in sync).
+ *
+ * If the carry *menu option* is missing entirely on one RW version, that is
+ * usually a Harmony load failure — not this driver. See CryoRegenesis.cs and
+ * Patch_DoRecruit_RegenContract docblocks.
+ */
+using RimWorld;
 using Verse;
 using Verse.AI;
 
@@ -20,6 +34,27 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
     private Building_CryoRegenesis Casket =>
         job.GetTarget(CasketIndex).Thing as Building_CryoRegenesis;
 
+    /// <summary>
+    /// Patient can be picked up when Downed or when Moving is 0%.
+    /// Must stay aligned with AllowHostedGuestsPatch.IsCryoCarryTargetState.
+    /// </summary>
+    private bool PatientIsImmobile()
+    {
+        Pawn patient = Patient;
+        if (patient == null || patient.Dead)
+            return false;
+
+        if (patient.Downed)
+            return true;
+
+        PawnCapacitiesHandler capacities = patient.health?.capacities;
+        if (capacities == null)
+            return false;
+
+        return !capacities.CapableOf(PawnCapacityDefOf.Moving) ||
+               capacities.GetLevel(PawnCapacityDefOf.Moving) <= 0f;
+    }
+
     public override bool TryMakePreToilReservations(bool errorOnFailed)
     {
         return pawn.Reserve(Patient, job, 1, -1, null, errorOnFailed) &&
@@ -40,7 +75,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
             Patient == null || Patient.Dead || Casket == null || Casket.HasAnyContents
         );
 
-        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.Touch);
+        // OnCell matches vanilla CarryToCryptosleepCasket and reaches pawns in beds.
+        yield return Toils_Goto.GotoThing(PatientIndex, PathEndMode.OnCell);
 
         /*
          * Sedation may take a few ticks to down a large pawn (humans have a
@@ -57,8 +93,8 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.initAction = () =>
         {
-            // Already downed? Skip the wait entirely.
-            if (Patient != null && Patient.Downed)
+            // Already immobile? Skip the wait entirely.
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -66,7 +102,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.tickAction = () =>
         {
-            if (Patient != null && Patient.Downed)
+            if (PatientIsImmobile())
             {
                 ReadyForNextToil();
             }
@@ -74,7 +110,7 @@ public class JobDriver_CarryToCryoRegenesis : JobDriver
 
         waitForDowned.AddFailCondition(() =>
             waitForDowned.actor.jobs.curDriver.ticksLeftThisToil <= 0 &&
-            (Patient == null || !Patient.Downed)
+            !PatientIsImmobile()
         );
 
         yield return waitForDowned;

--- a/Source/Recipe_AdministerCryoRegenesisSedation.cs
+++ b/Source/Recipe_AdministerCryoRegenesisSedation.cs
@@ -88,16 +88,24 @@ public class Recipe_AdministerCryoRegenesisSedation : Recipe_Surgery
         if (map == null)
             return null;
 
+        /*
+         * Availability (carrier == null) must NOT require the patient to path
+         * to the casket. Prisoners, prison guests, and area-restricted guests
+         * often cannot leave their pen, and the whole point of sedation is that
+         * a doctor carries them. Only check that an empty colony casket exists.
+         *
+         * When applying (carrier != null), require the doctor to reserve/reach.
+         */
         return map.listerBuildings
             .AllBuildingsColonistOfClass<Building_CryoRegenesis>()
             .Where(c => !c.HasAnyContents)
             .OrderBy(c => c.Position.DistanceToSquared(pawn.PositionHeld))
             .FirstOrDefault(c =>
             {
-                if (carrier != null)
-                    return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                if (carrier == null)
+                    return true;
 
-                return pawn.CanReach(c, PathEndMode.InteractionCell, Danger.Deadly);
+                return carrier.CanReserveAndReach(c, PathEndMode.InteractionCell, Danger.Deadly);
             });
     }
 

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ solutionPath="Source/${MOD}.sln"
 
 # Define an array of configurations
 configurations=("v1.2" "v1.3" "v1.4" "v1.5" "v1.6")
+#configurations=("v1.2")
 
 dotnet restore "$solutionPath"
 
@@ -75,16 +76,16 @@ if [ "$1" == "1" ]; then
     exit
 fi
 
-# Watch for changes to .cs and XML files in the directory and subdirectories
-inotifywait --recursive --monitor --format "%e %w%f" \
-    --exclude '/\.idea($|/)' \
-    --event modify,move,create,delete "$dir" "$MOD" |
-    while read event fullpath; do
-        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
-            echo "Running build for $fullpath"
-            build || echo "Build failed, skipping sync."
-        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
-            echo "Running sync_mod for $fullpath"
-            sync_mod
-        fi
-    done
+## Watch for changes to .cs and XML files in the directory and subdirectories
+#inotifywait --recursive --monitor --format "%e %w%f" \
+#    --exclude '/\.idea($|/)' \
+#    --event modify,move,create,delete "$dir" "$MOD" |
+#    while read event fullpath; do
+#        if [[ "$fullpath" == "$dir"* && "$fullpath" == *.cs ]]; then
+#            echo "Running build for $fullpath"
+#            build || echo "Build failed, skipping sync."
+#        elif [[ "$fullpath" == "$MOD"* && "$fullpath" == *.xml ]]; then
+#            echo "Running sync_mod for $fullpath"
+#            sync_mod
+#        fi
+#    done


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Make CryoRegenesis carry and sedation work for downed, anesthetized, and restricted pawns**

### What Changed
- The carry-to-casket option now appears for more immobilized pawns, including downed pawns, pawns at 0% moving capacity, and sedated pawns
- The option now works for prisoners, prison guests, and other pawns who cannot walk to the casket themselves
- Bed occupants are now detected correctly, so the carry option shows up when a pawn is lying in bed
- The sedation bill can now run even when the patient is not already in a bed
- CryoRegenesis caskets can now be ejected by the player
- When no casket is available, the menu and job messages now use clearer wording

### Impact
`✅ Fewer missing carry options for prisoners and guests`
`✅ Shorter sedation-to-casket workflow`
`✅ Clearer no-casket messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
