### PR TITLE
Regen Quests Foundation: Royalty CryoRegenesis contracts with arrival, treatment, and completion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ artifacts/
 *.pidb
 *.svclog
 *.scc
+*.zip
 
 # Chutzpah Test files
 _Chutzpah*

--- a/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
+++ b/CryoRegenesis/Defs/QuestScriptDefs/RoyaltyRegenesisQuestChain.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+  <!-- Persistent parent chain quest. Created in code and kept Ongoing until success or abandoned. -->
+  <QuestScriptDef>
+    <defName>CR_RoyaltyRegenesisQuestChain</defName>
+    <autoAccept>true</autoAccept>
+    <defaultChallengeRating>4</defaultChallengeRating>
+    <isRootSpecial>true</isRootSpecial>
+    <questDescriptionAndNameRules>
+      <rulesStrings>
+        <li>questName->CryoRegenesis: Imperial Rejuvenation</li>
+        <li>questDescription->Planetary factions and eventually the Empire send CryoRegenesis clients by shuttle with fixed return dates. Death or recruitment destroys trust and resets the chain.</li>
+      </rulesStrings>
+    </questDescriptionAndNameRules>
+    <root Class="BetterRimworlds.CryoRegenesis.QuestNode_StartRoyaltyRegenesisChain" />
+  </QuestScriptDef>
+
+  <!-- Per-visit contract quest. Spawned in code for each shuttle delivery; parented to the chain. -->
+  <QuestScriptDef>
+    <defName>CR_RoyaltyRegenesisContract</defName>
+    <autoAccept>true</autoAccept>
+    <defaultChallengeRating>3</defaultChallengeRating>
+    <isRootSpecial>true</isRootSpecial>
+    <questDescriptionAndNameRules>
+      <rulesStrings>
+        <li>questName->CryoRegenesis contract</li>
+        <li>questDescription->Treat contracted clients in a CryoRegenesis casket and return them alive by shuttle before the deadline.</li>
+      </rulesStrings>
+    </questDescriptionAndNameRules>
+    <root Class="BetterRimworlds.CryoRegenesis.QuestNode_StartRoyaltyRegenesisChain" />
+  </QuestScriptDef>
+</Defs>

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -219,7 +219,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             Pawn pawn = ContainedThing as Pawn;
             float pawnAge = pawn.ageTracker.AgeBiologicalTicks / GenDate.TicksPerYear;
 
-            isTargetAge = this.regenesisCycle.IsTargetAge(pawn, rate);
+            isTargetAge = this.regenesisCycle.IsTargetAge(pawn);
             hasInjuries = this.regenesisCycle.HasCurableInjuries;
 
             // if (this.isSafeToRepair == false)
@@ -233,6 +233,14 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
             if (power.PowerOn)
             {
+                // Latch contract completion before the healthy-at-target branch ejects
+                // the pawn and returns. Natural Guest departure otherwise bypasses
+                // MarkTargetAgeReached entirely.
+                if (isTargetAge)
+                {
+                    this.regenesisCycle.MarkTargetAgeReached(pawn);
+                }
+
                 if (isTargetAge && !hasInjuries)
                 {
                     this.EjectContents();
@@ -251,11 +259,6 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                 if (this.regenesisCycle.IsOutOfFuelForHealing(pawn, refuelable))
                 {
                     Log.Message("Not enough Uranium to heal.");
-                }
-
-                if (isTargetAge)
-                {
-                    this.regenesisCycle.MarkTargetAgeReached(pawn);
                 }
 
                 this.regenesisCycle.TryHealNextInjury(pawn, refuelable);

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -479,6 +479,14 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
             string bioTime = "AgeBiological".Translate((NamedArgument) years,
                 (NamedArgument) quadrums, (NamedArgument) days);
 
+            var trueAgeTracker = pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            if (trueAgeTracker != null && trueAgeTracker.underRegenContract && trueAgeTracker.desiredAgeTicks > 0)
+            {
+                bioTime += "\nContract target age: " + trueAgeTracker.GetContractTargetAgeYears().ToString("0.#")
+                    + " (" + trueAgeTracker.GetContractProgressPercent().ToString("0") + "% there)";
+            }
+
             if (this.regenesisCycle.HasCurableInjuries)
             {
                 return base.GetInspectString() + ", " + this.regenesisCycle.AgeHediffs() + " Age Disabilities, " + this.regenesisCycle.InjuryHediffs() + " Injuries\n" + bioTime + "\nTime To Heal: " + this.regenesisCycle.TtlToHeal;

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -233,7 +233,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
             if (power.PowerOn)
             {
-                // Latch contract completion before the healthy-at-target branch ejects
+                // Record contract completion before the healthy-at-target branch ejects
                 // the pawn and returns. Natural Guest departure otherwise bypasses
                 // MarkTargetAgeReached entirely.
                 if (isTargetAge)

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -272,7 +272,7 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                 this.EjectContents();
             }
 
-            if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
+            if (pawn.ageTracker.AgeBiologicalTicks > this.regenesisCycle.TargetAgeTicks)
             {
                 #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
                 power.PowerOutput = -props.PowerConsumption;
@@ -282,11 +282,11 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
 
                 if (power.PowerOn)
                 {
-                    if (pawn.ageTracker.AgeBiologicalTicks > GenDate.TicksPerYear * this.regenesisCycle.TargetAge)
+                    if (pawn.ageTracker.AgeBiologicalTicks > this.regenesisCycle.TargetAgeTicks)
                     {
                         refuelable.ConsumeFuel(fuelConsumption * ((pawnAge - 10) * 0.1f));
 
-                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, GenDate.TicksPerYear * this.regenesisCycle.TargetAge);
+                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, this.regenesisCycle.TargetAgeTicks);
                     }
                 }
             }

--- a/Source/Quests/RoyaltyRegenesisQuestRewards.cs
+++ b/Source/Quests/RoyaltyRegenesisQuestRewards.cs
@@ -1,0 +1,162 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Completion rewards for the planetary-ruler and imperial portions of the
+/// CryoRegenesis quest chain. Each reward includes uranium and Luciferium,
+/// with one additional cache selected at random for its contract tier.
+public partial class RoyaltyRegenesisQuestSystem
+{
+    private const int GuaranteedUranium = 50;
+    private bool completionRewardGranted;
+
+    private void ExposeCompletionRewardData()
+    {
+        Scribe_Values.Look(ref this.completionRewardGranted, "crRoyalCompletionRewardGranted", false);
+    }
+
+    private void ResetCompletionRewardState()
+    {
+        this.completionRewardGranted = false;
+    }
+
+    private void GrantCompletionRewardIfEligible(RoyaltyRegenesisStage contractStage)
+    {
+        if (this.completionRewardGranted || !TryGetRewardTier(contractStage, out CompletionRewardTier tier))
+        {
+            return;
+        }
+
+        Map map = this.GetTargetMap();
+        if (map == null)
+        {
+            Log.Warning("[CryoRegenesis] Could not deliver the contract reward because no player home map is available.");
+            return;
+        }
+
+        RewardEntry bonus = tier.bonuses.RandomElement();
+        List<RewardEntry> rewards = new List<RewardEntry>
+        {
+            new RewardEntry(ThingDefOf.Luciferium, tier.luciferium, "Luciferium"),
+            new RewardEntry(ThingDefOf.Uranium, GuaranteedUranium, "uranium"),
+            bonus,
+        };
+
+        List<Thing> delivered = new List<Thing>();
+        foreach (RewardEntry reward in rewards)
+        {
+            this.SpawnReward(map, reward, delivered);
+        }
+
+        this.completionRewardGranted = true;
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis contract reward",
+            "In gratitude for completing the " + tier.name + " contract, the client has delivered "
+            + tier.luciferium + " Luciferium, " + GuaranteedUranium + " uranium, and a random bonus cache: "
+            + bonus.count + " " + bonus.label + ".",
+            LetterDefOf.PositiveEvent,
+            delivered.Any() ? new LookTargets(delivered) : null);
+    }
+
+    private void SpawnReward(Map map, RewardEntry reward, List<Thing> delivered)
+    {
+        int remaining = reward.count;
+        IntVec3 dropCell = DropCellFinder.TradeDropSpot(map);
+        if (!dropCell.IsValid)
+        {
+            dropCell = DropCellFinder.RandomDropSpot(map);
+        }
+
+        while (remaining > 0)
+        {
+            Thing stack = ThingMaker.MakeThing(reward.def);
+            stack.stackCount = Math.Min(remaining, reward.def.stackLimit);
+            remaining -= stack.stackCount;
+
+            if (GenPlace.TryPlaceThing(stack, dropCell, map, ThingPlaceMode.Near))
+            {
+                delivered.Add(stack);
+            }
+        }
+    }
+
+    private static bool TryGetRewardTier(RoyaltyRegenesisStage stage, out CompletionRewardTier tier)
+    {
+        switch (stage)
+        {
+            case RoyaltyRegenesisStage.Leaders:
+                tier = new CompletionRewardTier("planetary ruler", 10, new List<RewardEntry>
+                {
+                    new RewardEntry(ThingDefOf.ComponentIndustrial, 20, "components"),
+                    new RewardEntry(ThingDefOf.Plasteel, 250, "plasteel"),
+                    new RewardEntry(ThingDefOf.Gold, 75, "gold"),
+                });
+                return true;
+            case RoyaltyRegenesisStage.LowerNobility:
+                tier = new CompletionRewardTier("imperial noble", 15, new List<RewardEntry>
+                {
+                    new RewardEntry(ThingDefOf.ComponentSpacer, 15, "advanced components"),
+                    new RewardEntry(ThingDefOf.Plasteel, 500, "plasteel"),
+                    new RewardEntry(ThingDefOf.Gold, 150, "gold"),
+                });
+                return true;
+            case RoyaltyRegenesisStage.StellarchArrival:
+                tier = new CompletionRewardTier("Stellarch", 20, new List<RewardEntry>
+                {
+                    new RewardEntry(ThingDefOf.ComponentSpacer, 30, "advanced components"),
+                    new RewardEntry(ThingDefOf.Plasteel, 800, "plasteel"),
+                    new RewardEntry(ThingDefOf.Gold, 250, "gold"),
+                });
+                return true;
+            case RoyaltyRegenesisStage.EmperorArrival:
+                tier = new CompletionRewardTier("Emperor", 25, new List<RewardEntry>
+                {
+                    new RewardEntry(ThingDefOf.ComponentSpacer, 50, "advanced components"),
+                    new RewardEntry(ThingDefOf.Plasteel, 1500, "plasteel"),
+                    new RewardEntry(ThingDefOf.Gold, 400, "gold"),
+                });
+                return true;
+            default:
+                tier = null;
+                return false;
+        }
+    }
+
+    private sealed class CompletionRewardTier
+    {
+        public CompletionRewardTier(string name, int luciferium, List<RewardEntry> bonuses)
+        {
+            this.name = name;
+            this.luciferium = luciferium;
+            this.bonuses = bonuses;
+        }
+
+        public readonly string name;
+        public readonly int luciferium;
+        public readonly List<RewardEntry> bonuses;
+    }
+
+    private sealed class RewardEntry
+    {
+        public RewardEntry(ThingDef def, int count, string label)
+        {
+            this.def = def;
+            this.count = count;
+            this.label = label;
+        }
+
+        public readonly ThingDef def;
+        public readonly int count;
+        public readonly string label;
+    }
+}

--- a/Source/Quests/RoyaltyRegenesisQuestRewards.cs
+++ b/Source/Quests/RoyaltyRegenesisQuestRewards.cs
@@ -81,10 +81,10 @@ public partial class RoyaltyRegenesisQuestSystem
         {
             Thing stack = ThingMaker.MakeThing(reward.def);
             stack.stackCount = Math.Min(remaining, reward.def.stackLimit);
-            remaining -= stack.stackCount;
 
             if (GenPlace.TryPlaceThing(stack, dropCell, map, ThingPlaceMode.Near))
             {
+                remaining -= stack.stackCount;
                 delivered.Add(stack);
             }
         }

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -26,6 +26,7 @@ public class RegenesisCycle
     private bool enteredHealthy;
     private long restoreCoolDown = NoRegenesisInProgress;
     private int targetAge;
+    private long targetAgeTicks;
     private string ttlToHeal;
     private int origAge;
 
@@ -33,6 +34,7 @@ public class RegenesisCycle
     public bool HasCurableInjuries => this.hediffsToHeal.Any();
     public int OriginalAge => this.origAge;
     public int TargetAge => this.targetAge;
+    public long TargetAgeTicks => this.targetAgeTicks;
     public string TtlToHeal => this.ttlToHeal;
 
     public void ExposeData()
@@ -61,7 +63,7 @@ public class RegenesisCycle
 
     public bool IsTargetAge(Pawn pawn, int rate)
     {
-        return pawn.ageTracker.AgeBiologicalTicks <= ((GenDate.TicksPerYear * this.targetAge) + rate);
+        return pawn.ageTracker.AgeBiologicalTicks <= (this.targetAgeTicks + rate);
     }
 
     public void UpdateHealingEta(Pawn pawn, int rate)
@@ -383,10 +385,21 @@ public class RegenesisCycle
         if (pawn.RaceProps.Humanlike)
         {
             this.targetAge = CryoRegenesis.Settings.targetAge;
+            this.targetAgeTicks = GenDate.TicksPerYear * (long)this.targetAge;
         }
         else
         {
             this.targetAge = (int)Math.Floor(pawn.RaceProps.lifeExpectancy * 0.25);
+            this.targetAgeTicks = GenDate.TicksPerYear * (long)this.targetAge;
+        }
+
+        TrueAgeTracker tracker =
+            pawn.health?.hediffSet?.GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+
+        if (tracker?.desiredAgeTicks > 0)
+        {
+            this.targetAgeTicks = tracker.desiredAgeTicks;
+            this.targetAge = (int)Math.Ceiling((double)this.targetAgeTicks / GenDate.TicksPerYear);
         }
 
         if (CryoRegenesis.Settings.debugMode)

--- a/Source/RegenesisCycle.cs
+++ b/Source/RegenesisCycle.cs
@@ -59,16 +59,17 @@ public class RegenesisCycle
     public void MarkTargetAgeReached(Pawn pawn)
     {
         this.restoreCoolDown = pawn.ageTracker.AgeBiologicalTicks;
+        RoyaltyRegenesisQuestSystem.NotifyRegenesisTargetReached(pawn);
     }
 
-    public bool IsTargetAge(Pawn pawn, int rate)
+    public bool IsTargetAge(Pawn pawn)
     {
-        return pawn.ageTracker.AgeBiologicalTicks <= (this.targetAgeTicks + rate);
+        return pawn.ageTracker.AgeBiologicalTicks <= this.targetAgeTicks;
     }
 
     public void UpdateHealingEta(Pawn pawn, int rate)
     {
-        if (!this.HasCurableInjuries || this.IsTargetAge(pawn, rate) || this.restoreCoolDown == NoRegenesisInProgress)
+        if (!this.HasCurableInjuries || this.IsTargetAge(pawn) || this.restoreCoolDown == NoRegenesisInProgress)
         {
             return;
         }
@@ -180,6 +181,11 @@ public class RegenesisCycle
 
     public bool ShouldEjectAfterHealing(Pawn pawn)
     {
+        if (RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(pawn))
+        {
+            return false;
+        }
+
         return CryoRegenesis.Settings.regenUntilHealed
             && !this.enteredHealthy
             && pawn.RaceProps.Humanlike

--- a/Source/RegenesisThoughts.cs
+++ b/Source/RegenesisThoughts.cs
@@ -26,6 +26,7 @@ public static class RegenesisThoughts
     /// actually de-aged the pawn. Stage, description years, and duration use
     /// lifetime years erased from the True Age tracker (must be updated first).
     /// Stack count scales with how many years this session removed.
+    /// <param name="pawn">The target HumanLike.</param>
     /// <param name="sessionYearsRemoved">Whole years of bio-age removed this eject (gate + multi-stack).</param>
     public static void AddBodyPositivityThought(Pawn pawn, int sessionYearsRemoved)
     {
@@ -94,8 +95,6 @@ public static class RegenesisThoughts
         if (lastThought.CurStageIndex >= 2)
         {
             // Regen-quest contract clients must never become voluntarily recruitable.
-            TrueAgeTracker tracker = pawn.health?.hediffSet?
-                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
             bool underContract = (tracker != null && tracker.underRegenContract)
                 || RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(pawn);
 

--- a/Source/RegenesisThoughts.cs
+++ b/Source/RegenesisThoughts.cs
@@ -22,12 +22,10 @@ public static class RegenesisThoughts
 {
     private const int YearsPerStack = 15;
 
-    /// <summary>
     /// Grant stackable body-positivity memories after a CryoRegenesis eject that
     /// actually de-aged the pawn. Stage, description years, and duration use
     /// lifetime years erased from the True Age tracker (must be updated first).
     /// Stack count scales with how many years this session removed.
-    /// </summary>
     /// <param name="sessionYearsRemoved">Whole years of bio-age removed this eject (gate + multi-stack).</param>
     public static void AddBodyPositivityThought(Pawn pawn, int sessionYearsRemoved)
     {
@@ -95,7 +93,13 @@ public static class RegenesisThoughts
         #if !RIMWORLD12 && !RIMWORLD13
         if (lastThought.CurStageIndex >= 2)
         {
-            if (pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
+            // Regen-quest contract clients must never become voluntarily recruitable.
+            TrueAgeTracker tracker = pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            bool underContract = (tracker != null && tracker.underRegenContract)
+                || RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(pawn);
+
+            if (!underContract && pawn.IsPrisoner && pawn.guest != null && !pawn.guest.Recruitable)
             {
                 pawn.guest.Recruitable = true;
                 Messages.Message("Grateful to be so much younger, " + pawn.Name + " is now recruitable.", pawn, MessageTypeDefOf.PositiveEvent);

--- a/Source/RoyaltyRegenesisQuestParts.cs
+++ b/Source/RoyaltyRegenesisQuestParts.cs
@@ -1,0 +1,174 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Live progress text for the persistent chain quest in the Quests tab.
+public class QuestPart_RoyaltyRegenesisChainStatus : QuestPart
+{
+    public override string DescriptionPart
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            return system != null ? system.GetChainProgressDescription() : string.Empty;
+        }
+    }
+}
+
+/// Live progress text for an individual CryoRegenesis contract quest.
+public class QuestPart_RoyaltyRegenesisContractStatus : QuestPart
+{
+    public override string DescriptionPart
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            return system != null ? system.GetContractProgressDescription() : string.Empty;
+        }
+    }
+
+    public override IEnumerable<GlobalTargetInfo> QuestLookTargets
+    {
+        get
+        {
+            RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+            if (system == null)
+            {
+                yield break;
+            }
+
+            foreach (RoyaltyRegenesisClient client in system.ActiveClients)
+            {
+                if (client?.pawn != null && !client.pawn.Destroyed)
+                {
+                    yield return client.pawn;
+                }
+            }
+        }
+    }
+}
+
+/// Creates and maintains RimWorld Quest objects for the Regenesis campaign.
+public static class RoyaltyRegenesisQuestFactory
+{
+    public const string ChainQuestDefName = "CR_RoyaltyRegenesisQuestChain";
+    public const string ContractQuestDefName = "CR_RoyaltyRegenesisContract";
+
+    public static Quest MakeChainQuest()
+    {
+        Quest quest = Quest.MakeRaw();
+        quest.name = "CryoRegenesis: Imperial Rejuvenation";
+        quest.description = BuildChainDescriptionBody();
+        quest.root = DefDatabase<QuestScriptDef>.GetNamedSilentFail(ChainQuestDefName);
+        quest.challengeRating = 4;
+        quest.AddPart(new QuestPart_RoyaltyRegenesisChainStatus());
+        Find.QuestManager.Add(quest);
+        quest.Accept(null);
+        return quest;
+    }
+
+    public static Quest MakeContractQuest(string title, string description, Quest parentChain)
+    {
+        Quest quest = Quest.MakeRaw();
+        quest.name = title;
+        quest.description = description;
+        quest.root = DefDatabase<QuestScriptDef>.GetNamedSilentFail(ContractQuestDefName);
+        quest.challengeRating = 3;
+#if !RIMWORLD12
+        if (parentChain != null)
+        {
+            quest.parent = parentChain;
+        }
+#endif
+        quest.AddPart(new QuestPart_RoyaltyRegenesisContractStatus());
+        Find.QuestManager.Add(quest);
+        quest.Accept(null);
+        return quest;
+    }
+
+    public static void EndQuestSafe(Quest quest, QuestEndOutcome outcome, bool sendLetter = true)
+    {
+        if (quest == null || quest.Historical)
+        {
+            return;
+        }
+
+        quest.End(outcome, sendLetter);
+    }
+
+    public static string BuildChainDescriptionBody()
+    {
+        return
+            "Planetary factions will send CryoRegenesis clients by shuttle with fixed return dates. " +
+            "Complete enough foreign contracts and the Empire takes notice — lower nobility, then the Stellarch, then the Emperor.\n\n" +
+            "Rules:\n" +
+            "• Clients arrive and leave by shuttle.\n" +
+            "• Never recruit them (recruitment destroys trust).\n" +
+            "• If a client dies under contract, trust collapses and progress resets.\n\n" +
+            "Track live stage progress below.";
+    }
+
+    public static string BuildContractDescription(
+        string roleSummary,
+        Faction sender,
+        bool isPrisoner,
+        int returnByTick,
+        IEnumerable<Pawn> clients)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(roleSummary);
+        sb.AppendLine();
+        if (sender != null)
+        {
+            sb.AppendLine("Sending faction: " + sender.Name);
+        }
+
+        sb.AppendLine(isPrisoner
+            ? "Status: prisoners under contract (do not recruit)."
+            : "Status: guests under contract (do not recruit).");
+        sb.AppendLine("Return shuttle arrives: " + FormatGameTickDate(returnByTick));
+        sb.AppendLine();
+        sb.AppendLine("Clients:");
+        foreach (Pawn pawn in clients.Where(p => p != null))
+        {
+            sb.AppendLine("• " + pawn.Name.ToStringFull + " (bio age " + pawn.ageTracker.AgeBiologicalYears + ")");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Objectives:");
+        sb.AppendLine("1. Place clients in a CryoRegenesis casket.");
+        sb.AppendLine("2. Reach their requested regression age before the return shuttle.");
+        sb.AppendLine("3. Return them alive by shuttle — death or recruitment resets the whole chain.");
+        return sb.ToString().TrimEnd();
+    }
+
+    /// Formats a <see cref="TickManager.TicksGame"/> value as a calendar date.
+    /// GenDate expects absolute ticks, so convert from game ticks first.
+    public static string FormatGameTickDate(int ticksGame)
+    {
+        int tile = Find.CurrentMap?.Tile ?? Find.AnyPlayerHomeMap?.Tile ?? 0;
+        int delta = ticksGame - Find.TickManager.TicksGame;
+        int absTick = Find.TickManager.TicksAbs + delta;
+        return GenDate.DateFullStringAt(absTick, Find.WorldGrid.LongLatOf(tile));
+    }
+
+    public static string FormatTickDate(int absoluteTick)
+    {
+        int tile = Find.CurrentMap?.Tile ?? Find.AnyPlayerHomeMap?.Tile ?? 0;
+        return GenDate.DateFullStringAt(absoluteTick, Find.WorldGrid.LongLatOf(tile));
+    }
+}

--- a/Source/RoyaltyRegenesisQuestParts.cs
+++ b/Source/RoyaltyRegenesisQuestParts.cs
@@ -140,7 +140,7 @@ public static class RoyaltyRegenesisQuestFactory
         sb.AppendLine(isPrisoner
             ? "Status: prisoners under contract (do not recruit)."
             : "Status: guests under contract (do not recruit).");
-        sb.AppendLine("Return shuttle arrives: " + FormatGameTickDate(returnByTick));
+        sb.AppendLine("Shuttle departs (parked on site until then): " + FormatGameTickDate(returnByTick));
         sb.AppendLine();
         sb.AppendLine("Clients:");
         foreach (Pawn pawn in clients.Where(p => p != null))
@@ -151,8 +151,8 @@ public static class RoyaltyRegenesisQuestFactory
         sb.AppendLine();
         sb.AppendLine("Objectives:");
         sb.AppendLine("1. Place clients in a CryoRegenesis casket.");
-        sb.AppendLine("2. Reach their requested regression age before the return shuttle.");
-        sb.AppendLine("3. Return them alive by shuttle — death or recruitment resets the whole chain.");
+        sb.AppendLine("2. Reach their requested regression age before their shuttle departs.");
+        sb.AppendLine("3. Return them alive aboard their shuttle — death or recruitment resets the whole chain.");
         return sb.ToString().TrimEnd();
     }
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1220,10 +1220,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
             if (extraFactionPart == null)
             {
-                extraFactionPart = this.activeContractQuest.ExtraFaction(
-                    homeFaction,
-                    pawns,
-                    ExtraFactionType.HomeFaction);
+                extraFactionPart = new QuestPart_ExtraFaction
+                {
+                    extraFaction = new ExtraFaction(homeFaction, ExtraFactionType.HomeFaction),
+                    affectedPawns = new List<Pawn>(pawns)
+                };
+                this.activeContractQuest.AddPart(extraFactionPart);
             }
             else
             {

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -21,7 +21,7 @@ using LudeonTK;
 
 namespace BetterRimworlds.CryoRegenesis;
 
-public class RoyaltyRegenesisQuestSystem : GameComponent
+public partial class RoyaltyRegenesisQuestSystem : GameComponent
 {
     private const int CheckIntervalTicks = 2500;
     private const int HalfYearTicks = GenDate.TicksPerYear / 2;
@@ -127,6 +127,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
         Scribe_References.Look(ref this.contractShuttle, "crRoyalContractShuttle");
+        this.ExposeCompletionRewardData();
 
         if (Scribe.mode == LoadSaveMode.PostLoadInit)
         {
@@ -615,6 +616,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.pickupShuttleSpawnTick = -1;
         this.pickupAllClientsReady = false;
         this.contractCompletionLogged = false;
+        this.ResetCompletionRewardState();
     }
 
     private void ApplyGuestOrPrisonerStatus(Pawn pawn, bool isPrisoner)
@@ -1119,6 +1121,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         if (triggerEndgame && success)
         {
             this.LogRoyaltyDebug("Outcome: SUCCESS + Royal Ascent endgame.");
+            this.GrantCompletionRewardIfEligible(this.activeContractStage);
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.stage = RoyaltyRegenesisStage.Completed;
             this.royalAscentTriggered = true;
@@ -1130,6 +1133,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         if (success)
         {
             this.LogRoyaltyDebug("Outcome: SUCCESS — CompleteActiveContract.");
+            this.GrantCompletionRewardIfEligible(this.activeContractStage);
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.CompleteActiveContract();
         }
@@ -1575,6 +1579,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.LogRoyaltyDebug(
             "All clients reached target age → contract quest completed now (stage=" + this.activeContractStage + ").");
         this.EndActiveContractQuest(QuestEndOutcome.Success);
+        this.GrantCompletionRewardIfEligible(this.activeContractStage);
 
         if (this.activeClients.Any(client => client != null && client.triggerRoyalAscent))
         {

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1,0 +1,1660 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using RimWorld;
+using RimWorld.QuestGen;
+using Verse;
+
+#if RIMWORLD15 || RIMWORLD16
+using LudeonTK;
+#endif
+
+namespace BetterRimworlds.CryoRegenesis;
+
+public class RoyaltyRegenesisQuestSystem : GameComponent
+{
+    private const int CheckIntervalTicks = 2500;
+    private const int HalfYearTicks = GenDate.TicksPerYear / 2;
+    private const int RecruitGoodwillPenalty = -35;
+    private const int DeathTrustGoodwillPenalty = -75;
+    private const int MinContractDays = 3;
+    private const int MaxContractDays = 30;
+    private const int MajorResetMinDays = 60;
+    private const int MajorResetMaxDays = 90;
+
+    private RoyaltyRegenesisStage stage = RoyaltyRegenesisStage.NotStarted;
+    private RoyaltyRegenesisStage activeContractStage = RoyaltyRegenesisStage.NotStarted;
+    private int nextEventTick = -1;
+    private int rulerContractsCompleted;
+    private int leaderContractsCompleted;
+    private int nobleContractsCompleted;
+    private bool royalAscentTriggered;
+    private int trustBreaks;
+    private string lastTrustBreakReason = string.Empty;
+    private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
+    private Quest chainQuest;
+    private Quest activeContractQuest;
+
+    public RoyaltyRegenesisQuestSystem(Game game)
+    {
+    }
+
+    public IReadOnlyList<RoyaltyRegenesisClient> ActiveClients => this.activeClients;
+
+    public static RoyaltyRegenesisQuestSystem CurrentSystem =>
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>();
+
+    public static bool IsActiveRegenContractPawn(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return false;
+        }
+
+        RoyaltyRegenesisQuestSystem system = CurrentSystem;
+        return system != null && system.activeClients.Any(client => client?.pawn == pawn);
+    }
+
+    public static RoyaltyRegenesisClient GetActiveClient(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return null;
+        }
+
+        return CurrentSystem?.activeClients.FirstOrDefault(client => client?.pawn == pawn);
+    }
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+
+        Scribe_Values.Look(ref this.stage, "crRoyalStage", RoyaltyRegenesisStage.NotStarted);
+        Scribe_Values.Look(ref this.activeContractStage, "crRoyalActiveContractStage", RoyaltyRegenesisStage.NotStarted);
+        Scribe_Values.Look(ref this.nextEventTick, "crRoyalNextEventTick", -1);
+        Scribe_Values.Look(ref this.rulerContractsCompleted, "crRoyalRulerContractsCompleted", 0);
+        Scribe_Values.Look(ref this.leaderContractsCompleted, "crRoyalLeaderContractsCompleted", 0);
+        Scribe_Values.Look(ref this.nobleContractsCompleted, "crRoyalNobleContractsCompleted", 0);
+        Scribe_Values.Look(ref this.royalAscentTriggered, "crRoyalAscentTriggered", false);
+        Scribe_Values.Look(ref this.trustBreaks, "crRoyalTrustBreaks", 0);
+        Scribe_Values.Look(ref this.lastTrustBreakReason, "crRoyalLastTrustBreakReason");
+        Scribe_Collections.Look(ref this.activeClients, "crRoyalActiveClients", LookMode.Deep);
+        Scribe_References.Look(ref this.chainQuest, "crRoyalChainQuest");
+        Scribe_References.Look(ref this.activeContractQuest, "crRoyalActiveContractQuest");
+
+        if (Scribe.mode == LoadSaveMode.PostLoadInit)
+        {
+            if (this.activeClients == null)
+            {
+                this.activeClients = new List<RoyaltyRegenesisClient>();
+            }
+
+            if (this.lastTrustBreakReason == null)
+            {
+                this.lastTrustBreakReason = string.Empty;
+            }
+        }
+    }
+
+    public override void GameComponentTick()
+    {
+        base.GameComponentTick();
+
+        if (!ModsConfig.RoyaltyActive)
+        {
+            return;
+        }
+
+        if (Find.TickManager.TicksGame % CheckIntervalTicks != 0)
+        {
+            return;
+        }
+
+        if (!this.CanRunCampaign())
+        {
+            return;
+        }
+
+        this.CheckActiveClients();
+
+        if (this.activeClients.Any())
+        {
+            return;
+        }
+
+        int ticksGame = Find.TickManager.TicksGame;
+        if (this.stage == RoyaltyRegenesisStage.NotStarted)
+        {
+            // Other planetary factions send clients first. The Empire only
+            // notices after those contracts succeed.
+            this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+            this.nextEventTick = ticksGame + Rand.RangeInclusive(3, 8) * GenDate.TicksPerDay;
+            this.EnsureChainQuest();
+        }
+        else if (this.stage != RoyaltyRegenesisStage.Completed)
+        {
+            this.EnsureChainQuest();
+        }
+
+        if (this.stage != RoyaltyRegenesisStage.Completed && ticksGame >= this.nextEventTick)
+        {
+            this.AdvanceCampaign();
+        }
+    }
+
+    private bool CanRunCampaign()
+    {
+        return Find.Maps.Any(map =>
+            map.IsPlayerHome &&
+            map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any());
+    }
+
+    private Map GetTargetMap()
+    {
+        return Find.Maps.FirstOrDefault(map =>
+            map.IsPlayerHome &&
+            map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any());
+    }
+
+    private void AdvanceCampaign()
+    {
+        Map map = this.GetTargetMap();
+        if (map == null)
+        {
+            this.nextEventTick = Find.TickManager.TicksGame + GenDate.TicksPerDay;
+            return;
+        }
+
+        switch (this.stage)
+        {
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                this.StartRulerPrisonerContract(map);
+                break;
+            case RoyaltyRegenesisStage.Leaders:
+                this.StartLeaderContract(map);
+                break;
+            case RoyaltyRegenesisStage.LowerNobility:
+                this.StartLowerNobilityContract(map);
+                break;
+            case RoyaltyRegenesisStage.StellarchNotice:
+                this.SendTravelNotice(
+                    "The Stellarch has taken notice",
+                    "Reports of successful CryoRegenesis treatments have reached the Stellarch. An imperial shuttle has departed. It should arrive in several days.");
+                this.stage = RoyaltyRegenesisStage.StellarchArrival;
+                this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(3, 8) * GenDate.TicksPerDay;
+                break;
+            case RoyaltyRegenesisStage.StellarchArrival:
+                this.StartStellarchContract(map);
+                break;
+            case RoyaltyRegenesisStage.EmperorNotice:
+                int years = Rand.RangeInclusive(1, 10);
+                this.SendTravelNotice(
+                    "The Emperor is coming",
+                    $"The restored Stellarch's report has reached the Emperor. The imperial household has committed to the journey, but interstellar travel will take {years} year(s).");
+                this.stage = RoyaltyRegenesisStage.EmperorArrival;
+                this.nextEventTick = Find.TickManager.TicksGame + years * GenDate.TicksPerYear;
+                break;
+            case RoyaltyRegenesisStage.EmperorArrival:
+                this.StartEmperorContract(map);
+                break;
+        }
+    }
+
+    public void DebugStartAt(RoyaltyRegenesisStage debugStage)
+    {
+        if (!ModsConfig.RoyaltyActive)
+        {
+            Messages.Message("CryoRegenesis Royalty quest chain requires the Royalty DLC.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        if (this.GetTargetMap() == null)
+        {
+            Messages.Message("Build a CryoRegenesis casket on a player home map before starting the Royalty quest chain.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
+        this.activeClients.Clear();
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = debugStage;
+        this.nextEventTick = Find.TickManager.TicksGame;
+        this.EnsureChainQuest();
+        this.AdvanceCampaign();
+    }
+
+    public void DebugTriggerNextEvent()
+    {
+        if (!ModsConfig.RoyaltyActive)
+        {
+            Messages.Message("CryoRegenesis Royalty quest chain requires the Royalty DLC.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        if (this.GetTargetMap() == null)
+        {
+            Messages.Message("Build a CryoRegenesis casket on a player home map before triggering the next Royalty quest event.", MessageTypeDefOf.RejectInput);
+            return;
+        }
+
+        this.nextEventTick = Find.TickManager.TicksGame;
+        this.AdvanceCampaign();
+    }
+
+    private void StartRulerPrisonerContract(Map map)
+    {
+        Faction sender = this.RandomPlanetarySenderFaction();
+        if (sender == null)
+        {
+            this.ScheduleRetry(
+                "No eligible factions",
+                "No non-Empire, non-Ancient planetary factions are available to send CryoRegenesis prisoners. Retrying later.");
+            return;
+        }
+
+        int pawnCount = Rand.RangeInclusive(1, 2);
+        List<Pawn> pawns = new List<Pawn>();
+        int contractDays = 0;
+
+        for (int i = 0; i < pawnCount; i++)
+        {
+            Pawn pawn = this.GeneratePawn(this.CommonPawnKind(sender), sender, Rand.RangeInclusive(24, 70));
+            int duration = Rand.Element(HalfYearTicks, GenDate.TicksPerYear, GenDate.TicksPerYear * 2);
+            long targetTicks = Math.Max(18L * GenDate.TicksPerYear, pawn.ageTracker.AgeBiologicalTicks - duration);
+            int days = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
+            contractDays = Math.Max(contractDays, days);
+            this.PrepareClient(pawn, targetTicks, "foreign prisoner", sender, isPrisoner: true, contractDays: days);
+            pawns.Add(pawn);
+        }
+
+        this.activeContractStage = RoyaltyRegenesisStage.RulerPrisoners;
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"{sender.Name} has sent prisoners for a trial CryoRegenesis contract. " +
+            $"Their requested regression is six months, one year, or two years. " +
+            $"They arrive and depart by shuttle and must be returned by {returnText}. " +
+            "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            pawns,
+            sender,
+            "CryoRegenesis contract: prisoners",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Prisoner trial",
+            letterBody,
+            sender,
+            isPrisoner: true);
+    }
+
+    private void StartLeaderContract(Map map)
+    {
+        Faction sender = this.RandomPlanetarySenderFaction();
+        if (sender == null)
+        {
+            this.ScheduleRetry(
+                "No eligible factions",
+                "No non-Empire, non-Ancient planetary leaders are available for a CryoRegenesis stay. Retrying later.");
+            return;
+        }
+
+        Pawn leader = this.GeneratePawn(this.NoblePawnKind(sender), sender, Rand.RangeInclusive(35, 82));
+        int yearsToRemove = Rand.RangeInclusive(2, 18);
+        long targetTicks = Math.Max(30L * GenDate.TicksPerYear, leader.ageTracker.AgeBiologicalTicks - yearsToRemove * GenDate.TicksPerYear);
+        int contractDays = this.CalculateContractDays(leader.ageTracker.AgeBiologicalTicks - targetTicks);
+
+        // Leaders come as guests (not prisoners) with a hard return time.
+        this.PrepareClient(leader, targetTicks, "planetary ruler", sender, isPrisoner: false, contractDays: contractDays);
+        this.activeContractStage = RoyaltyRegenesisStage.Leaders;
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"{leader.Name.ToStringShort} of {sender.Name}, a ruler over the age of 30, has arrived by shuttle " +
+            $"for a privately negotiated CryoRegenesis stay. The shuttle returns on {returnText}. " +
+            "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            new List<Pawn> { leader },
+            sender,
+            "CryoRegenesis contract: ruler",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Planetary ruler",
+            letterBody,
+            sender,
+            isPrisoner: false);
+    }
+
+    private void StartLowerNobilityContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the lower nobility contract.");
+            return;
+        }
+
+        Pawn pawn = this.GeneratePawn(this.LowerNoblePawnKind(), empire, Rand.RangeInclusive(31, 72));
+        int targetAge = Rand.RangeInclusive(21, 40);
+        long targetTicks = targetAge * (long)GenDate.TicksPerYear;
+        int contractDays = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
+
+        this.PrepareClient(pawn, targetTicks, "lower imperial noble", empire, isPrisoner: false, contractDays: contractDays);
+        this.activeContractStage = RoyaltyRegenesisStage.LowerNobility;
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Empire has sent {pawn.Name.ToStringShort}, a lower noble, by shuttle to verify your CryoRegenesis process. " +
+            $"They must return by {returnText}. Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+        this.DeliverClientsByShuttle(
+            map,
+            new List<Pawn> { pawn },
+            empire,
+            "Imperial CryoRegenesis contract",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Imperial noble",
+            letterBody,
+            empire,
+            isPrisoner: false);
+    }
+
+    private void StartStellarchContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the Stellarch contract.");
+            return;
+        }
+
+        Pawn stellarch = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(45, 85));
+        this.TrySetRoyalTitle(stellarch, empire, "Stellarch");
+
+        int targetAge = Rand.RangeInclusive(21, 35);
+        long targetTicks = targetAge * (long)GenDate.TicksPerYear;
+        List<Pawn> party = new List<Pawn> { stellarch };
+        int contractDays = this.CalculateContractDays(stellarch.ageTracker.AgeBiologicalTicks - targetTicks);
+        this.PrepareClient(stellarch, targetTicks, "stellarch", empire, isPrisoner: false, contractDays: contractDays);
+        party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
+
+        this.activeContractStage = RoyaltyRegenesisStage.StellarchArrival;
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Stellarch has arrived by shuttle for CryoRegenesis and has chosen to regress to age {targetAge}. " +
+            $"Any spouses or lovers in the party have chosen age 30. The imperial shuttle returns on {returnText}.";
+        this.DeliverClientsByShuttle(
+            map,
+            party,
+            empire,
+            "The Stellarch has arrived",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: Stellarch",
+            letterBody,
+            empire,
+            isPrisoner: false);
+    }
+
+    private void StartEmperorContract(Map map)
+    {
+        Faction empire = this.EmpireFaction();
+        if (empire == null)
+        {
+            this.ScheduleRetry("Empire unavailable", "The Empire could not be found for the Emperor contract.");
+            return;
+        }
+
+        Pawn emperor = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(60, 100));
+        this.TrySetRoyalTitle(emperor, empire, "Emperor");
+
+        List<Pawn> party = new List<Pawn> { emperor };
+        long targetTicks = 20L * GenDate.TicksPerYear;
+        int contractDays = this.CalculateContractDays(emperor.ageTracker.AgeBiologicalTicks - targetTicks);
+        this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
+        party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
+
+        this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
+        string returnText = this.FormatReturnDeadline(contractDays);
+        string letterBody =
+            $"The Emperor has arrived by shuttle for CryoRegenesis and will regress to age 20. " +
+            $"Any spouses or lovers in the party have chosen age 21. The imperial shuttle returns on {returnText}.";
+        this.DeliverClientsByShuttle(
+            map,
+            party,
+            empire,
+            "The Emperor has arrived",
+            letterBody);
+        this.BeginContractQuest(
+            "CryoRegenesis: The Emperor",
+            letterBody,
+            empire,
+            isPrisoner: false);
+    }
+
+    private List<Pawn> GetOrGeneratePartners(Pawn noble, Faction faction, int targetAge, string role, bool isPrisoner, int contractDays)
+    {
+        List<Pawn> partners = noble.relations?.DirectRelations
+            ?.Where(relation =>
+                relation.def == PawnRelationDefOf.Spouse ||
+                relation.def == PawnRelationDefOf.Lover ||
+                relation.def == PawnRelationDefOf.Fiance)
+            .Select(relation => relation.otherPawn)
+            .Where(pawn => pawn != null && !pawn.Dead)
+            .Distinct()
+            .ToList() ?? new List<Pawn>();
+
+        if (!partners.Any() && Rand.Chance(0.65f))
+        {
+            Pawn spouse = this.GeneratePawn(this.NoblePawnKind(faction), faction, Rand.RangeInclusive(35, 80));
+            noble.relations.AddDirectRelation(PawnRelationDefOf.Spouse, spouse);
+            partners.Add(spouse);
+        }
+
+        foreach (Pawn partner in partners)
+        {
+            if (partner.ageTracker.AgeBiologicalYears < targetAge + 5)
+            {
+                partner.ageTracker.AgeBiologicalTicks = Rand.RangeInclusive(targetAge + 10, targetAge + 45) * (long)GenDate.TicksPerYear;
+            }
+
+            this.PrepareClient(partner, targetAge * (long)GenDate.TicksPerYear, role, faction, isPrisoner, contractDays);
+        }
+
+        return partners;
+    }
+
+    private void PrepareClient(
+        Pawn pawn,
+        long desiredAgeTicks,
+        string role,
+        Faction sourceFaction,
+        bool isPrisoner,
+        int contractDays,
+        bool triggerRoyalAscent = false)
+    {
+        desiredAgeTicks = Math.Max(0, Math.Min(desiredAgeTicks, pawn.ageTracker.AgeBiologicalTicks));
+        TrueAgeTracker tracker = RegenesisThoughts.GetOrAddTrueAgeTracker(pawn, pawn.ageTracker.AgeBiologicalTicks);
+        if (tracker != null)
+        {
+            tracker.desiredAgeTicks = desiredAgeTicks;
+            tracker.underRegenContract = true;
+        }
+
+        this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner);
+        this.LockRecruitment(pawn);
+
+        if (isPrisoner && !pawn.health.hediffSet.HasHediff(HediffDefOf.Anesthetic))
+        {
+            pawn.health.AddHediff(HediffDefOf.Anesthetic);
+        }
+
+        int returnByTick = Find.TickManager.TicksGame + Math.Max(MinContractDays, contractDays) * GenDate.TicksPerDay;
+
+        this.activeClients.Add(new RoyaltyRegenesisClient
+        {
+            pawn = pawn,
+            desiredAgeTicks = desiredAgeTicks,
+            role = role,
+            triggerRoyalAscent = triggerRoyalAscent,
+            returnByTick = returnByTick,
+            isPrisoner = isPrisoner,
+            sourceFaction = sourceFaction,
+        });
+    }
+
+    private void ApplyGuestOrPrisonerStatus(Pawn pawn, bool isPrisoner)
+    {
+        if (pawn?.guest == null)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        pawn.guest.SetGuestStatus(Faction.OfPlayer, isPrisoner);
+#else
+        pawn.guest.SetGuestStatus(Faction.OfPlayer, isPrisoner ? GuestStatus.Prisoner : GuestStatus.Guest);
+#endif
+
+        if (isPrisoner)
+        {
+#if RIMWORLD12 || RIMWORLD13 || RIMWORLD14
+            pawn.guest.interactionMode = PrisonerInteractionModeDefOf.NoInteraction;
+#else
+            // 1.5+: exclusive interaction modes; block recruitment attempts.
+            pawn.guest.SetNoInteraction();
+#endif
+#if !RIMWORLD12 && !RIMWORLD13
+            // Keep resistance high so they never "break" into recruitability.
+            if (pawn.guest.resistance < 50f)
+            {
+                pawn.guest.resistance = 99f;
+            }
+#endif
+        }
+    }
+
+    private void LockRecruitment(Pawn pawn)
+    {
+        if (pawn?.guest == null)
+        {
+            return;
+        }
+
+#if !RIMWORLD12 && !RIMWORLD13
+        pawn.guest.Recruitable = false;
+#endif
+    }
+
+    private int CalculateContractDays(long bioTicksToRemove)
+    {
+        // Treatment is fast in-casket, but contracts are narrative stays with a hard pickup.
+        double years = Math.Max(0.25, (double)bioTicksToRemove / GenDate.TicksPerYear);
+        int days = (int)Math.Ceiling(8 + years * 4);
+        return Math.Max(MinContractDays, Math.Min(MaxContractDays, days));
+    }
+
+    private string FormatReturnDeadline(int contractDays)
+    {
+        int returnTick = Find.TickManager.TicksGame + contractDays * GenDate.TicksPerDay;
+        return GenDate.DateFullStringAt(returnTick, Find.WorldGrid.LongLatOf(Find.CurrentMap?.Tile ?? 0));
+    }
+
+    private void DeliverClientsByShuttle(Map map, List<Pawn> pawns, Faction faction, string label, string text)
+    {
+        if (map == null || pawns == null || !pawns.Any())
+        {
+            return;
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+
+#if RIMWORLD12
+        this.DeliverByLegacyShuttle(map, pawns, faction, cell);
+#else
+        this.DeliverByTransportShip(map, pawns, faction, cell);
+#endif
+
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent, new LookTargets(pawns));
+    }
+
+#if RIMWORLD12
+    private void DeliverByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    {
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        if (transporter != null)
+        {
+            transporter.innerContainer.TryAddRangeOrTransfer(pawns.Cast<Thing>().ToList(), true, true);
+        }
+
+        if (compShuttle != null)
+        {
+            compShuttle.dropEverythingOnArrival = true;
+            compShuttle.leaveAfterTicks = GenDate.TicksPerHour;
+        }
+
+        Skyfaller skyfaller = SkyfallerMaker.MakeSkyfaller(ThingDefOf.ShuttleIncoming, shuttle);
+        GenPlace.TryPlaceThing(skyfaller, cell, map, ThingPlaceMode.Near);
+    }
+
+    private void DepartByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction)
+    {
+        this.EjectClientsFromCaskets(map, pawns);
+
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+        GenPlace.TryPlaceThing(shuttle, cell, map, ThingPlaceMode.Near);
+
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        foreach (Pawn pawn in pawns.Where(p => p != null && !p.Destroyed))
+        {
+            this.TransferPawnIntoTransporter(pawn, transporter);
+        }
+
+        if (compShuttle != null)
+        {
+            if (transporter != null && !transporter.LoadingInProgressOrReadyToLaunch)
+            {
+                TransporterUtility.InitiateLoading(Gen.YieldSingle(transporter));
+            }
+
+            compShuttle.Send();
+        }
+    }
+#else
+    private void DeliverByTransportShip(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    {
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        TransportShip ship = TransportShipMaker.MakeTransportShip(
+            TransportShipDefOf.Ship_Shuttle,
+            pawns.Cast<Thing>(),
+            shuttle);
+        ship.ArriveAt(cell, map.Parent);
+        ship.AddJobs(ShipJobDefOf.Unload, ShipJobDefOf.FlyAway);
+    }
+
+    private void DepartByTransportShip(Map map, List<Pawn> pawns, Faction faction)
+    {
+        this.EjectClientsFromCaskets(map, pawns);
+
+        List<Pawn> living = pawns.Where(p => p != null && !p.Destroyed && !p.Dead).ToList();
+        if (!living.Any())
+        {
+            return;
+        }
+
+        // Collect clients into the shuttle immediately so pickup is guaranteed.
+        List<Thing> cargo = new List<Thing>();
+        foreach (Pawn pawn in living)
+        {
+            if (pawn.Spawned)
+            {
+                pawn.DeSpawn(DestroyMode.Vanish);
+            }
+            else if (pawn.ParentHolder is Building_CryoRegenesis casket)
+            {
+                casket.EjectContents();
+                if (pawn.Spawned)
+                {
+                    pawn.DeSpawn(DestroyMode.Vanish);
+                }
+            }
+            else if (pawn.ParentHolder is IThingHolder holder && holder != Find.WorldPawns)
+            {
+                // Leave other holders if transfer fails later.
+            }
+
+            cargo.Add(pawn);
+        }
+
+        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
+        if (faction != null)
+        {
+            shuttle.SetFaction(faction);
+        }
+
+        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
+        TransportShip ship = TransportShipMaker.MakeTransportShip(
+            TransportShipDefOf.Ship_Shuttle,
+            cargo,
+            shuttle);
+        ship.ArriveAt(cell, map.Parent);
+        // Already loaded: do not unload; leave immediately.
+        ship.AddJob(ShipJobDefOf.FlyAway);
+    }
+#endif
+
+    private void EjectClientsFromCaskets(Map map, List<Pawn> pawns)
+    {
+        if (map == null)
+        {
+            return;
+        }
+
+        foreach (Building_CryoRegenesis casket in map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>())
+        {
+            if (casket.ContainedThing is Pawn contained && pawns.Contains(contained))
+            {
+                casket.EjectContents();
+            }
+        }
+    }
+
+    private void TransferPawnIntoTransporter(Pawn pawn, CompTransporter transporter)
+    {
+        if (pawn == null || transporter == null)
+        {
+            return;
+        }
+
+        if (pawn.Spawned)
+        {
+            pawn.DeSpawn(DestroyMode.Vanish);
+        }
+
+        transporter.innerContainer.TryAddOrTransfer(pawn, true);
+    }
+
+    private IntVec3 FindShuttleLandingCell(Map map, Faction faction)
+    {
+        Faction landingFaction = faction ?? Faction.OfPlayer;
+#if RIMWORLD12
+        return DropCellFinder.TradeDropSpot(map);
+#else
+        return DropCellFinder.GetBestShuttleLandingSpot(map, landingFaction);
+#endif
+    }
+
+    private void CheckActiveClients()
+    {
+        if (!this.activeClients.Any())
+        {
+            return;
+        }
+
+        this.activeClients.RemoveAll(client => client?.pawn == null || client.pawn.Destroyed);
+        if (!this.activeClients.Any())
+        {
+            this.MajorTrustReset(
+                "CryoRegenesis clients vanished under contract. Trust is lost — the chain resets.",
+                null,
+                "Contract clients lost");
+            return;
+        }
+
+        // Keep recruitment locked for the entire stay.
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            this.LockRecruitment(client.pawn);
+            if (client.pawn?.guest != null && client.isPrisoner && !client.pawn.IsPrisoner)
+            {
+                this.ApplyGuestOrPrisonerStatus(client.pawn, isPrisoner: true);
+            }
+        }
+
+        if (this.activeClients.Any(client => client.pawn.Dead))
+        {
+            Pawn dead = this.activeClients.First(client => client.pawn.Dead).pawn;
+            Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction;
+            List<Pawn> survivors = this.activeClients
+                .Where(client => client.pawn != null && !client.pawn.Dead)
+                .Select(client => client.pawn)
+                .ToList();
+            Map map = survivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+            if (map != null && survivors.Any())
+            {
+                this.DepartClients(map, survivors, sender);
+            }
+
+            this.MajorTrustReset(
+                $"{dead.Name.ToStringShort} died under a CryoRegenesis return contract. " +
+                "Trust is shattered — all progress is lost and the chain restarts from the beginning.",
+                sender,
+                "Client died under contract");
+            return;
+        }
+
+        bool allDone = this.activeClients.All(this.ClientReachedDesiredAge);
+        bool deadlineReached = this.activeClients.Any(client => Find.TickManager.TicksGame >= client.returnByTick);
+
+        if (!allDone && !deadlineReached)
+        {
+            return;
+        }
+
+        bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
+        List<Pawn> departing = this.activeClients.Select(client => client.pawn).Where(p => p != null).ToList();
+        Faction sourceFaction = this.activeClients.FirstOrDefault()?.sourceFaction;
+        Map targetMap = departing.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+
+        bool success = allDone;
+        this.ClearContractFlags(this.activeClients);
+
+        if (targetMap != null && departing.Any())
+        {
+            this.DepartClients(targetMap, departing, sourceFaction);
+        }
+
+        this.activeClients.Clear();
+
+        if (triggerEndgame && success)
+        {
+            this.EndActiveContractQuest(QuestEndOutcome.Success);
+            this.stage = RoyaltyRegenesisStage.Completed;
+            this.royalAscentTriggered = true;
+            this.CompleteChainQuest();
+            this.TryMakeRoyalAscentAvailable();
+            return;
+        }
+
+        if (success)
+        {
+            this.EndActiveContractQuest(QuestEndOutcome.Success);
+            this.CompleteActiveContract();
+        }
+        else
+        {
+            // Soft failure: contract fails, stage progress kept, no full chain reset.
+            this.EndActiveContractQuest(QuestEndOutcome.Fail);
+            this.ScheduleRetry(
+                "CryoRegenesis contract expired",
+                "The pickup shuttle returned before the requested regression was finished. The clients have left. Another attempt may come later.");
+        }
+    }
+
+    private void DepartClients(Map map, List<Pawn> pawns, Faction faction)
+    {
+#if RIMWORLD12
+        this.DepartByLegacyShuttle(map, pawns, faction);
+#else
+        this.DepartByTransportShip(map, pawns, faction);
+#endif
+    }
+
+    private void ClearContractFlags(IEnumerable<RoyaltyRegenesisClient> clients)
+    {
+        foreach (RoyaltyRegenesisClient client in clients)
+        {
+            if (client?.pawn == null)
+            {
+                continue;
+            }
+
+            TrueAgeTracker tracker = client.pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            if (tracker != null)
+            {
+                tracker.underRegenContract = false;
+            }
+        }
+    }
+
+    private bool ClientReachedDesiredAge(RoyaltyRegenesisClient client)
+    {
+        return client.pawn.ageTracker.AgeBiologicalTicks <= client.desiredAgeTicks + CheckIntervalTicks;
+    }
+
+    private void CompleteActiveContract()
+    {
+        switch (this.activeContractStage)
+        {
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                this.rulerContractsCompleted++;
+                if (this.rulerContractsCompleted < 3)
+                {
+                    this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(15, 35) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    this.stage = RoyaltyRegenesisStage.Leaders;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(25, 45) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.Leaders:
+                this.leaderContractsCompleted++;
+                if (this.leaderContractsCompleted < 2)
+                {
+                    this.stage = RoyaltyRegenesisStage.Leaders;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    // Only after other factions succeed does the Empire take interest.
+                    this.stage = RoyaltyRegenesisStage.LowerNobility;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.LowerNobility:
+                this.nobleContractsCompleted++;
+                if (this.nobleContractsCompleted < 2)
+                {
+                    this.stage = RoyaltyRegenesisStage.LowerNobility;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+                }
+                else
+                {
+                    this.stage = RoyaltyRegenesisStage.StellarchNotice;
+                    this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(15, 30) * GenDate.TicksPerDay;
+                }
+                break;
+            case RoyaltyRegenesisStage.StellarchArrival:
+                this.stage = RoyaltyRegenesisStage.EmperorNotice;
+                this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 90) * GenDate.TicksPerDay;
+                break;
+        }
+
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis contract complete",
+            "The CryoRegenesis clients reached the requested regression age and have departed by shuttle. Check the Quests tab for chain progress.",
+            LetterDefOf.PositiveEvent);
+    }
+
+    private void ScheduleRetry(string label, string text)
+    {
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NegativeEvent);
+        this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 60) * GenDate.TicksPerDay;
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+    }
+
+    private void SendTravelNotice(string label, string text)
+    {
+        Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent);
+        this.EnsureChainQuest();
+    }
+
+    public void NotifyClientRecruited(Pawn recruitee)
+    {
+        RoyaltyRegenesisClient client = this.activeClients.FirstOrDefault(c => c?.pawn == recruitee);
+        if (client == null)
+        {
+            return;
+        }
+
+        Faction faction = client.sourceFaction;
+
+        // Return any remaining contracted clients; the recruited one stays as a colonist.
+        List<Pawn> survivors = this.activeClients
+            .Where(c => c?.pawn != null && c.pawn != recruitee && !c.pawn.Dead)
+            .Select(c => c.pawn)
+            .ToList();
+        Map map = survivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
+        if (map != null && survivors.Any())
+        {
+            this.DepartClients(map, survivors, faction);
+        }
+
+        this.MajorTrustReset(
+            $"{recruitee.Name.ToStringShort} was recruited while under a CryoRegenesis return contract. " +
+            $"{(faction?.Name ?? "Their faction")} considers this a betrayal — trust is lost and the chain resets.",
+            faction,
+            "Contract client recruited");
+    }
+
+    public string GetChainProgressDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(this.GetStageLabel(this.stage));
+        sb.AppendLine();
+        sb.AppendLine("Progress:");
+        sb.AppendLine("• Prisoner trials: " + this.rulerContractsCompleted + " / 3");
+        sb.AppendLine("• Planetary rulers: " + this.leaderContractsCompleted + " / 2");
+        sb.AppendLine("• Imperial nobles: " + this.nobleContractsCompleted + " / 2");
+        sb.AppendLine("• Stellarch: " + (this.stage > RoyaltyRegenesisStage.StellarchArrival || this.stage == RoyaltyRegenesisStage.Completed ? "done" : "pending"));
+        sb.AppendLine("• Emperor: " + (this.stage == RoyaltyRegenesisStage.Completed ? "done" : "pending"));
+
+        if (this.trustBreaks > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Trust breaks: " + this.trustBreaks);
+            if (!this.lastTrustBreakReason.NullOrEmpty())
+            {
+                sb.AppendLine("Last setback: " + this.lastTrustBreakReason);
+            }
+        }
+
+        if (this.activeClients.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("Active contract clients: " + this.activeClients.Count);
+            int earliestReturn = this.activeClients.Min(c => c.returnByTick);
+            sb.AppendLine("Next return deadline: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn));
+        }
+        else if (this.stage != RoyaltyRegenesisStage.Completed && this.nextEventTick > Find.TickManager.TicksGame)
+        {
+            int days = (this.nextEventTick - Find.TickManager.TicksGame + GenDate.TicksPerDay - 1) / GenDate.TicksPerDay;
+            sb.AppendLine();
+            sb.AppendLine("Next event in about " + days + " day(s).");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public string GetContractProgressDescription()
+    {
+        if (!this.activeClients.Any())
+        {
+            return "No active CryoRegenesis clients on this contract.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        int earliestReturn = this.activeClients.Min(c => c.returnByTick);
+        int ticksLeft = Math.Max(0, earliestReturn - Find.TickManager.TicksGame);
+        sb.AppendLine("Return shuttle: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn)
+            + " (" + ticksLeft.ToStringTicksToPeriod() + " remaining)");
+        sb.AppendLine();
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client?.pawn == null)
+            {
+                continue;
+            }
+
+            Pawn pawn = client.pawn;
+            int currentYears = pawn.ageTracker.AgeBiologicalYears;
+            int targetYears = (int)(client.desiredAgeTicks / GenDate.TicksPerYear);
+            bool done = this.ClientReachedDesiredAge(client);
+            string location = pawn.ParentHolder is Building_CryoRegenesis
+                ? "in CryoRegenesis"
+                : (pawn.Spawned ? "on map" : "held");
+
+            sb.AppendLine("• " + pawn.Name.ToStringShort
+                + " — bio " + currentYears + " → " + targetYears
+                + (done ? " [ready]" : " [treating]")
+                + " (" + location + ")");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine(this.activeClients.All(this.ClientReachedDesiredAge)
+            ? "All clients ready for return."
+            : "Keep treating until each client reaches their target age before pickup.");
+        return sb.ToString().TrimEnd();
+    }
+
+    private void EnsureChainQuest()
+    {
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            return;
+        }
+
+        // Recover an existing ongoing chain quest after load if needed.
+        Quest existing = Find.QuestManager.QuestsListForReading.FirstOrDefault(q =>
+            q != null &&
+            !q.Historical &&
+            q.root != null &&
+            q.root.defName == RoyaltyRegenesisQuestFactory.ChainQuestDefName);
+
+        if (existing != null)
+        {
+            this.chainQuest = existing;
+            return;
+        }
+
+        this.chainQuest = RoyaltyRegenesisQuestFactory.MakeChainQuest();
+    }
+
+    private void BeginContractQuest(string title, string roleSummary, Faction sender, bool isPrisoner)
+    {
+        this.EnsureChainQuest();
+        this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
+
+        int returnByTick = this.activeClients.Any()
+            ? this.activeClients.Max(c => c.returnByTick)
+            : Find.TickManager.TicksGame + MinContractDays * GenDate.TicksPerDay;
+
+        string description = RoyaltyRegenesisQuestFactory.BuildContractDescription(
+            roleSummary,
+            sender,
+            isPrisoner,
+            returnByTick,
+            this.activeClients.Select(c => c.pawn));
+
+        this.activeContractQuest = RoyaltyRegenesisQuestFactory.MakeContractQuest(
+            title,
+            description,
+            this.chainQuest);
+    }
+
+    private void EndActiveContractQuest(QuestEndOutcome outcome, bool sendLetter = true)
+    {
+        RoyaltyRegenesisQuestFactory.EndQuestSafe(this.activeContractQuest, outcome, sendLetter);
+        this.activeContractQuest = null;
+    }
+
+    private void CompleteChainQuest()
+    {
+        this.EnsureChainQuest();
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            this.chainQuest.description =
+                RoyaltyRegenesisQuestFactory.BuildChainDescriptionBody()
+                + "\n\nThe Emperor has been rejuvenated. The Imperial Rejuvenation chain is complete.";
+            RoyaltyRegenesisQuestFactory.EndQuestSafe(this.chainQuest, QuestEndOutcome.Success);
+        }
+
+        this.chainQuest = null;
+    }
+
+    /// <summary>
+    /// Death, recruitment, or loss of clients: fail the contract, wipe chain progress,
+    /// and force a long cooldown before anyone will trust you again.
+    /// </summary>
+    private void MajorTrustReset(string letterText, Faction offendedFaction, string shortReason)
+    {
+        this.EndActiveContractQuest(QuestEndOutcome.Fail);
+
+        this.ClearContractFlags(this.activeClients);
+        this.activeClients.Clear();
+
+        this.trustBreaks++;
+        this.lastTrustBreakReason = shortReason;
+        this.rulerContractsCompleted = 0;
+        this.leaderContractsCompleted = 0;
+        this.nobleContractsCompleted = 0;
+        this.royalAscentTriggered = false;
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+        this.nextEventTick = Find.TickManager.TicksGame
+            + Rand.RangeInclusive(MajorResetMinDays, MajorResetMaxDays) * GenDate.TicksPerDay;
+
+        if (offendedFaction != null && offendedFaction != Faction.OfPlayer)
+        {
+            this.ApplyTrustBreakGoodwillPenalty(offendedFaction);
+        }
+
+        this.EnsureChainQuest();
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            this.chainQuest.description =
+                RoyaltyRegenesisQuestFactory.BuildChainDescriptionBody()
+                + "\n\nTRUST BROKEN: " + shortReason
+                + "\nAll stage progress has been reset. Foreign and imperial patrons will only return after a long cooling-off period.";
+        }
+
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis trust lost",
+            letterText + "\n\nThe Quests tab shows the chain restarting from the beginning.",
+            LetterDefOf.NegativeEvent);
+    }
+
+    private string GetStageLabel(RoyaltyRegenesisStage current)
+    {
+        switch (current)
+        {
+            case RoyaltyRegenesisStage.NotStarted:
+                return "Stage: not started";
+            case RoyaltyRegenesisStage.RulerPrisoners:
+                return "Stage: foreign prisoner trials (before Empire notice)";
+            case RoyaltyRegenesisStage.Leaders:
+                return "Stage: planetary rulers (before Empire notice)";
+            case RoyaltyRegenesisStage.LowerNobility:
+                return "Stage: Empire lower nobility";
+            case RoyaltyRegenesisStage.StellarchNotice:
+                return "Stage: Stellarch en route";
+            case RoyaltyRegenesisStage.StellarchArrival:
+                return "Stage: Stellarch contract";
+            case RoyaltyRegenesisStage.EmperorNotice:
+                return "Stage: Emperor en route";
+            case RoyaltyRegenesisStage.EmperorArrival:
+                return "Stage: Emperor contract";
+            case RoyaltyRegenesisStage.Completed:
+                return "Stage: complete";
+            default:
+                return "Stage: " + current;
+        }
+    }
+
+    private void ApplyTrustBreakGoodwillPenalty(Faction faction)
+    {
+        if (faction == null || faction == Faction.OfPlayer)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            DeathTrustGoodwillPenalty,
+            true,
+            true,
+            "CryoRegenesis trust broken",
+            null);
+#else
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            DeathTrustGoodwillPenalty,
+            true,
+            true,
+            HistoryEventDefOf.MemberKilled,
+            null);
+#endif
+    }
+
+    private void ApplyRecruitmentGoodwillPenalty(Faction faction, Pawn pawn)
+    {
+        if (faction == null || faction == Faction.OfPlayer)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            RecruitGoodwillPenalty,
+            true,
+            true,
+            "Recruited CryoRegenesis contract client",
+            pawn);
+#else
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            RecruitGoodwillPenalty,
+            true,
+            true,
+            HistoryEventDefOf.MemberCaptured,
+            pawn);
+#endif
+    }
+
+    private Pawn GeneratePawn(PawnKindDef kind, Faction faction, int biologicalAge)
+    {
+        PawnGenerationRequest request = new PawnGenerationRequest(kind, faction);
+        request.FixedBiologicalAge = biologicalAge;
+        request.FixedChronologicalAge = biologicalAge;
+        return PawnGenerator.GeneratePawn(request);
+    }
+
+    private PawnKindDef CommonPawnKind(Faction faction = null)
+    {
+        if (faction?.def?.basicMemberKind != null)
+        {
+            return faction.def.basicMemberKind;
+        }
+
+        return this.NamedPawnKind("Empire_Common_Lodger", this.AnyHumanPawnKind());
+    }
+
+    private PawnKindDef NoblePawnKind(Faction faction = null)
+    {
+        if (faction != null && !this.IsEmpire(faction) && faction.def.basicMemberKind != null)
+        {
+            // Prefer the faction's own member kinds for non-Empire leaders.
+            return faction.def.basicMemberKind;
+        }
+
+        return this.NamedPawnKind("Empire_Royal_NobleWimp", this.CommonPawnKind(faction));
+    }
+
+    private PawnKindDef LowerNoblePawnKind()
+    {
+        return this.NamedPawnKind(
+            Rand.Element("Empire_Royal_Yeoman", "Empire_Royal_Esquire", "Empire_Royal_Knight"),
+            this.NoblePawnKind(this.EmpireFaction()));
+    }
+
+    private PawnKindDef NamedPawnKind(string defName, PawnKindDef fallback)
+    {
+        return DefDatabase<PawnKindDef>.GetNamedSilentFail(defName) ?? fallback;
+    }
+
+    private PawnKindDef AnyHumanPawnKind()
+    {
+        return DefDatabase<PawnKindDef>.AllDefsListForReading
+            .FirstOrDefault(def => def.race != null && def.race.race != null && def.race.race.Humanlike);
+    }
+
+    private Faction EmpireFaction()
+    {
+        FactionDef empireDef = DefDatabase<FactionDef>.GetNamedSilentFail("Empire");
+        if (empireDef != null)
+        {
+            Faction empire = Find.FactionManager.FirstFactionOfDef(empireDef);
+            if (empire != null)
+            {
+                return empire;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Other planetary factions only — never Ancients, never Empire.
+    /// Empire contracts begin only after these succeed.
+    /// </summary>
+    private Faction RandomPlanetarySenderFaction()
+    {
+        return Find.FactionManager.AllFactionsListForReading
+            .Where(this.IsEligiblePlanetarySender)
+            .RandomElementWithFallback(null);
+    }
+
+    private bool IsEligiblePlanetarySender(Faction faction)
+    {
+        if (faction == null || faction == Faction.OfPlayer || faction.defeated)
+        {
+            return false;
+        }
+
+        if (!faction.def.humanlikeFaction)
+        {
+            return false;
+        }
+
+        if (faction.HostileTo(Faction.OfPlayer))
+        {
+            return false;
+        }
+
+        if (faction.Hidden)
+        {
+            return false;
+        }
+
+        if (this.IsEmpire(faction) || this.IsAncient(faction))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsEmpire(Faction faction)
+    {
+        if (faction?.def == null)
+        {
+            return false;
+        }
+
+        if (faction.def.defName == "Empire")
+        {
+            return true;
+        }
+
+        try
+        {
+            return faction.def == FactionDefOf.Empire;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool IsAncient(Faction faction)
+    {
+        if (faction?.def == null)
+        {
+            return false;
+        }
+
+        string defName = faction.def.defName;
+        if (defName == "Ancients" || defName == "AncientsHostile")
+        {
+            return true;
+        }
+
+        try
+        {
+            return faction.def == FactionDefOf.Ancients || faction.def == FactionDefOf.AncientsHostile;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void TrySetRoyalTitle(Pawn pawn, Faction faction, string titleDefName)
+    {
+        RoyalTitleDef title = DefDatabase<RoyalTitleDef>.GetNamedSilentFail(titleDefName);
+        if (title == null || pawn == null || faction == null)
+        {
+            return;
+        }
+
+        object royalty = pawn.GetType().GetField("royalty")?.GetValue(pawn)
+            ?? pawn.GetType().GetProperty("royalty")?.GetValue(pawn, null);
+
+        if (royalty == null)
+        {
+            return;
+        }
+
+        MethodInfo method = royalty.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate =>
+                candidate.Name == "SetTitle" &&
+                candidate.GetParameters().Any(parameter => parameter.ParameterType == typeof(RoyalTitleDef)));
+
+        if (method == null)
+        {
+            return;
+        }
+
+        object[] args = method.GetParameters()
+            .Select<ParameterInfo, object>(parameter =>
+            {
+                if (parameter.ParameterType == typeof(Faction))
+                {
+                    return faction;
+                }
+
+                if (parameter.ParameterType == typeof(RoyalTitleDef))
+                {
+                    return title;
+                }
+
+                if (parameter.ParameterType == typeof(bool))
+                {
+                    return false;
+                }
+
+                return null;
+            })
+            .ToArray();
+
+        try
+        {
+            method.Invoke(royalty, args);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"[CryoRegenesis] Failed to set Royalty title {titleDefName} for {pawn.Name}: {ex.Message}");
+        }
+    }
+
+    private void TryMakeRoyalAscentAvailable()
+    {
+        Find.LetterStack.ReceiveLetter(
+            "Imperial CryoRegenesis complete",
+            "The Emperor has reached age 20 and departed by shuttle. Royal Ascent endgame protocols are now being activated.",
+            LetterDefOf.PositiveEvent);
+
+        QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");
+        object questManager = Find.QuestManager;
+
+        if (questDef == null || questManager == null)
+        {
+            Log.Warning("[CryoRegenesis] Could not activate Royal Ascent: EndGame_RoyalAscent or QuestManager was unavailable.");
+            return;
+        }
+
+        foreach (MethodInfo method in questManager.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (method.Name != "GenerateAndAddQuest" && method.Name != "GenerateQuestAndMakeAvailable")
+            {
+                continue;
+            }
+
+            object[] args = this.BuildQuestManagerArgs(method, questDef);
+            if (args == null)
+            {
+                continue;
+            }
+
+            try
+            {
+                method.Invoke(questManager, args);
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[CryoRegenesis] Royal Ascent activation via {method.Name} failed: {ex.Message}");
+            }
+        }
+
+        Log.Warning("[CryoRegenesis] Could not find a compatible Royal Ascent quest generation method.");
+    }
+
+    private object[] BuildQuestManagerArgs(MethodInfo method, QuestScriptDef questDef)
+    {
+        ParameterInfo[] parameters = method.GetParameters();
+        object[] args = new object[parameters.Length];
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            Type parameterType = parameters[i].ParameterType;
+            if (parameterType == typeof(QuestScriptDef))
+            {
+                args[i] = questDef;
+            }
+            else if (!parameterType.IsValueType)
+            {
+                args[i] = null;
+            }
+            else if (parameterType == typeof(int))
+            {
+                args[i] = 0;
+            }
+            else if (parameterType == typeof(float))
+            {
+                args[i] = 0f;
+            }
+            else if (parameterType == typeof(bool))
+            {
+                args[i] = false;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return args.Any(arg => arg == questDef) ? args : null;
+    }
+}
+
+public class RoyaltyRegenesisClient : IExposable
+{
+    public Pawn pawn;
+    public long desiredAgeTicks;
+    public string role;
+    public bool triggerRoyalAscent;
+    public int returnByTick;
+    public bool isPrisoner;
+    public Faction sourceFaction;
+
+    public void ExposeData()
+    {
+        Scribe_References.Look(ref this.pawn, "pawn");
+        Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
+        Scribe_Values.Look(ref this.role, "role");
+        Scribe_Values.Look(ref this.triggerRoyalAscent, "triggerRoyalAscent", false);
+        Scribe_Values.Look(ref this.returnByTick, "returnByTick", 0);
+        Scribe_Values.Look(ref this.isPrisoner, "isPrisoner", false);
+        Scribe_References.Look(ref this.sourceFaction, "sourceFaction");
+    }
+}
+
+public enum RoyaltyRegenesisStage
+{
+    NotStarted,
+    RulerPrisoners,
+    Leaders,
+    LowerNobility,
+    StellarchNotice,
+    StellarchArrival,
+    EmperorNotice,
+    EmperorArrival,
+    Completed,
+}
+
+public static class RoyaltyRegenesisDebugActions
+{
+    [DebugAction("CryoRegenesis", "Start Royalty chain")]
+    public static void StartRoyaltyChain()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.RulerPrisoners);
+    }
+
+    [DebugAction("CryoRegenesis", "Start Stellarch arrival")]
+    public static void StartStellarchArrival()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.StellarchArrival);
+    }
+
+    [DebugAction("CryoRegenesis", "Start Emperor arrival")]
+    public static void StartEmperorArrival()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugStartAt(RoyaltyRegenesisStage.EmperorArrival);
+    }
+
+    [DebugAction("CryoRegenesis", "Trigger next Royalty event")]
+    public static void TriggerNextRoyaltyEvent()
+    {
+        Current.Game?.GetComponent<RoyaltyRegenesisQuestSystem>()
+            ?.DebugTriggerNextEvent();
+    }
+}
+
+/// No-op root so Royalty Regenesis QuestScriptDefs are valid.
+/// Chain and contract quests are created in code via RoyaltyRegenesisQuestFactory, not QuestGen.
+public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
+{
+    protected override bool TestRunInt(Slate slate)
+    {
+        return true;
+    }
+
+    protected override void RunInt()
+    {
+    }
+}
+
+/// <summary>
+/// Regen-contract pawns never recruit voluntarily. If recruitment still happens,
+/// punish relations with their sending faction.
+/// </summary>
+[HarmonyPatch]
+public static class Patch_DoRecruit_RegenContract
+{
+    private static MethodBase TargetMethod()
+    {
+        // Prefer the full overload used by all recruit paths.
+        MethodInfo full = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[]
+            {
+                typeof(Pawn),
+                typeof(Pawn),
+                typeof(string).MakeByRefType(),
+                typeof(string).MakeByRefType(),
+                typeof(bool),
+                typeof(bool),
+            });
+
+        if (full != null)
+        {
+            return full;
+        }
+
+        return AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[] { typeof(Pawn), typeof(Pawn), typeof(bool) });
+    }
+
+    public static void Prefix(Pawn recruiter, Pawn recruitee)
+    {
+        if (!RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(recruitee))
+        {
+            return;
+        }
+
+        RoyaltyRegenesisQuestSystem.CurrentSystem?.NotifyClientRecruited(recruitee);
+    }
+}

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1619,11 +1619,56 @@ public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
 /// punish relations with their sending faction.
 /// </summary>
 [HarmonyPatch]
+/*
+ * CRITICAL — TargetMethod() MUST resolve on EVERY supported RimWorld version
+ * or this patch (and historically the whole assembly) fails to apply.
+ *
+ * Incident (2026-07, RW 1.2):
+ *   This patch originally looked up only the 1.3+ DoRecruit overloads
+ *   (no float recruitChance). On 1.2, AccessTools.Method returned null,
+ *   harmony.PatchAll() threw, and *all* mod Harmony patches failed to apply —
+ *   including Carry-to-CryoRegenesis float menu orders.
+ *
+ * Signature shapes:
+ *   1.2:     DoRecruit(Pawn, Pawn, float recruitChance, out string, out string, bool, bool)
+ *            DoRecruit(Pawn, Pawn, float recruitChance, bool)
+ *   1.3–1.6: DoRecruit(Pawn, Pawn, out string, out string, bool, bool)
+ *            DoRecruit(Pawn, Pawn, bool)
+ *
+ * Rules:
+ *   - Always try the 1.2 (float) overloads first, then 1.3+ shapes.
+ *   - Never return null from TargetMethod without a compile-time version gate;
+ *     a null target aborts batch PatchAll (mitigated in CryoRegenesis ctor by
+ *     per-type CreateClassProcessor, but a null target still means THIS patch
+ *     never runs).
+ *   - After any DoRecruit / recruit API change, boot RW 1.2 and confirm no
+ *     "[CryoRegenesis] Harmony patch failed on ...Patch_DoRecruit_RegenContract".
+ */
 public static class Patch_DoRecruit_RegenContract
 {
     private static MethodBase TargetMethod()
     {
-        // Prefer the full overload used by all recruit paths.
+        // RimWorld 1.2: DoRecruit(..., float recruitChance, out string, out string, bool, bool)
+        MethodInfo rw12 = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[]
+            {
+                typeof(Pawn),
+                typeof(Pawn),
+                typeof(float),
+                typeof(string).MakeByRefType(),
+                typeof(string).MakeByRefType(),
+                typeof(bool),
+                typeof(bool),
+            });
+
+        if (rw12 != null)
+        {
+            return rw12;
+        }
+
+        // RimWorld 1.3+: recruitChance argument was removed.
         MethodInfo full = AccessTools.Method(
             typeof(InteractionWorker_RecruitAttempt),
             nameof(InteractionWorker_RecruitAttempt.DoRecruit),
@@ -1640,6 +1685,17 @@ public static class Patch_DoRecruit_RegenContract
         if (full != null)
         {
             return full;
+        }
+
+        // Last-resort short overloads.
+        MethodInfo short12 = AccessTools.Method(
+            typeof(InteractionWorker_RecruitAttempt),
+            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
+            new[] { typeof(Pawn), typeof(Pawn), typeof(float), typeof(bool) });
+
+        if (short12 != null)
+        {
+            return short12;
         }
 
         return AccessTools.Method(

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -2587,76 +2587,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             LetterDefOf.PositiveEvent);
 
         QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");
-        object questManager = Find.QuestManager;
-
-        if (questDef == null || questManager == null)
+        if (questDef == null)
         {
-            Log.Warning("[CryoRegenesis] Could not activate Royal Ascent: EndGame_RoyalAscent or QuestManager was unavailable.");
+            Log.Warning("[CryoRegenesis] Could not activate Royal Ascent: EndGame_RoyalAscent was unavailable.");
             return;
         }
 
-        foreach (MethodInfo method in questManager.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
-        {
-            if (method.Name != "GenerateAndAddQuest" && method.Name != "GenerateQuestAndMakeAvailable")
-            {
-                continue;
-            }
-
-            object[] args = this.BuildQuestManagerArgs(method, questDef);
-            if (args == null)
-            {
-                continue;
-            }
-
-            try
-            {
-                method.Invoke(questManager, args);
-                return;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning($"[CryoRegenesis] Royal Ascent activation via {method.Name} failed: {ex.Message}");
-            }
-        }
-
-        Log.Warning("[CryoRegenesis] Could not find a compatible Royal Ascent quest generation method.");
-    }
-
-    private object[] BuildQuestManagerArgs(MethodInfo method, QuestScriptDef questDef)
-    {
-        ParameterInfo[] parameters = method.GetParameters();
-        object[] args = new object[parameters.Length];
-
-        for (int i = 0; i < parameters.Length; i++)
-        {
-            Type parameterType = parameters[i].ParameterType;
-            if (parameterType == typeof(QuestScriptDef))
-            {
-                args[i] = questDef;
-            }
-            else if (!parameterType.IsValueType)
-            {
-                args[i] = null;
-            }
-            else if (parameterType == typeof(int))
-            {
-                args[i] = 0;
-            }
-            else if (parameterType == typeof(float))
-            {
-                args[i] = 0f;
-            }
-            else if (parameterType == typeof(bool))
-            {
-                args[i] = false;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        return args.Any(arg => arg == questDef) ? args : null;
+        QuestUtility.GenerateQuestAndMakeAvailable(questDef, new Slate());
     }
 }
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -306,11 +306,21 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        int pawnCount = Rand.RangeInclusive(1, 2);
+        List<Pawn> availablePawns = this.GetAvailableWorldPawns(sender, 19);
+        if (!availablePawns.Any())
+        {
+            this.ScheduleRetry(
+                "No eligible faction members",
+                $"{sender.Name} has no eligible world pawns available for a CryoRegenesis trial. Retrying later.");
+            return;
+        }
+
+        int pawnCount = Math.Min(Rand.RangeInclusive(1, 2), availablePawns.Count);
         List<Pawn> pawns = new List<Pawn>();
         for (int i = 0; i < pawnCount; i++)
         {
-            Pawn pawn = this.GeneratePawn(this.CommonPawnKind(sender), sender, Rand.RangeInclusive(24, 70));
+            Pawn pawn = availablePawns.RandomElement();
+            availablePawns.Remove(pawn);
             int duration = Rand.Element(HalfYearTicks, GenDate.TicksPerYear, GenDate.TicksPerYear * 2);
             long targetTicks = Math.Max(18L * GenDate.TicksPerYear, pawn.ageTracker.AgeBiologicalTicks - duration);
             this.PrepareClient(pawn, targetTicks, "foreign prisoner", sender, isPrisoner: true, contractDays: 0);
@@ -350,9 +360,20 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        Pawn leader = this.GeneratePawn(this.NoblePawnKind(sender), sender, Rand.RangeInclusive(35, 82));
-        int yearsToRemove = Rand.RangeInclusive(2, 18);
-        long targetTicks = Math.Max(30L * GenDate.TicksPerYear, leader.ageTracker.AgeBiologicalTicks - yearsToRemove * GenDate.TicksPerYear);
+        Pawn leader = this.GetFactionLeader(sender, 31);
+        if (leader == null)
+        {
+            this.ScheduleRetry(
+                "No eligible faction ruler",
+                $"{sender.Name}'s ruler is unavailable for a CryoRegenesis stay. Retrying later.");
+            return;
+        }
+
+        int yearsToRemove = Rand.RangeInclusive(2, 60);
+        int targetAgeYears = Math.Max(
+            30,
+            (leader.ageTracker.AgeBiologicalYears - yearsToRemove) / 5 * 5);
+        long targetTicks = targetAgeYears * GenDate.TicksPerYear;
         int contractDays = this.CalculateContractDays(1);
 
         // Leaders come as guests (not prisoners) with a hard return time.
@@ -386,8 +407,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        Pawn pawn = this.GeneratePawn(this.LowerNoblePawnKind(), empire, Rand.RangeInclusive(31, 72));
         int targetAge = Rand.RangeInclusive(21, 40);
+        Pawn pawn = this.GetAvailableWorldPawns(empire, targetAge + 1).RandomElementWithFallback(null);
+        if (pawn == null)
+        {
+            this.ScheduleRetry("No eligible imperial noble", "No eligible Imperial world pawn is available for a CryoRegenesis stay. Retrying later.");
+            return;
+        }
+
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
         int contractDays = this.CalculateContractDays(1);
 
@@ -420,15 +447,19 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        Pawn stellarch = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(45, 85));
-        this.TrySetRoyalTitle(stellarch, empire, "Stellarch");
-
         int targetAge = Rand.RangeInclusive(21, 35);
+        Pawn stellarch = this.GetAvailableWorldPawns(empire, targetAge + 1).RandomElementWithFallback(null);
+        if (stellarch == null)
+        {
+            this.ScheduleRetry("No eligible Stellarch", "No eligible Imperial world pawn is available for the Stellarch's CryoRegenesis stay. Retrying later.");
+            return;
+        }
+
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
         List<Pawn> party = new List<Pawn> { stellarch };
         int contractDays = this.CalculateContractDays(party.Count);
         this.PrepareClient(stellarch, targetTicks, "stellarch", empire, isPrisoner: false, contractDays: contractDays);
-        party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
+        party.AddRange(this.GetWorldPawnPartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
         contractDays = this.CalculateContractDays(party.Count);
         this.SetActiveContractDeadlineDays(contractDays);
 
@@ -459,14 +490,18 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        Pawn emperor = this.GeneratePawn(this.NamedPawnKind("Empire_Royal_Stellarch", this.NoblePawnKind(empire)), empire, Rand.RangeInclusive(60, 100));
-        this.TrySetRoyalTitle(emperor, empire, "Emperor");
+        Pawn emperor = this.GetFactionLeader(empire, 21);
+        if (emperor == null)
+        {
+            this.ScheduleRetry("Emperor unavailable", "The Empire's leader is unavailable for a CryoRegenesis stay. Retrying later.");
+            return;
+        }
 
         List<Pawn> party = new List<Pawn> { emperor };
         long targetTicks = 20L * GenDate.TicksPerYear;
         int contractDays = this.CalculateContractDays(party.Count);
         this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
-        party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
+        party.AddRange(this.GetWorldPawnPartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
         contractDays = this.CalculateContractDays(party.Count);
         this.SetActiveContractDeadlineDays(contractDays);
 
@@ -488,7 +523,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             isPrisoner: false);
     }
 
-    private List<Pawn> GetOrGeneratePartners(Pawn noble, Faction faction, int targetAge, string role, bool isPrisoner, int contractDays)
+    private List<Pawn> GetWorldPawnPartners(Pawn noble, Faction faction, int targetAge, string role, bool isPrisoner, int contractDays)
     {
         List<Pawn> partners = noble.relations?.DirectRelations
             ?.Where(relation =>
@@ -496,24 +531,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 relation.def == PawnRelationDefOf.Lover ||
                 relation.def == PawnRelationDefOf.Fiance)
             .Select(relation => relation.otherPawn)
-            .Where(pawn => pawn != null && !pawn.Dead)
+            .Where(pawn => this.IsAvailableWorldPawn(pawn, faction, targetAge + 1))
             .Distinct()
             .ToList() ?? new List<Pawn>();
 
-        if (!partners.Any() && Rand.Chance(0.65f))
-        {
-            Pawn spouse = this.GeneratePawn(this.NoblePawnKind(faction), faction, Rand.RangeInclusive(35, 80));
-            noble.relations.AddDirectRelation(PawnRelationDefOf.Spouse, spouse);
-            partners.Add(spouse);
-        }
-
         foreach (Pawn partner in partners)
         {
-            if (partner.ageTracker.AgeBiologicalYears < targetAge + 5)
-            {
-                partner.ageTracker.AgeBiologicalTicks = Rand.RangeInclusive(targetAge + 10, targetAge + 45) * (long)GenDate.TicksPerYear;
-            }
-
             this.PrepareClient(partner, targetAge * (long)GenDate.TicksPerYear, role, faction, isPrisoner, contractDays);
         }
 
@@ -2101,12 +2124,37 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 #endif
     }
 
-    private Pawn GeneratePawn(PawnKindDef kind, Faction faction, int biologicalAge)
+    private Pawn GetFactionLeader(Faction faction, int minimumBiologicalAge)
     {
-        PawnGenerationRequest request = new PawnGenerationRequest(kind, faction);
-        request.FixedBiologicalAge = biologicalAge;
-        request.FixedChronologicalAge = biologicalAge;
-        return PawnGenerator.GeneratePawn(request);
+        Pawn leader = faction?.leader;
+        return this.IsAvailableWorldPawn(leader, faction, minimumBiologicalAge, includeFactionLeader: true)
+            ? leader
+            : null;
+    }
+
+    private List<Pawn> GetAvailableWorldPawns(Faction faction, int minimumBiologicalAge)
+    {
+        if (faction == null || Find.WorldPawns == null)
+        {
+            return new List<Pawn>();
+        }
+
+        return Find.WorldPawns.AllPawnsAlive
+            .Where(pawn => this.IsAvailableWorldPawn(pawn, faction, minimumBiologicalAge))
+            .ToList();
+    }
+
+    private bool IsAvailableWorldPawn(Pawn pawn, Faction faction, int minimumBiologicalAge, bool includeFactionLeader = false)
+    {
+        return pawn != null
+            && !pawn.Dead
+            && pawn.Faction == faction
+            && (includeFactionLeader || pawn != faction.leader)
+            && pawn.ageTracker != null
+            && pawn.ageTracker.AgeBiologicalYears >= minimumBiologicalAge
+            && !pawn.Spawned
+            && !IsActiveRegenContractPawn(pawn)
+            && Find.WorldPawns?.AllPawnsAlive.Contains(pawn) == true;
     }
 
     private PawnKindDef CommonPawnKind(Faction faction = null)

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -27,8 +27,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     private const int HalfYearTicks = GenDate.TicksPerYear / 2;
     private const int RecruitGoodwillPenalty = -35;
     private const int DeathTrustGoodwillPenalty = -75;
-    private const int ContractDaysPerClient = 2;
     private const int MinContractDays = 2;
+    private const int ContractHandlingBufferDays = 1;
+    private const int RegressionTicksPerGameTick = 500;
     private const int MajorResetMinDays = 60;
     private const int MajorResetMaxDays = 90;
     /// Vanilla hospitality pickup grace period (Script_Hospitality_Worker shuttleLeaveDelayTicks = 3*60000).
@@ -67,9 +68,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// True once every active client has reached the requested age during pickup.
     private bool pickupAllClientsReady;
 
-    /// True once the contract quest has been logged as completed (every client reached
-    /// their target age). Success is banked here — shuttle logistics can no longer fail it.
+    /// True once every client has reached their target age. Success is banked here so
+    /// shuttle logistics cannot fail it — the quest is still only finalized on departure.
     private bool contractCompletionLogged;
+
+    /// True once every living client has been map-reachable after delivery unload.
+    /// Distinguishes "still arriving" from "left with / after the contract shuttle".
+    private bool clientsHaveArrived;
+
+    /// Banked when ages are met (or departure is started after ages met). Survives
+    /// client despawn so a scheduled shuttle leave cannot soft-fail a finished treatment.
+    private bool departureSuccessBanked;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
@@ -101,6 +110,32 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return CurrentSystem?.activeClients.FirstOrDefault(client => client?.pawn == pawn);
     }
 
+    /// Called by a CryoRegenesis casket on the exact tick that a pawn reaches its target.
+    /// The periodic quest check can otherwise miss that instant after natural aging resumes.
+    public static void NotifyRegenesisTargetReached(Pawn pawn)
+    {
+        RoyaltyRegenesisQuestSystem system = CurrentSystem;
+        RoyaltyRegenesisClient client = system?.activeClients
+            .FirstOrDefault(candidate => candidate?.pawn == pawn);
+        if (client == null || client.everReachedDesiredAge)
+        {
+            return;
+        }
+
+        if (!system.EvaluateAgeAgainstTarget(client, out _, out _))
+        {
+            return;
+        }
+
+        client.everReachedDesiredAge = true;
+        system.LogRoyaltyDebug(
+            "Client target latched directly from casket: "
+            + (pawn?.Name?.ToStringShort ?? "?")
+            + " bioTicks=" + (pawn?.ageTracker?.AgeBiologicalTicks ?? -1)
+            + " desired=" + client.desiredAgeTicks);
+        system.RefreshClientAgeProgress();
+    }
+
     public override void ExposeData()
     {
         base.ExposeData();
@@ -123,6 +158,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.pickupShuttleSpawnTick, "crRoyalPickupShuttleSpawnTick", -1);
         Scribe_Values.Look(ref this.pickupAllClientsReady, "crRoyalPickupAllClientsReady", false);
         Scribe_Values.Look(ref this.contractCompletionLogged, "crRoyalContractCompletionLogged", false);
+        Scribe_Values.Look(ref this.clientsHaveArrived, "crRoyalClientsHaveArrived", false);
+        Scribe_Values.Look(ref this.departureSuccessBanked, "crRoyalDepartureSuccessBanked", false);
 #if !RIMWORLD12
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
@@ -144,6 +181,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             if (this.activeClients.Any())
             {
                 this.EnsureContractDeadline();
+                // Older saves lack this flag; treat currently map-reachable clients as arrived.
+                if (!this.clientsHaveArrived
+                    && this.activeClients.All(c => c?.pawn != null && this.IsClientAvailableOnMap(c.pawn)))
+                {
+                    this.clientsHaveArrived = true;
+                }
             }
         }
     }
@@ -327,7 +370,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             pawns.Add(pawn);
         }
 
-        int contractDays = this.CalculateContractDays(pawns.Count);
+        int contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.RulerPrisoners;
         string returnText = this.FormatReturnDeadline(contractDays);
@@ -374,10 +417,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             30,
             (leader.ageTracker.AgeBiologicalYears - yearsToRemove) / 5 * 5);
         long targetTicks = targetAgeYears * GenDate.TicksPerYear;
-        int contractDays = this.CalculateContractDays(1);
-
         // Leaders come as guests (not prisoners) with a hard return time.
-        this.PrepareClient(leader, targetTicks, "planetary ruler", sender, isPrisoner: false, contractDays: contractDays);
+        this.PrepareClient(leader, targetTicks, "planetary ruler", sender, isPrisoner: false, contractDays: MinContractDays);
+        int contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.Leaders;
         string returnText = this.FormatReturnDeadline(contractDays);
@@ -416,9 +458,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
-        int contractDays = this.CalculateContractDays(1);
-
-        this.PrepareClient(pawn, targetTicks, "lower imperial noble", empire, isPrisoner: false, contractDays: contractDays);
+        this.PrepareClient(pawn, targetTicks, "lower imperial noble", empire, isPrisoner: false, contractDays: MinContractDays);
+        int contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.LowerNobility;
         string returnText = this.FormatReturnDeadline(contractDays);
@@ -457,10 +498,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
         List<Pawn> party = new List<Pawn> { stellarch };
-        int contractDays = this.CalculateContractDays(party.Count);
+        int contractDays = MinContractDays;
         this.PrepareClient(stellarch, targetTicks, "stellarch", empire, isPrisoner: false, contractDays: contractDays);
         party.AddRange(this.GetWorldPawnPartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
-        contractDays = this.CalculateContractDays(party.Count);
+        contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
 
         this.activeContractStage = RoyaltyRegenesisStage.StellarchArrival;
@@ -499,10 +540,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         List<Pawn> party = new List<Pawn> { emperor };
         long targetTicks = 20L * GenDate.TicksPerYear;
-        int contractDays = this.CalculateContractDays(party.Count);
+        int contractDays = MinContractDays;
         this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
         party.AddRange(this.GetWorldPawnPartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
-        contractDays = this.CalculateContractDays(party.Count);
+        contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
 
         this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
@@ -639,6 +680,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.pickupShuttleSpawnTick = -1;
         this.pickupAllClientsReady = false;
         this.contractCompletionLogged = false;
+        this.clientsHaveArrived = false;
+        this.departureSuccessBanked = false;
         this.ResetCompletionRewardState();
     }
 
@@ -685,9 +728,22 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 #endif
     }
 
-    private int CalculateContractDays(int clientCount)
+    /// Allows enough time for the slowest requested regression at the casket's
+    /// normal rate, with a day for loading, unloading, and treatment setup.
+    private int CalculateContractDays()
     {
-        return Math.Max(MinContractDays, Math.Max(1, clientCount) * ContractDaysPerClient);
+        long longestRegressionTicks = this.activeClients
+            .Where(client => client?.pawn?.ageTracker != null)
+            .Select(client => Math.Max(0L, client.pawn.ageTracker.AgeBiologicalTicks - client.desiredAgeTicks))
+            .DefaultIfEmpty(0L)
+            .Max();
+
+        int regressionDays = (int)Math.Ceiling(
+            (double)longestRegressionTicks
+            / RegressionTicksPerGameTick
+            / GenDate.TicksPerDay);
+
+        return Math.Max(MinContractDays, regressionDays + ContractHandlingBufferDays);
     }
 
     private void SetActiveContractDeadlineDays(int contractDays)
@@ -870,24 +926,24 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 "Removed " + (beforeCount - this.activeClients.Count)
                 + " destroyed/null client(s). Remaining=" + this.activeClients.Count
                 + " pickupSpawned=" + this.pickupShuttleSpawned
-                + " allReady=" + this.pickupAllClientsReady);
+                + " allReady=" + this.pickupAllClientsReady
+                + " arrived=" + this.clientsHaveArrived);
         }
 
+        this.UpdateClientsArrivedFlag();
+
+        // Contract ends when the shuttle actually leaves the map (or every client is gone
+        // with it). Being aboard a still-parked shuttle is NOT enough — that used to soft-fail
+        // successful ruler contracts that boarded on the scheduled return. Death/recruit still
+        // hard-reset trust.
         if (!this.activeClients.Any())
         {
-            if (this.pickupShuttleSpawned)
+            if (this.clientsHaveArrived || this.pickupShuttleSpawned || this.IsDepartureSuccessBanked())
             {
                 this.LogRoyaltyDebug(
-                    "All clients gone after pickup spawn → FinishContractAfterDeparture(success="
-                    + this.pickupAllClientsReady + ")");
-                this.FinishContractAfterDeparture(this.pickupAllClientsReady);
-                return;
-            }
-
-            if (this.contractCompletionLogged)
-            {
-                this.LogRoyaltyDebug("Clients gone before pickup, but contract already completed — cleanup only.");
-                this.FinishContractAfterDeparture(true);
+                    "All clients gone after delivery/pickup → FinishContractAfterDeparture(success="
+                    + this.IsDepartureSuccessBanked() + ")");
+                this.FinishContractAfterDeparture(this.IsDepartureSuccessBanked());
                 return;
             }
 
@@ -899,60 +955,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        if (this.pickupShuttleSpawned)
+        if (this.activeClients.Any(client => client.pawn != null && client.pawn.Dead))
         {
-            this.RefreshClientAgeProgress();
-
-            bool allInTransport = this.activeClients.All(client => this.IsClientInReturnTransport(client.pawn));
-            if (allInTransport)
-            {
-                this.LogRoyaltyDebug(
-                    "All clients in return transport → FinishContractAfterDeparture(success="
-                    + this.pickupAllClientsReady + ")");
-                this.LogClientAgeSnapshot("pre-finish (in transport)");
-                this.FinishContractAfterDeparture(this.pickupAllClientsReady);
-                return;
-            }
-
-            if (this.PickupLoadingWindowExpired())
-            {
-                this.LogRoyaltyDebug(
-                    "Pickup loading window expired. allReady=" + this.pickupAllClientsReady
-                    + " onMap=" + this.activeClients.Count(c => this.IsClientAvailableOnMap(c.pawn))
-                    + " inTransport=" + this.activeClients.Count(c => this.IsClientInReturnTransport(c.pawn)));
-                this.LogClientAgeSnapshot("pickup timeout");
-                this.FailContractAfterPickupTimeout();
-                return;
-            }
-
-            if (this.activeClients.Any(client => !this.IsClientAvailableOnMap(client.pawn)))
-            {
-                return;
-            }
-        }
-
-        // Wait until the delivery shuttle has finished unloading before success/deadline checks.
-        // Otherwise a brand-new contract can "complete" or soft-fail while clients are still landing.
-        if (!this.pickupShuttleSpawned && this.activeClients.Any(client => !this.IsClientAvailableOnMap(client.pawn)))
-        {
-            return;
-        }
-
-        // Keep recruitment locked for the entire stay.
-        foreach (RoyaltyRegenesisClient client in this.activeClients)
-        {
-            this.LockRecruitment(client.pawn);
-            if (client.pawn?.guest != null && client.isPrisoner && !client.pawn.IsPrisoner)
-            {
-                this.ApplyGuestOrPrisonerStatus(client.pawn, isPrisoner: true);
-            }
-        }
-
-        this.EnsureGuestClientsAreQuestLodgers();
-
-        if (this.activeClients.Any(client => client.pawn.Dead))
-        {
-            Pawn dead = this.activeClients.First(client => client.pawn.Dead).pawn;
+            Pawn dead = this.activeClients.First(client => client.pawn != null && client.pawn.Dead).pawn;
             Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction;
             List<Pawn> survivors = this.activeClients
                 .Where(client => client.pawn != null && !client.pawn.Dead)
@@ -972,6 +977,61 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        // Player Send, auto-leave, FlyAway, or destruction of the contract shuttle.
+        // Final success is evaluated here — not when pawns merely board a parked shuttle.
+        if (this.clientsHaveArrived && this.HasContractShuttleLeftMap())
+        {
+            this.LogRoyaltyDebug(
+                "Contract shuttle left the map → FinishContractAfterDeparture(success="
+                + this.IsDepartureSuccessBanked() + ")");
+            this.LogClientAgeSnapshot("pre-finish (shuttle left)");
+            this.FinishContractAfterDeparture(this.IsDepartureSuccessBanked());
+            return;
+        }
+
+        if (this.pickupShuttleSpawned)
+        {
+            this.RefreshClientAgeProgress();
+
+            if (this.PickupLoadingWindowExpired())
+            {
+                this.LogRoyaltyDebug(
+                    "Pickup loading window expired. allReady=" + this.pickupAllClientsReady
+                    + " banked=" + this.departureSuccessBanked
+                    + " onMap=" + this.activeClients.Count(c => this.IsClientAvailableOnMap(c.pawn))
+                    + " inTransport=" + this.activeClients.Count(c => this.IsClientInReturnTransport(c.pawn)));
+                this.LogClientAgeSnapshot("pickup timeout");
+                this.FailContractAfterPickupTimeout();
+                return;
+            }
+
+            // Still boarding: wait for the shuttle to leave (HasContractShuttleLeftMap) or timeout.
+            if (this.activeClients.Any(client => !this.IsClientAvailableOnMap(client.pawn))
+                || this.activeClients.Any(client => this.IsClientAboardContractShuttle(client.pawn)))
+            {
+                return;
+            }
+        }
+
+        // Wait until the delivery shuttle has finished unloading before success/deadline checks.
+        // Otherwise a brand-new contract can "complete" or soft-fail while clients are still landing.
+        if (!this.clientsHaveArrived)
+        {
+            return;
+        }
+
+        // Keep recruitment locked for the entire stay.
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            this.LockRecruitment(client.pawn);
+            if (client.pawn?.guest != null && client.isPrisoner && !client.pawn.IsPrisoner)
+            {
+                this.ApplyGuestOrPrisonerStatus(client.pawn, isPrisoner: true);
+            }
+        }
+
+        this.EnsureGuestClientsAreQuestLodgers();
+
         this.EnsureContractDeadline();
         this.RefreshClientAgeProgress();
 
@@ -988,11 +1048,18 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        // Bank success before logistics so a scheduled board/leave cannot soft-fail a finished treatment.
+        if (allDone)
+        {
+            this.BankDepartureSuccess("pre-depart (ages ready)");
+        }
+
         this.LogRoyaltyDebug(
             "Sending clients to board the contract shuttle. reason="
             + (allDone ? "all clients ready" : "deadline reached")
             + " allDone=" + allDone
             + " deadlineReached=" + deadlineReached
+            + " banked=" + this.departureSuccessBanked
             + " deadlineTick=" + this.contractDeadlineTick
             + " now=" + Find.TickManager.TicksGame
             + " contractStart=" + this.contractStartTick);
@@ -1019,8 +1086,99 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             this.LogRoyaltyDebug(
                 "DepartClients succeeded. pickupSpawned=" + this.pickupShuttleSpawned
                 + " allReady=" + this.pickupAllClientsReady
+                + " banked=" + this.departureSuccessBanked
                 + " shuttle=" + (this.contractShuttle?.LabelCap ?? "null"));
         }
+    }
+
+    private bool IsDepartureSuccessBanked()
+    {
+        return this.departureSuccessBanked
+            || this.contractCompletionLogged
+            || this.pickupAllClientsReady;
+    }
+
+    private void BankDepartureSuccess(string reason)
+    {
+        if (this.departureSuccessBanked)
+        {
+            return;
+        }
+
+        this.departureSuccessBanked = true;
+        this.contractCompletionLogged = true;
+        this.pickupAllClientsReady = true;
+        this.LogRoyaltyDebug("Departure success banked (" + reason + ").");
+    }
+
+    private void UpdateClientsArrivedFlag()
+    {
+        if (this.clientsHaveArrived || !this.activeClients.Any())
+        {
+            return;
+        }
+
+        if (this.activeClients.All(client => client?.pawn != null && this.IsClientAvailableOnMap(client.pawn)))
+        {
+            this.clientsHaveArrived = true;
+            this.LogRoyaltyDebug("All clients delivered and available on map.");
+        }
+    }
+
+    /// True when the parked/pickup contract shuttle is no longer on the map after delivery.
+    private bool HasContractShuttleLeftMap()
+    {
+#if !RIMWORLD12
+        if (this.contractTransportShip != null)
+        {
+            return !this.contractTransportShip.ShipExistsAndIsSpawned;
+        }
+#endif
+
+        if (this.contractShuttle != null)
+        {
+            return this.contractShuttle.Destroyed || !this.contractShuttle.Spawned;
+        }
+
+        // No shuttle reference: only treat as departed once return boarding has started.
+        // Mid-contract with a lost ref should fall through to deadline + replacement shuttle.
+        return this.pickupShuttleSpawned;
+    }
+
+    private Thing GetContractShuttleThing()
+    {
+        if (this.contractShuttle != null && !this.contractShuttle.Destroyed)
+        {
+            return this.contractShuttle;
+        }
+
+#if !RIMWORLD12
+        if (this.contractTransportShip != null && this.contractTransportShip.shipThing != null
+            && !this.contractTransportShip.shipThing.Destroyed)
+        {
+            return this.contractTransportShip.shipThing;
+        }
+#endif
+
+        return null;
+    }
+
+    /// True when the pawn is inside the contract shuttle's transporter container.
+    private bool IsClientAboardContractShuttle(Pawn pawn)
+    {
+        if (pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        Thing shuttle = this.GetContractShuttleThing();
+        if (shuttle == null)
+        {
+            return false;
+        }
+
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        return transporter != null && transporter.innerContainer.Contains(pawn);
     }
 
     /// Vanilla Royalty hospitality guests are temporary player-faction pawns whose
@@ -1070,26 +1228,54 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
+    /// Returns guest lodgers to their home faction after the contract ends.
+    /// Must run while client references still exist (before <see cref="activeClients"/> is cleared).
+    ///
+    /// Do NOT call this at boarding time: SetFaction away from the player turns a temporary
+    /// colonist-lodger (e.g. a planetary ruler) into a foreign Town Councilman mid-leave,
+    /// which breaks ExitOnShuttle / CompShuttle loading and soft-fails successful contracts.
+    /// Vanilla hospitality keeps ExtraFaction lodgers as OfPlayer until the quest cleans up.
     private void RestoreGuestClientFactions()
     {
         foreach (RoyaltyRegenesisClient client in this.activeClients.Where(client => client != null && !client.isPrisoner))
         {
             Pawn pawn = client.pawn;
-            if (pawn != null && !pawn.Destroyed && client.sourceFaction != null && pawn.Faction == Faction.OfPlayer)
+            if (pawn == null || pawn.Destroyed || client.sourceFaction == null)
             {
-                this.ReleaseFromCurrentLord(pawn);
-                pawn.SetFaction(client.sourceFaction);
-                this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner: false);
+                continue;
             }
+
+            if (pawn.Faction != Faction.OfPlayer)
+            {
+                continue;
+            }
+
+            // Drop any leave/boarding lord first so SetFaction does not race with it.
+            this.ReleaseFromCurrentLord(pawn);
+            pawn.SetFaction(client.sourceFaction);
+            // Do not re-apply Guest of player — they are going home, not visiting.
+            // ApplyGuestOrPrisonerStatus here recreated a visitor state that left
+            // rulers showing as Town Councilman while still stuck in guest AI.
         }
     }
 
     private void AssignExitOnShuttleLord(Map map, Thing shuttle, List<Pawn> pawns, Faction faction)
     {
-        this.RestoreGuestClientFactions();
+        // Keep guest lodgers as temporary player-faction pawns for the whole boarding
+        // sequence. Restoring home faction is deferred to FinishContractAfterDeparture /
+        // EndActiveContractQuest so they remain controllable required-shuttle passengers.
         this.ReleaseFromCurrentLords(pawns);
+
+        // Prefer OfPlayer when any departing client is still a player lodger so the lord
+        // faction matches the pawns. Prisoners remain their source faction.
+        Faction lordFaction = faction ?? Faction.OfPlayer;
+        if (pawns != null && pawns.Any(p => p != null && !p.Destroyed && p.Faction == Faction.OfPlayer))
+        {
+            lordFaction = Faction.OfPlayer;
+        }
+
         LordMaker.MakeNewLord(
-            faction ?? Faction.OfPlayer,
+            lordFaction,
             new LordJob_ExitOnShuttle(shuttle),
             map,
             pawns);
@@ -1108,12 +1294,29 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         pawn?.GetLord()?.Notify_PawnLost(pawn, PawnLostCondition.ForcedToJoinOtherLord);
     }
 
-    private void FinishContractAfterDeparture(bool success)
+    /// Finalizes the active contract quest on shuttle departure (or equivalent leave).
+    /// Success if ages were banked/latched; otherwise soft-fails without a full chain reset.
+    private void FinishContractAfterDeparture(
+        bool success,
+        string failLabel = null,
+        string failText = null)
     {
-        // Final re-evaluation from latched per-client flags (pawns may already be gone).
+        // Nothing left to settle (already finalized).
+        if (this.activeContractStage == RoyaltyRegenesisStage.NotStarted
+            && this.activeContractQuest == null
+            && !this.activeClients.Any())
+        {
+            this.ClearContractShuttle();
+            this.ClearContractTiming();
+            this.LogRoyaltyDebug("FinishContractAfterDeparture: nothing to finalize.");
+            return;
+        }
+
+        // Final re-evaluation from banked flags and any clients still referenced.
         this.RefreshClientAgeProgress();
-        bool latchedSuccess = this.pickupAllClientsReady
-            || (this.activeClients.Any() && this.activeClients.All(c => c.everReachedDesiredAge));
+        bool latchedSuccess = this.IsDepartureSuccessBanked()
+            || (this.activeClients.Any()
+                && this.activeClients.All(c => c != null && c.everReachedDesiredAge));
         if (latchedSuccess != success)
         {
             this.LogRoyaltyDebug(
@@ -1121,33 +1324,38 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             success = latchedSuccess;
         }
 
+        RoyaltyRegenesisStage finishedStage = this.activeContractStage;
+        bool triggerEndgame = this.activeClients.Any(client => client != null && client.triggerRoyalAscent);
+
         this.LogRoyaltyDebug(
             "FinishContractAfterDeparture success=" + success
-            + " stage=" + this.activeContractStage
+            + " stage=" + finishedStage
             + " clients=" + this.activeClients.Count
-            + " triggerRoyalAscent=" + this.activeClients.Any(c => c.triggerRoyalAscent));
+            + " triggerRoyalAscent=" + triggerEndgame
+            + " banked=" + this.departureSuccessBanked
+            + " completionLatched=" + this.contractCompletionLogged
+            + " allReady=" + this.pickupAllClientsReady);
         this.LogClientAgeSnapshot("finish");
 
-        bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
-        bool alreadyLogged = this.contractCompletionLogged;
+        // Return lodgers to their home faction while client pawn refs still exist.
+        // EndActiveContractQuest also calls Restore as a safety net, but activeClients
+        // is cleared below so it must happen here first.
+        this.RestoreGuestClientFactions();
+
         this.ClearContractFlags(this.activeClients);
         this.activeClients.Clear();
         this.ClearContractShuttle();
         this.ClearContractTiming();
 
-        if (alreadyLogged)
-        {
-            this.LogRoyaltyDebug("Contract was already logged as completed at target-age; departure is cleanup only.");
-            return;
-        }
-
         if (triggerEndgame && success)
         {
-            this.LogRoyaltyDebug("Outcome: SUCCESS + Royal Ascent endgame.");
-            this.GrantCompletionRewardIfEligible(this.activeContractStage);
+            this.LogRoyaltyDebug("Outcome: SUCCESS + Royal Ascent endgame (shuttle departed).");
+            this.activeContractStage = finishedStage;
+            this.GrantCompletionRewardIfEligible(finishedStage);
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.stage = RoyaltyRegenesisStage.Completed;
             this.royalAscentTriggered = true;
+            this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
             this.CompleteChainQuest();
             this.TryMakeRoyalAscentAvailable();
             return;
@@ -1155,47 +1363,38 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (success)
         {
-            this.LogRoyaltyDebug("Outcome: SUCCESS — CompleteActiveContract.");
-            this.GrantCompletionRewardIfEligible(this.activeContractStage);
+            this.LogRoyaltyDebug("Outcome: SUCCESS — CompleteActiveContract (shuttle departed).");
+            this.activeContractStage = finishedStage;
+            this.GrantCompletionRewardIfEligible(finishedStage);
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.CompleteActiveContract();
         }
         else
         {
             // Soft failure: contract fails, stage progress kept, no full chain reset.
-            this.LogRoyaltyDebug("Outcome: FAIL — contract expired (regression not finished / ready never latched).");
+            this.LogRoyaltyDebug("Outcome: FAIL — shuttle departed without banked age targets.");
             this.EndActiveContractQuest(QuestEndOutcome.Fail);
             this.ScheduleRetry(
-                "CryoRegenesis contract expired",
-                "The contract return deadline was reached before the requested regression was finished. But one or more of the clients have left the map. Another attempt may come later.");
+                failLabel ?? "CryoRegenesis contract expired",
+                failText
+                ?? "The shuttle departed before the requested regression was finished. Another attempt may come later.");
         }
     }
 
     private void FailContractAfterPickupTimeout()
     {
-        if (this.contractCompletionLogged)
+        // Ages banked → still succeed when the loading window ends without everyone aboard.
+        if (this.IsDepartureSuccessBanked())
         {
-            this.LogRoyaltyDebug("Pickup window expired after completion was logged — contract stays completed.");
-            this.ClearContractFlags(this.activeClients);
-            this.activeClients.Clear();
-            this.ClearContractShuttle();
-            this.ClearContractTiming();
-            Find.LetterStack.ReceiveLetter(
-                "Regenesis shuttle left without clients",
-                "The shuttle left before every CryoRegenesis client was loaded, "
-                + "but they had already reached their target ages — the contract remains completed.",
-                LetterDefOf.NeutralEvent);
+            this.LogRoyaltyDebug("Pickup window expired after success was banked — success on departure.");
+            this.FinishContractAfterDeparture(true);
             return;
         }
 
         this.LogRoyaltyDebug("FailContractAfterPickupTimeout — clients not loaded in time.");
         this.LogClientAgeSnapshot("pickup timeout fail");
-        this.ClearContractFlags(this.activeClients);
-        this.activeClients.Clear();
-        this.ClearContractShuttle();
-        this.ClearContractTiming();
-        this.EndActiveContractQuest(QuestEndOutcome.Fail);
-        this.ScheduleRetry(
+        this.FinishContractAfterDeparture(
+            false,
             "CryoRegenesis return missed",
             "The shuttle left before every CryoRegenesis client was loaded. Another attempt may come later.");
     }
@@ -1372,10 +1571,18 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.pickupShuttleSpawned = true;
         this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
         this.RefreshClientAgeProgress();
+        if (this.pickupAllClientsReady || this.contractCompletionLogged
+            || (this.activeClients.Any()
+                && this.activeClients.All(c => c != null && c.everReachedDesiredAge)))
+        {
+            this.BankDepartureSuccess("board-and-send with ages ready");
+        }
+
         this.LogRoyaltyDebug(
             "BoardAndSendShuttle: pickupSpawned=true tick=" + this.pickupShuttleSpawnTick
             + " requiredPawns=" + living.Count
-            + " allReady=" + this.pickupAllClientsReady);
+            + " allReady=" + this.pickupAllClientsReady
+            + " banked=" + this.departureSuccessBanked);
     }
 
     private bool SpawnPickupShuttle(Map map, List<Pawn> living, Faction faction)
@@ -1524,7 +1731,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     }
 
     /// Recompute age latches for every living client and update <see cref="pickupAllClientsReady"/>.
-    /// Once a client has ever hit the padded target, that fact is sticky for the contract.
+    /// Once a client has ever reached the contracted target, that fact is sticky for the contract.
     private void RefreshClientAgeProgress()
     {
         if (!this.activeClients.Any())
@@ -1545,7 +1752,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 continue;
             }
 
-            if (this.EvaluateAgeAgainstTarget(client, out _, out _, out _))
+            if (this.EvaluateAgeAgainstTarget(client, out _, out _))
             {
                 client.everReachedDesiredAge = true;
                 anyNew = true;
@@ -1572,10 +1779,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         bool allEver = this.activeClients.All(c => c != null && c.everReachedDesiredAge);
-        if (allEver && !this.pickupAllClientsReady)
+        if (allEver && !this.IsDepartureSuccessBanked())
         {
-            this.pickupAllClientsReady = true;
-            this.LogRoyaltyDebug("All clients have latched everReachedDesiredAge → pickupAllClientsReady=true");
+            this.LogRoyaltyDebug("All clients have latched everReachedDesiredAge → banking departure success.");
             this.MarkContractQuestCompleted();
         }
         else if (anyNew)
@@ -1584,37 +1790,31 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 "Age progress: ready "
                 + this.activeClients.Count(c => c.everReachedDesiredAge)
                 + "/" + this.activeClients.Count
+                + " banked=" + this.departureSuccessBanked
                 + " pickupAllClientsReady=" + this.pickupAllClientsReady);
         }
     }
 
-    /// Logs the contract quest as completed the moment every client has reached their
-    /// target age. Success is banked here, no matter how long the departure takes —
-    /// departure and pickup afterwards are cleanup only.
+    /// Banks success the moment every client has reached their target age.
+    /// The quest stays open until the shuttle departs — then it is finalized as success.
     private void MarkContractQuestCompleted()
     {
-        if (this.contractCompletionLogged)
+        bool alreadyBanked = this.IsDepartureSuccessBanked();
+        this.BankDepartureSuccess("all clients reached target age (stage=" + this.activeContractStage + ")");
+
+        if (alreadyBanked)
         {
             return;
         }
 
-        this.contractCompletionLogged = true;
         this.LogRoyaltyDebug(
-            "All clients reached target age → contract quest completed now (stage=" + this.activeContractStage + ").");
-        this.EndActiveContractQuest(QuestEndOutcome.Success);
-        this.GrantCompletionRewardIfEligible(this.activeContractStage);
+            "All clients reached target age → success banked. Quest finalizes when the shuttle departs.");
 
-        if (this.activeClients.Any(client => client != null && client.triggerRoyalAscent))
-        {
-            this.stage = RoyaltyRegenesisStage.Completed;
-            this.royalAscentTriggered = true;
-            this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
-            this.CompleteChainQuest();
-            this.TryMakeRoyalAscentAvailable();
-            return;
-        }
-
-        this.CompleteActiveContract();
+        Find.LetterStack.ReceiveLetter(
+            "CryoRegenesis treatment complete",
+            "Every CryoRegenesis client has reached their requested age. "
+            + "The contract will succeed once their shuttle departs with them.",
+            LetterDefOf.PositiveEvent);
     }
 
     /// True when this client has ever met the contracted age (sticky), or currently meets it.
@@ -1630,7 +1830,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return true;
         }
 
-        if (this.EvaluateAgeAgainstTarget(client, out _, out _, out _))
+        if (this.EvaluateAgeAgainstTarget(client, out _, out _))
         {
             client.everReachedDesiredAge = true;
             return true;
@@ -1639,37 +1839,39 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return false;
     }
 
-    /// Current bio age is at/below contracted target, padded by elapsed contract time so
-    /// natural aging while waiting to depart does not fail a finished regen.
+    /// Current biological age is at or below the contracted target, forgiving natural
+    /// aging since the contract began.
+    ///
+    /// The casket ejects a client the same tick it clamps them at the exact target, and
+    /// they age +1 tick per tick from then on — so an exact comparison can only succeed
+    /// on that single tick. The casket latches that instant via
+    /// <see cref="NotifyRegenesisTargetReached"/>, but if it is ever missed (pawn already
+    /// ejected on load, older build, power loss on the boundary tick) an exact check can
+    /// never latch again and the contract is unwinnable. Since a pawn ages at most
+    /// (now - contractStart) ticks during the contract, anyone who ever reached the
+    /// target still satisfies current <= target + elapsed, while a client whose
+    /// regression was never finished remains years over the allowance.
     private bool EvaluateAgeAgainstTarget(
         RoyaltyRegenesisClient client,
         out long currentTicks,
-        out long allowedTicks,
-        out long agePadTicks)
+        out long allowedTicks)
     {
         currentTicks = -1;
         allowedTicks = -1;
-        agePadTicks = CheckIntervalTicks;
 
         if (client?.pawn?.ageTracker == null)
         {
             return false;
         }
 
+        long agingAllowance = CheckIntervalTicks;
         if (this.contractStartTick >= 0)
         {
-            agePadTicks += Math.Max(0, Find.TickManager.TicksGame - this.contractStartTick);
-        }
-
-        // Also allow the full contracted stay window (deadline - start) so a client who
-        // finished on day 1 and ages until a late deadline still counts.
-        if (this.contractStartTick >= 0 && this.contractDeadlineTick > this.contractStartTick)
-        {
-            agePadTicks = Math.Max(agePadTicks, (long)(this.contractDeadlineTick - this.contractStartTick) + CheckIntervalTicks);
+            agingAllowance += Math.Max(0, Find.TickManager.TicksGame - this.contractStartTick);
         }
 
         currentTicks = client.pawn.ageTracker.AgeBiologicalTicks;
-        allowedTicks = client.desiredAgeTicks + agePadTicks;
+        allowedTicks = client.desiredAgeTicks + agingAllowance;
         return currentTicks <= allowedTicks;
     }
 
@@ -1709,7 +1911,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 continue;
             }
 
-            bool meets = this.EvaluateAgeAgainstTarget(client, out long cur, out long allowed, out long pad);
+            bool meets = this.EvaluateAgeAgainstTarget(client, out long cur, out long allowed);
             string holder = pawn.ParentHolder != null ? pawn.ParentHolder.GetType().Name : "none";
             this.LogRoyaltyDebug(
                 "  • " + pawn.Name.ToStringShort
@@ -1718,7 +1920,6 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 + " targetYears=" + ((double)client.desiredAgeTicks / GenDate.TicksPerYear).ToString("0.000")
                 + " bioTicks=" + cur
                 + " desiredTicks=" + client.desiredAgeTicks
-                + " padTicks=" + pad
                 + " allowedTicks=" + allowed
                 + " overBy=" + (cur - client.desiredAgeTicks)
                 + " meetsNow=" + meets
@@ -1784,8 +1985,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
         Find.LetterStack.ReceiveLetter(
             "CryoRegenesis contract complete",
-            "The CryoRegenesis clients have reached the requested regression age — the contract is fulfilled. "
-            + "They will board their shuttle and depart. Check the Quests tab for chain progress.",
+            "The shuttle has departed with the CryoRegenesis clients after they reached the requested "
+            + "regression age — the contract is fulfilled. Check the Quests tab for chain progress.",
             LetterDefOf.PositiveEvent);
     }
 
@@ -1918,9 +2119,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         sb.AppendLine();
-        sb.AppendLine(this.pickupAllClientsReady || this.activeClients.All(this.ClientReachedDesiredAge)
-            ? "All clients ready for return."
+        sb.AppendLine(this.IsDepartureSuccessBanked() || this.activeClients.All(this.ClientReachedDesiredAge)
+            ? "All clients ready — contract succeeds when the shuttle departs."
             : "Keep treating until each client reaches their target age before the shuttle departs.");
+        if (this.IsDepartureSuccessBanked())
+        {
+            sb.AppendLine("Treatment success is banked. The quest finalizes when the shuttle leaves.");
+        }
+
         return sb.ToString().TrimEnd();
     }
 
@@ -2444,7 +2650,8 @@ public class RoyaltyRegenesisClient : IExposable
     public bool isPrisoner;
     public Faction sourceFaction;
 
-    /// Latched the first time this client meets the contracted age (with wait pad).
+    /// Latched the first time this client reaches the contracted age (the casket
+    /// notifies the exact tick; the periodic check forgives natural aging afterwards).
     /// Survives subsequent natural aging so pickup success is not lost.
     public bool everReachedDesiredAge;
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -16,6 +16,7 @@ using HarmonyLib;
 using RimWorld;
 using RimWorld.QuestGen;
 using Verse;
+using Verse.AI.Group;
 
 #if RIMWORLD15 || RIMWORLD16
 using LudeonTK;
@@ -29,10 +30,14 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     private const int HalfYearTicks = GenDate.TicksPerYear / 2;
     private const int RecruitGoodwillPenalty = -35;
     private const int DeathTrustGoodwillPenalty = -75;
-    private const int MinContractDays = 3;
-    private const int MaxContractDays = 30;
+    private const int ContractDaysPerClient = 2;
+    private const int MinContractDays = 2;
     private const int MajorResetMinDays = 60;
     private const int MajorResetMaxDays = 90;
+    /// <summary>
+    /// Vanilla hospitality pickup grace (Script_Hospitality_Worker shuttleLeaveDelayTicks = 3*60000).
+    /// </summary>
+    private const int ShuttleLeaveDelayDays = 3;
 
     private RoyaltyRegenesisStage stage = RoyaltyRegenesisStage.NotStarted;
     private RoyaltyRegenesisStage activeContractStage = RoyaltyRegenesisStage.NotStarted;
@@ -46,6 +51,26 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
     private Quest chainQuest;
     private Quest activeContractQuest;
+    /// <summary>TicksGame when the current contract was opened.</summary>
+    private int contractStartTick = -1;
+    /// <summary>TicksGame when the return/pickup shuttle is due.</summary>
+    private int contractDeadlineTick = -1;
+#if !RIMWORLD12
+    /// <summary>Active contract shuttle transport (delivery or pickup).</summary>
+    private TransportShip contractTransportShip;
+#endif
+    private Thing contractShuttle;
+    /// <summary>True once the send-off (pickup) shuttle has been spawned for this contract.</summary>
+    private bool pickupShuttleSpawned;
+    /// <summary>TicksGame when the pickup shuttle became available for loading.</summary>
+    private int pickupShuttleSpawnTick = -1;
+    /// <summary>True once every active client has reached the requested age during pickup.</summary>
+    private bool pickupAllClientsReady;
+    /// <summary>
+    /// True once the contract quest has been logged as completed (every client reached
+    /// their target age). Success is banked here — shuttle logistics can no longer fail it.
+    /// </summary>
+    private bool contractCompletionLogged;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
@@ -93,6 +118,16 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Collections.Look(ref this.activeClients, "crRoyalActiveClients", LookMode.Deep);
         Scribe_References.Look(ref this.chainQuest, "crRoyalChainQuest");
         Scribe_References.Look(ref this.activeContractQuest, "crRoyalActiveContractQuest");
+        Scribe_Values.Look(ref this.contractStartTick, "crRoyalContractStartTick", -1);
+        Scribe_Values.Look(ref this.contractDeadlineTick, "crRoyalContractDeadlineTick", -1);
+        Scribe_Values.Look(ref this.pickupShuttleSpawned, "crRoyalPickupShuttleSpawned", false);
+        Scribe_Values.Look(ref this.pickupShuttleSpawnTick, "crRoyalPickupShuttleSpawnTick", -1);
+        Scribe_Values.Look(ref this.pickupAllClientsReady, "crRoyalPickupAllClientsReady", false);
+        Scribe_Values.Look(ref this.contractCompletionLogged, "crRoyalContractCompletionLogged", false);
+#if !RIMWORLD12
+        Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
+#endif
+        Scribe_References.Look(ref this.contractShuttle, "crRoyalContractShuttle");
 
         if (Scribe.mode == LoadSaveMode.PostLoadInit)
         {
@@ -104,6 +139,11 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             if (this.lastTrustBreakReason == null)
             {
                 this.lastTrustBreakReason = string.Empty;
+            }
+
+            if (this.activeClients.Any())
+            {
+                this.EnsureContractDeadline();
             }
         }
     }
@@ -228,6 +268,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
         this.activeClients.Clear();
+        this.ClearContractShuttle();
+        this.ClearContractTiming();
         this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
         this.stage = debugStage;
         this.nextEventTick = Find.TickManager.TicksGame;
@@ -266,25 +308,23 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         int pawnCount = Rand.RangeInclusive(1, 2);
         List<Pawn> pawns = new List<Pawn>();
-        int contractDays = 0;
-
         for (int i = 0; i < pawnCount; i++)
         {
             Pawn pawn = this.GeneratePawn(this.CommonPawnKind(sender), sender, Rand.RangeInclusive(24, 70));
             int duration = Rand.Element(HalfYearTicks, GenDate.TicksPerYear, GenDate.TicksPerYear * 2);
             long targetTicks = Math.Max(18L * GenDate.TicksPerYear, pawn.ageTracker.AgeBiologicalTicks - duration);
-            int days = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
-            contractDays = Math.Max(contractDays, days);
-            this.PrepareClient(pawn, targetTicks, "foreign prisoner", sender, isPrisoner: true, contractDays: days);
+            this.PrepareClient(pawn, targetTicks, "foreign prisoner", sender, isPrisoner: true, contractDays: 0);
             pawns.Add(pawn);
         }
 
+        int contractDays = this.CalculateContractDays(pawns.Count);
+        this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.RulerPrisoners;
         string returnText = this.FormatReturnDeadline(contractDays);
         string letterBody =
             $"{sender.Name} has sent prisoners for a trial CryoRegenesis contract. " +
             $"Their requested regression is six months, one year, or two years. " +
-            $"They arrive and depart by shuttle and must be returned by {returnText}. " +
+            $"Their shuttle will stay parked on site and departs with them on {returnText}. " +
             "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
         this.DeliverClientsByShuttle(
             map,
@@ -313,15 +353,16 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         Pawn leader = this.GeneratePawn(this.NoblePawnKind(sender), sender, Rand.RangeInclusive(35, 82));
         int yearsToRemove = Rand.RangeInclusive(2, 18);
         long targetTicks = Math.Max(30L * GenDate.TicksPerYear, leader.ageTracker.AgeBiologicalTicks - yearsToRemove * GenDate.TicksPerYear);
-        int contractDays = this.CalculateContractDays(leader.ageTracker.AgeBiologicalTicks - targetTicks);
+        int contractDays = this.CalculateContractDays(1);
 
         // Leaders come as guests (not prisoners) with a hard return time.
         this.PrepareClient(leader, targetTicks, "planetary ruler", sender, isPrisoner: false, contractDays: contractDays);
+        this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.Leaders;
         string returnText = this.FormatReturnDeadline(contractDays);
         string letterBody =
             $"{leader.Name.ToStringShort} of {sender.Name}, a ruler over the age of 30, has arrived by shuttle " +
-            $"for a privately negotiated CryoRegenesis stay. The shuttle returns on {returnText}. " +
+            $"for a privately negotiated CryoRegenesis stay. Their shuttle waits on site and departs on {returnText}. " +
             "Do not recruit them — death or recruitment will destroy trust and reset the chain.";
         this.DeliverClientsByShuttle(
             map,
@@ -348,14 +389,15 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         Pawn pawn = this.GeneratePawn(this.LowerNoblePawnKind(), empire, Rand.RangeInclusive(31, 72));
         int targetAge = Rand.RangeInclusive(21, 40);
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
-        int contractDays = this.CalculateContractDays(pawn.ageTracker.AgeBiologicalTicks - targetTicks);
+        int contractDays = this.CalculateContractDays(1);
 
         this.PrepareClient(pawn, targetTicks, "lower imperial noble", empire, isPrisoner: false, contractDays: contractDays);
+        this.SetActiveContractDeadlineDays(contractDays);
         this.activeContractStage = RoyaltyRegenesisStage.LowerNobility;
         string returnText = this.FormatReturnDeadline(contractDays);
         string letterBody =
             $"The Empire has sent {pawn.Name.ToStringShort}, a lower noble, by shuttle to verify your CryoRegenesis process. " +
-            $"They must return by {returnText}. Do not recruit them — death or recruitment will destroy trust and reset the chain.";
+            $"Their shuttle waits on site and departs on {returnText}. Do not recruit them — death or recruitment will destroy trust and reset the chain.";
         this.DeliverClientsByShuttle(
             map,
             new List<Pawn> { pawn },
@@ -384,15 +426,17 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         int targetAge = Rand.RangeInclusive(21, 35);
         long targetTicks = targetAge * (long)GenDate.TicksPerYear;
         List<Pawn> party = new List<Pawn> { stellarch };
-        int contractDays = this.CalculateContractDays(stellarch.ageTracker.AgeBiologicalTicks - targetTicks);
+        int contractDays = this.CalculateContractDays(party.Count);
         this.PrepareClient(stellarch, targetTicks, "stellarch", empire, isPrisoner: false, contractDays: contractDays);
         party.AddRange(this.GetOrGeneratePartners(stellarch, empire, 30, "stellarch companion", isPrisoner: false, contractDays: contractDays));
+        contractDays = this.CalculateContractDays(party.Count);
+        this.SetActiveContractDeadlineDays(contractDays);
 
         this.activeContractStage = RoyaltyRegenesisStage.StellarchArrival;
         string returnText = this.FormatReturnDeadline(contractDays);
         string letterBody =
             $"The Stellarch has arrived by shuttle for CryoRegenesis and has chosen to regress to age {targetAge}. " +
-            $"Any spouses or lovers in the party have chosen age 30. The imperial shuttle returns on {returnText}.";
+            $"Any spouses or lovers in the party have chosen age 30. The imperial shuttle waits on site and departs on {returnText}.";
         this.DeliverClientsByShuttle(
             map,
             party,
@@ -420,15 +464,17 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         List<Pawn> party = new List<Pawn> { emperor };
         long targetTicks = 20L * GenDate.TicksPerYear;
-        int contractDays = this.CalculateContractDays(emperor.ageTracker.AgeBiologicalTicks - targetTicks);
+        int contractDays = this.CalculateContractDays(party.Count);
         this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
         party.AddRange(this.GetOrGeneratePartners(emperor, empire, 21, "imperial companion", isPrisoner: false, contractDays: contractDays));
+        contractDays = this.CalculateContractDays(party.Count);
+        this.SetActiveContractDeadlineDays(contractDays);
 
         this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
         string returnText = this.FormatReturnDeadline(contractDays);
         string letterBody =
             $"The Emperor has arrived by shuttle for CryoRegenesis and will regress to age 20. " +
-            $"Any spouses or lovers in the party have chosen age 21. The imperial shuttle returns on {returnText}.";
+            $"Any spouses or lovers in the party have chosen age 21. The imperial shuttle waits on site and departs on {returnText}.";
         this.DeliverClientsByShuttle(
             map,
             party,
@@ -500,18 +546,78 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             pawn.health.AddHediff(HediffDefOf.Anesthetic);
         }
 
-        int returnByTick = Find.TickManager.TicksGame + Math.Max(MinContractDays, contractDays) * GenDate.TicksPerDay;
-
-        this.activeClients.Add(new RoyaltyRegenesisClient
+        int now = Find.TickManager.TicksGame;
+        if (this.contractStartTick < 0)
         {
-            pawn = pawn,
-            desiredAgeTicks = desiredAgeTicks,
-            role = role,
-            triggerRoyalAscent = triggerRoyalAscent,
-            returnByTick = returnByTick,
-            isPrisoner = isPrisoner,
-            sourceFaction = sourceFaction,
-        });
+            this.contractStartTick = now;
+        }
+
+        int stayDays = Math.Max(MinContractDays, contractDays);
+        // Always a real future TicksGame deadline — never 0 (0 soft-fails immediately).
+        int returnByTick = now + stayDays * GenDate.TicksPerDay;
+
+        RoyaltyRegenesisClient client = new RoyaltyRegenesisClient();
+        client.pawn = pawn;
+        client.desiredAgeTicks = desiredAgeTicks;
+        client.role = role;
+        client.triggerRoyalAscent = triggerRoyalAscent;
+        client.returnByTick = returnByTick;
+        client.isPrisoner = isPrisoner;
+        client.sourceFaction = sourceFaction;
+        this.activeClients.Add(client);
+
+        this.EnsureContractDeadline();
+    }
+
+    /// <summary>
+    /// Syncs <see cref="contractDeadlineTick"/> from client return ticks.
+    /// Only repairs clearly invalid (≤ 0) deadlines — does not push a live timer forward.
+    /// </summary>
+    private void EnsureContractDeadline()
+    {
+        if (!this.activeClients.Any())
+        {
+            this.ClearContractTiming();
+            return;
+        }
+
+        int now = Find.TickManager.TicksGame;
+        if (this.contractStartTick < 0)
+        {
+            this.contractStartTick = now;
+        }
+
+        int minDeadline = this.contractStartTick + MinContractDays * GenDate.TicksPerDay;
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client == null)
+            {
+                continue;
+            }
+
+            // Unset / corrupt only. Do not rewrite valid future deadlines every tick.
+            if (client.returnByTick <= 0)
+            {
+                client.returnByTick = minDeadline;
+            }
+        }
+
+        this.contractDeadlineTick = this.activeClients.Max(c => c.returnByTick);
+        if (this.contractDeadlineTick < minDeadline)
+        {
+            this.contractDeadlineTick = minDeadline;
+        }
+    }
+
+    private void ClearContractTiming()
+    {
+        this.contractStartTick = -1;
+        this.contractDeadlineTick = -1;
+        this.pickupShuttleSpawned = false;
+        this.pickupShuttleSpawnTick = -1;
+        this.pickupAllClientsReady = false;
+        this.contractCompletionLogged = false;
     }
 
     private void ApplyGuestOrPrisonerStatus(Pawn pawn, bool isPrisoner)
@@ -557,20 +663,49 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 #endif
     }
 
-    private int CalculateContractDays(long bioTicksToRemove)
+    private int CalculateContractDays(int clientCount)
     {
-        // Treatment is fast in-casket, but contracts are narrative stays with a hard pickup.
-        double years = Math.Max(0.25, (double)bioTicksToRemove / GenDate.TicksPerYear);
-        int days = (int)Math.Ceiling(8 + years * 4);
-        return Math.Max(MinContractDays, Math.Min(MaxContractDays, days));
+        return Math.Max(MinContractDays, Math.Max(1, clientCount) * ContractDaysPerClient);
+    }
+
+    private void SetActiveContractDeadlineDays(int contractDays)
+    {
+        if (!this.activeClients.Any())
+        {
+            return;
+        }
+
+        int now = Find.TickManager.TicksGame;
+        if (this.contractStartTick < 0)
+        {
+            this.contractStartTick = now;
+        }
+
+        int stayDays = Math.Max(MinContractDays, contractDays);
+        int returnByTick = this.contractStartTick + stayDays * GenDate.TicksPerDay;
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client != null)
+            {
+                client.returnByTick = returnByTick;
+            }
+        }
+
+        this.contractDeadlineTick = returnByTick;
     }
 
     private string FormatReturnDeadline(int contractDays)
     {
         int returnTick = Find.TickManager.TicksGame + contractDays * GenDate.TicksPerDay;
-        return GenDate.DateFullStringAt(returnTick, Find.WorldGrid.LongLatOf(Find.CurrentMap?.Tile ?? 0));
+        return RoyaltyRegenesisQuestFactory.FormatGameTickDate(returnTick);
     }
 
+    /// <summary>
+    /// Contract shuttle: GenerateShuttle → Arrive → Unload → park for the entire contract.
+    /// The same shuttle carries the clients home — <see cref="BoardAndSendShuttle"/> flips it
+    /// to leave-when-loaded when treatment completes or the deadline hits.
+    /// Faction is left unset so CompShuttle shows Autoload.
+    /// </summary>
     private void DeliverClientsByShuttle(Map map, List<Pawn> pawns, Faction faction, string label, string text)
     {
         if (map == null || pawns == null || !pawns.Any())
@@ -578,144 +713,98 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
-
 #if RIMWORLD12
-        this.DeliverByLegacyShuttle(map, pawns, faction, cell);
+        // No WaitForever ship job in 1.2: park far longer than any contract can last.
+        this.DeliverByLegacyShuttle(map, pawns, faction, 10 * GenDate.TicksPerYear);
 #else
-        this.DeliverByTransportShip(map, pawns, faction, cell);
+        this.DeliverByTransportShip(map, pawns, faction);
 #endif
 
         Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NeutralEvent, new LookTargets(pawns));
     }
 
 #if RIMWORLD12
-    private void DeliverByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    /// <summary>
+    /// RimWorld 1.2: <see cref="QuestGen_Shuttle.GenerateShuttle"/> + ShuttleIncoming.
+    /// Parks after drop-off for the whole contract with Autoload/Send for the return trip.
+    /// </summary>
+    private void DeliverByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction, int stayTicks)
     {
-        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
-        if (faction != null)
+        // No owningFaction: player-facing guest controls (Autoload) require null/player faction.
+        Thing shuttle = QuestGen_Shuttle.GenerateShuttle(
+            owningFaction: null,
+            requiredPawns: pawns,
+            leaveImmediatelyWhenSatisfied: false,
+            dropEverythingOnArrival: true,
+            stayAfterDroppedEverythingOnArrival: true,
+            hideControls: false);
+
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        if (compShuttle != null)
         {
-            shuttle.SetFaction(faction);
+            compShuttle.leaveAfterTicks = stayTicks;
         }
 
         CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
-        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
-        if (transporter != null)
+        transporter?.innerContainer.TryAddRangeOrTransfer(pawns.Cast<Thing>(), true, false);
+
+        this.contractShuttle = shuttle;
+
+        IntVec3 cell = DropCellFinder.TradeDropSpot(map);
+        if (!cell.IsValid)
         {
-            transporter.innerContainer.TryAddRangeOrTransfer(pawns.Cast<Thing>().ToList(), true, true);
+            cell = DropCellFinder.RandomDropSpot(map);
         }
 
-        if (compShuttle != null)
-        {
-            compShuttle.dropEverythingOnArrival = true;
-            compShuttle.leaveAfterTicks = GenDate.TicksPerHour;
-        }
-
-        Skyfaller skyfaller = SkyfallerMaker.MakeSkyfaller(ThingDefOf.ShuttleIncoming, shuttle);
-        GenPlace.TryPlaceThing(skyfaller, cell, map, ThingPlaceMode.Near);
-    }
-
-    private void DepartByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction)
-    {
-        this.EjectClientsFromCaskets(map, pawns);
-
-        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
-        if (faction != null)
-        {
-            shuttle.SetFaction(faction);
-        }
-
-        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
-        GenPlace.TryPlaceThing(shuttle, cell, map, ThingPlaceMode.Near);
-
-        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
-        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
-        foreach (Pawn pawn in pawns.Where(p => p != null && !p.Destroyed))
-        {
-            this.TransferPawnIntoTransporter(pawn, transporter);
-        }
-
-        if (compShuttle != null)
-        {
-            if (transporter != null && !transporter.LoadingInProgressOrReadyToLaunch)
-            {
-                TransporterUtility.InitiateLoading(Gen.YieldSingle(transporter));
-            }
-
-            compShuttle.Send();
-        }
+        GenPlace.TryPlaceThing(
+            SkyfallerMaker.MakeSkyfaller(ThingDefOf.ShuttleIncoming, shuttle),
+            cell,
+            map,
+            ThingPlaceMode.Near);
     }
 #else
-    private void DeliverByTransportShip(Map map, List<Pawn> pawns, Faction faction, IntVec3 cell)
+    /// <summary>
+    /// RimWorld 1.3+: contract shuttle (Arrive → Unload → WaitForever with gizmos → FlyAway).
+    /// It stays parked until <see cref="BoardAndSendShuttle"/> tells it to leave with the clients.
+    /// </summary>
+    private void DeliverByTransportShip(Map map, List<Pawn> pawns, Faction faction)
     {
-        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
-        if (faction != null)
-        {
-            shuttle.SetFaction(faction);
-        }
+        // Match Util_TransportShip_Pickup: no owningFaction so Autoload gizmos appear.
+        Thing shuttle = QuestGen_Shuttle.GenerateShuttle(
+            owningFaction: null,
+            requiredPawns: pawns,
+            hideControls: false);
 
+        // Never use MakeTransportShip(contents) destroyLeftover path — transfer safely.
         TransportShip ship = TransportShipMaker.MakeTransportShip(
             TransportShipDefOf.Ship_Shuttle,
-            pawns.Cast<Thing>(),
+            null,
             shuttle);
-        ship.ArriveAt(cell, map.Parent);
-        ship.AddJobs(ShipJobDefOf.Unload, ShipJobDefOf.FlyAway);
-    }
+        ship.TransporterComp.innerContainer.TryAddRangeOrTransfer(pawns.Cast<Thing>(), true, false);
 
-    private void DepartByTransportShip(Map map, List<Pawn> pawns, Faction faction)
-    {
-        this.EjectClientsFromCaskets(map, pawns);
+        ShipJob_Arrive arrive = (ShipJob_Arrive)ShipJobMaker.MakeShipJob(ShipJobDefOf.Arrive);
+        arrive.mapParent = map.Parent;
+        arrive.factionForArrival = faction ?? Faction.OfPlayer;
+        ship.AddJob(arrive);
+        ship.AddJob(ShipJobDefOf.Unload);
 
-        List<Pawn> living = pawns.Where(p => p != null && !p.Destroyed && !p.Dead).ToList();
-        if (!living.Any())
-        {
-            return;
-        }
+        ShipJob_Wait wait = (ShipJob_Wait)ShipJobMaker.MakeShipJob(ShipJobDefOf.WaitForever);
+        wait.leaveImmediatelyWhenSatisfied = false; // stays parked for the whole contract
+        wait.showGizmos = true;
+        ship.AddJob(wait);
 
-        // Collect clients into the shuttle immediately so pickup is guaranteed.
-        List<Thing> cargo = new List<Thing>();
-        foreach (Pawn pawn in living)
-        {
-            if (pawn.Spawned)
-            {
-                pawn.DeSpawn(DestroyMode.Vanish);
-            }
-            else if (pawn.ParentHolder is Building_CryoRegenesis casket)
-            {
-                casket.EjectContents();
-                if (pawn.Spawned)
-                {
-                    pawn.DeSpawn(DestroyMode.Vanish);
-                }
-            }
-            else if (pawn.ParentHolder is IThingHolder holder && holder != Find.WorldPawns)
-            {
-                // Leave other holders if transfer fails later.
-            }
-
-            cargo.Add(pawn);
-        }
-
-        Thing shuttle = ThingMaker.MakeThing(ThingDefOf.Shuttle);
-        if (faction != null)
-        {
-            shuttle.SetFaction(faction);
-        }
-
-        IntVec3 cell = this.FindShuttleLandingCell(map, faction);
-        TransportShip ship = TransportShipMaker.MakeTransportShip(
-            TransportShipDefOf.Ship_Shuttle,
-            cargo,
-            shuttle);
-        ship.ArriveAt(cell, map.Parent);
-        // Already loaded: do not unload; leave immediately.
         ship.AddJob(ShipJobDefOf.FlyAway);
+        ship.Start();
+
+        this.contractTransportShip = ship;
+        this.contractShuttle = shuttle;
+        this.pickupShuttleSpawned = false;
     }
 #endif
 
     private void EjectClientsFromCaskets(Map map, List<Pawn> pawns)
     {
-        if (map == null)
+        if (map == null || pawns == null)
         {
             return;
         }
@@ -729,29 +818,20 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
-    private void TransferPawnIntoTransporter(Pawn pawn, CompTransporter transporter)
+    private void DestroyClientsOffMap(IEnumerable<Pawn> pawns)
     {
-        if (pawn == null || transporter == null)
+        foreach (Pawn pawn in pawns.Where(p => p != null && !p.Destroyed))
         {
-            return;
+            if (pawn.Spawned)
+            {
+                pawn.DeSpawn(DestroyMode.Vanish);
+            }
+
+            if (!pawn.Destroyed)
+            {
+                pawn.Destroy(DestroyMode.Vanish);
+            }
         }
-
-        if (pawn.Spawned)
-        {
-            pawn.DeSpawn(DestroyMode.Vanish);
-        }
-
-        transporter.innerContainer.TryAddOrTransfer(pawn, true);
-    }
-
-    private IntVec3 FindShuttleLandingCell(Map map, Faction faction)
-    {
-        Faction landingFaction = faction ?? Faction.OfPlayer;
-#if RIMWORLD12
-        return DropCellFinder.TradeDropSpot(map);
-#else
-        return DropCellFinder.GetBestShuttleLandingSpot(map, landingFaction);
-#endif
     }
 
     private void CheckActiveClients()
@@ -761,13 +841,84 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        // Refresh latches before any success/fail decisions (including destroy/leave).
+        this.RefreshClientAgeProgress();
+
+        // Only drop truly destroyed pawns. Clients still in a skyfaller/shuttle container
+        // are not Destroyed and must not fail the contract.
+        int beforeCount = this.activeClients.Count;
         this.activeClients.RemoveAll(client => client?.pawn == null || client.pawn.Destroyed);
+        if (beforeCount != this.activeClients.Count)
+        {
+            this.LogRoyaltyDebug(
+                "Removed " + (beforeCount - this.activeClients.Count)
+                + " destroyed/null client(s). Remaining=" + this.activeClients.Count
+                + " pickupSpawned=" + this.pickupShuttleSpawned
+                + " allReady=" + this.pickupAllClientsReady);
+        }
+
         if (!this.activeClients.Any())
         {
+            if (this.pickupShuttleSpawned)
+            {
+                this.LogRoyaltyDebug(
+                    "All clients gone after pickup spawn → FinishContractAfterDeparture(success="
+                    + this.pickupAllClientsReady + ")");
+                this.FinishContractAfterDeparture(this.pickupAllClientsReady);
+                return;
+            }
+
+            if (this.contractCompletionLogged)
+            {
+                this.LogRoyaltyDebug("Clients gone before pickup, but contract already completed — cleanup only.");
+                this.FinishContractAfterDeparture(true);
+                return;
+            }
+
+            this.ClearContractShuttle();
             this.MajorTrustReset(
                 "CryoRegenesis clients vanished under contract. Trust is lost — the chain resets.",
                 null,
                 "Contract clients lost");
+            return;
+        }
+
+        if (this.pickupShuttleSpawned)
+        {
+            this.RefreshClientAgeProgress();
+
+            bool allInTransport = this.activeClients.All(client => this.IsClientInReturnTransport(client.pawn));
+            if (allInTransport)
+            {
+                this.LogRoyaltyDebug(
+                    "All clients in return transport → FinishContractAfterDeparture(success="
+                    + this.pickupAllClientsReady + ")");
+                this.LogClientAgeSnapshot("pre-finish (in transport)");
+                this.FinishContractAfterDeparture(this.pickupAllClientsReady);
+                return;
+            }
+
+            if (this.PickupLoadingWindowExpired())
+            {
+                this.LogRoyaltyDebug(
+                    "Pickup loading window expired. allReady=" + this.pickupAllClientsReady
+                    + " onMap=" + this.activeClients.Count(c => this.IsClientAvailableOnMap(c.pawn))
+                    + " inTransport=" + this.activeClients.Count(c => this.IsClientInReturnTransport(c.pawn)));
+                this.LogClientAgeSnapshot("pickup timeout");
+                this.FailContractAfterPickupTimeout();
+                return;
+            }
+
+            if (this.activeClients.Any(client => !this.IsClientAvailableOnMap(client.pawn)))
+            {
+                return;
+            }
+        }
+
+        // Wait until the delivery shuttle has finished unloading before success/deadline checks.
+        // Otherwise a brand-new contract can "complete" or soft-fail while clients are still landing.
+        if (!this.pickupShuttleSpawned && this.activeClients.Any(client => !this.IsClientAvailableOnMap(client.pawn)))
+        {
             return;
         }
 
@@ -803,31 +954,93 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        bool allDone = this.activeClients.All(this.ClientReachedDesiredAge);
-        bool deadlineReached = this.activeClients.Any(client => Find.TickManager.TicksGame >= client.returnByTick);
+        this.EnsureContractDeadline();
+        this.RefreshClientAgeProgress();
+
+        bool allDone = this.pickupAllClientsReady;
+        if (this.pickupShuttleSpawned)
+        {
+            return;
+        }
+
+        bool deadlineReached = this.IsContractDeadlineReached();
 
         if (!allDone && !deadlineReached)
         {
             return;
         }
 
-        bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
+        this.LogRoyaltyDebug(
+            "Sending clients to board the contract shuttle. reason="
+            + (allDone ? "all clients ready" : "deadline reached")
+            + " allDone=" + allDone
+            + " deadlineReached=" + deadlineReached
+            + " deadlineTick=" + this.contractDeadlineTick
+            + " now=" + Find.TickManager.TicksGame
+            + " contractStart=" + this.contractStartTick);
+        this.LogClientAgeSnapshot(allDone ? "early return (ready)" : "deadline return");
+
         List<Pawn> departing = this.activeClients.Select(client => client.pawn).Where(p => p != null).ToList();
         Faction sourceFaction = this.activeClients.FirstOrDefault()?.sourceFaction;
         Map targetMap = departing.FirstOrDefault(p => p.MapHeld != null)?.MapHeld ?? this.GetTargetMap();
 
-        bool success = allDone;
-        this.ClearContractFlags(this.activeClients);
-
-        if (targetMap != null && departing.Any())
+        if (departing.Any())
         {
-            this.DepartClients(targetMap, departing, sourceFaction);
+            if (targetMap == null)
+            {
+                this.LogRoyaltyDebug("DepartClients aborted: targetMap is null.");
+                return;
+            }
+
+            if (!this.DepartClients(targetMap, departing, sourceFaction))
+            {
+                this.LogRoyaltyDebug("DepartClients returned false (will retry next check).");
+                return;
+            }
+
+            this.LogRoyaltyDebug(
+                "DepartClients succeeded. pickupSpawned=" + this.pickupShuttleSpawned
+                + " allReady=" + this.pickupAllClientsReady
+                + " shuttle=" + (this.contractShuttle?.LabelCap ?? "null"));
+        }
+    }
+
+    private void FinishContractAfterDeparture(bool success)
+    {
+        // Final re-evaluation from latched per-client flags (pawns may already be gone).
+        this.RefreshClientAgeProgress();
+        bool latchedSuccess = this.pickupAllClientsReady
+            || (this.activeClients.Any() && this.activeClients.All(c => c.everReachedDesiredAge));
+        if (latchedSuccess != success)
+        {
+            this.LogRoyaltyDebug(
+                "Finish success override: arg=" + success + " → latched=" + latchedSuccess);
+            success = latchedSuccess;
         }
 
+        this.LogRoyaltyDebug(
+            "FinishContractAfterDeparture success=" + success
+            + " stage=" + this.activeContractStage
+            + " clients=" + this.activeClients.Count
+            + " triggerRoyalAscent=" + this.activeClients.Any(c => c.triggerRoyalAscent));
+        this.LogClientAgeSnapshot("finish");
+
+        bool triggerEndgame = this.activeClients.Any(client => client.triggerRoyalAscent);
+        bool alreadyLogged = this.contractCompletionLogged;
+        this.ClearContractFlags(this.activeClients);
         this.activeClients.Clear();
+        this.ClearContractShuttle();
+        this.ClearContractTiming();
+
+        if (alreadyLogged)
+        {
+            this.LogRoyaltyDebug("Contract was already logged as completed at target-age; departure is cleanup only.");
+            return;
+        }
 
         if (triggerEndgame && success)
         {
+            this.LogRoyaltyDebug("Outcome: SUCCESS + Royal Ascent endgame.");
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.stage = RoyaltyRegenesisStage.Completed;
             this.royalAscentTriggered = true;
@@ -838,25 +1051,356 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (success)
         {
+            this.LogRoyaltyDebug("Outcome: SUCCESS — CompleteActiveContract.");
             this.EndActiveContractQuest(QuestEndOutcome.Success);
             this.CompleteActiveContract();
         }
         else
         {
             // Soft failure: contract fails, stage progress kept, no full chain reset.
+            this.LogRoyaltyDebug("Outcome: FAIL — contract expired (regression not finished / ready never latched).");
             this.EndActiveContractQuest(QuestEndOutcome.Fail);
             this.ScheduleRetry(
                 "CryoRegenesis contract expired",
-                "The pickup shuttle returned before the requested regression was finished. The clients have left. Another attempt may come later.");
+                "The contract return deadline was reached before the requested regression was finished. But one or more of the clients have left the map. Another attempt may come later.");
         }
     }
 
-    private void DepartClients(Map map, List<Pawn> pawns, Faction faction)
+    private void FailContractAfterPickupTimeout()
+    {
+        if (this.contractCompletionLogged)
+        {
+            this.LogRoyaltyDebug("Pickup window expired after completion was logged — contract stays completed.");
+            this.ClearContractFlags(this.activeClients);
+            this.activeClients.Clear();
+            this.ClearContractShuttle();
+            this.ClearContractTiming();
+            Find.LetterStack.ReceiveLetter(
+                "Regenesis shuttle left without clients",
+                "The shuttle left before every CryoRegenesis client was loaded, "
+                + "but they had already reached their target ages — the contract remains completed.",
+                LetterDefOf.NeutralEvent);
+            return;
+        }
+
+        this.LogRoyaltyDebug("FailContractAfterPickupTimeout — clients not loaded in time.");
+        this.LogClientAgeSnapshot("pickup timeout fail");
+        this.ClearContractFlags(this.activeClients);
+        this.activeClients.Clear();
+        this.ClearContractShuttle();
+        this.ClearContractTiming();
+        this.EndActiveContractQuest(QuestEndOutcome.Fail);
+        this.ScheduleRetry(
+            "CryoRegenesis return missed",
+            "The shuttle left before every CryoRegenesis client was loaded. Another attempt may come later.");
+    }
+
+    private bool IsContractDeadlineReached()
+    {
+        if (this.contractDeadlineTick <= 0)
+        {
+            return false;
+        }
+
+        int now = Find.TickManager.TicksGame;
+
+        // Never fire before the minimum stay after contract start.
+        if (this.contractStartTick >= 0)
+        {
+            int minDeadline = this.contractStartTick + MinContractDays * GenDate.TicksPerDay;
+            if (now < minDeadline)
+            {
+                return false;
+            }
+        }
+
+        return now >= this.contractDeadlineTick;
+    }
+
+    /// <summary>
+    /// True when the client is map-reachable (spawned, in a casket, or walking) — not still
+    /// aboard an incoming delivery shuttle / skyfaller.
+    /// </summary>
+    private bool IsClientAvailableOnMap(Pawn pawn)
+    {
+        if (pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        if (pawn.Spawned)
+        {
+            return true;
+        }
+
+        // Inside a player cryo casket counts as "on map" for contract progress.
+        if (pawn.ParentHolder is Building_CryoRegenesis)
+        {
+            return true;
+        }
+
+        // Still in shuttle/transporter/skyfaller — wait for unload.
+        return false;
+    }
+
+    private bool IsClientInReturnTransport(Pawn pawn)
+    {
+        if (pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        return !this.IsClientAvailableOnMap(pawn);
+    }
+
+    private bool PickupLoadingWindowExpired()
+    {
+        if (!this.pickupShuttleSpawned || this.pickupShuttleSpawnTick < 0)
+        {
+            return false;
+        }
+
+        return Find.TickManager.TicksGame >= this.pickupShuttleSpawnTick + ShuttleLeaveDelayDays * GenDate.TicksPerDay;
+    }
+
+    /// <summary>
+    /// Send clients home aboard the contract shuttle that has been parked on site the whole
+    /// stay. A replacement shuttle is spawned only if the parked one was lost (destroyed, etc.).
+    /// </summary>
+    private bool DepartClients(Map map, List<Pawn> pawns, Faction faction)
+    {
+        this.RefreshClientAgeProgress();
+        this.LogRoyaltyDebug(
+            "DepartClients begin. map=" + (map?.ToString() ?? "null")
+            + " pawns=" + (pawns?.Count ?? 0)
+            + " faction=" + (faction?.Name ?? "null")
+            + " allReady=" + this.pickupAllClientsReady);
+
+        this.EjectClientsFromCaskets(map, pawns);
+
+        List<Pawn> living = pawns.Where(p => p != null && !p.Destroyed && !p.Dead).ToList();
+        if (!living.Any())
+        {
+            this.LogRoyaltyDebug("DepartClients: no living pawns after eject.");
+            return false;
+        }
+
+        // Prisoners are kept anesthetized during treatment; wake them so they can walk
+        // themselves aboard like any other departing guest.
+        foreach (Pawn pawn in living)
+        {
+            Hediff anesthetic = pawn.health?.hediffSet?.GetFirstHediffOfDef(HediffDefOf.Anesthetic);
+            if (anesthetic != null)
+            {
+                pawn.health.RemoveHediff(anesthetic);
+                this.LogRoyaltyDebug("Removed anesthetic from " + pawn.Name.ToStringShort);
+            }
+        }
+
+        // Normal path: the contract shuttle has been parked on site since delivery.
+        Thing shuttle = this.GetUsableContractShuttle(map);
+        if (shuttle != null && !this.pickupShuttleSpawned)
+        {
+            this.LogRoyaltyDebug("Boarding the parked contract shuttle for departure: " + shuttle.LabelCap);
+            this.BoardAndSendShuttle(map, shuttle, living, faction);
+            this.LogClientAgeSnapshot("after board-and-send (parked shuttle)");
+            return true;
+        }
+
+        // Fallback: the parked shuttle was lost — spawn a replacement to carry them home.
+        this.LogRoyaltyDebug("Spawning replacement departure shuttle for " + living.Count + " client(s).");
+        bool spawned = this.SpawnPickupShuttle(map, living, faction);
+        this.LogRoyaltyDebug("SpawnPickupShuttle result=" + spawned + " pickupSpawned=" + this.pickupShuttleSpawned);
+        this.LogClientAgeSnapshot("after spawn pickup shuttle");
+        return spawned;
+    }
+
+    private Thing GetUsableContractShuttle(Map map)
+    {
+        if (this.contractShuttle != null && !this.contractShuttle.Destroyed && this.contractShuttle.Spawned
+            && this.contractShuttle.Map == map)
+        {
+            return this.contractShuttle;
+        }
+
+#if !RIMWORLD12
+        if (this.contractTransportShip != null
+            && this.contractTransportShip.ShipExistsAndIsSpawned
+            && this.contractTransportShip.shipThing != null
+            && this.contractTransportShip.shipThing.Map == map)
+        {
+            this.contractShuttle = this.contractTransportShip.shipThing;
+            return this.contractShuttle;
+        }
+#endif
+
+        return null;
+    }
+
+    private void BoardAndSendShuttle(Map map, Thing shuttle, List<Pawn> living, Faction faction)
+    {
+        CompShuttle compShuttle = shuttle.TryGetComp<CompShuttle>();
+        if (compShuttle != null)
+        {
+            compShuttle.requiredPawns.Clear();
+            compShuttle.requiredPawns.AddRange(living);
+        }
+
+#if !RIMWORLD12
+        // Promote Wait job to leave as soon as required pawns re-board; keep Send gizmo usable.
+        if (this.contractTransportShip != null
+            && this.contractTransportShip.curJob is ShipJob_Wait waitJob)
+        {
+            waitJob.leaveImmediatelyWhenSatisfied = true;
+            waitJob.showGizmos = true;
+        }
+#endif
+
+#if RIMWORLD12
+        if (compShuttle != null)
+        {
+            compShuttle.leaveImmediatelyWhenSatisfied = true;
+            if (compShuttle.leaveAfterTicks <= 0 || compShuttle.leaveAfterTicks > ShuttleLeaveDelayDays * GenDate.TicksPerDay)
+            {
+                compShuttle.leaveAfterTicks = ShuttleLeaveDelayDays * GenDate.TicksPerDay;
+            }
+        }
+#endif
+
+        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+        this.pickupShuttleSpawned = true;
+        this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
+        this.RefreshClientAgeProgress();
+        this.LogRoyaltyDebug(
+            "BoardAndSendShuttle: pickupSpawned=true tick=" + this.pickupShuttleSpawnTick
+            + " requiredPawns=" + living.Count
+            + " allReady=" + this.pickupAllClientsReady);
+    }
+
+    private bool SpawnPickupShuttle(Map map, List<Pawn> living, Faction faction)
     {
 #if RIMWORLD12
-        this.DepartByLegacyShuttle(map, pawns, faction);
+        Thing shuttle = QuestGen_Shuttle.GenerateShuttle(
+            owningFaction: null,
+            requiredPawns: living,
+            leaveImmediatelyWhenSatisfied: true,
+            hideControls: false);
+
+        CompShuttle compShuttle = shuttle?.TryGetComp<CompShuttle>();
+        if (shuttle == null || compShuttle == null)
+        {
+            Log.Error("[CryoRegenesis] Pickup shuttle generation failed; destroying clients off-map.");
+            this.DestroyClientsOffMap(living);
+            return true;
+        }
+
+        compShuttle.leaveAfterTicks = ShuttleLeaveDelayDays * GenDate.TicksPerDay;
+        this.contractShuttle = shuttle;
+        this.pickupShuttleSpawned = true;
+        this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
+
+        IntVec3 cell = DropCellFinder.TradeDropSpot(map);
+        if (!cell.IsValid)
+        {
+            cell = DropCellFinder.RandomDropSpot(map);
+        }
+
+        if (!GenPlace.TryPlaceThing(
+                SkyfallerMaker.MakeSkyfaller(ThingDefOf.ShuttleIncoming, shuttle),
+                cell,
+                map,
+                ThingPlaceMode.Near))
+        {
+            Log.Warning("[CryoRegenesis] Could not place pickup shuttle; destroying clients off-map.");
+            this.DestroyClientsOffMap(living);
+            if (!shuttle.Destroyed)
+            {
+                shuttle.Destroy(DestroyMode.Vanish);
+            }
+
+            return true;
+        }
+
+        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+
+        this.RefreshClientAgeProgress();
+        this.LogRoyaltyDebug(
+            "Pickup shuttle (1.2) placed. leaveAfterTicks=" + compShuttle.leaveAfterTicks
+            + " allReady=" + this.pickupAllClientsReady);
+
+        Find.LetterStack.ReceiveLetter(
+            "Regenesis Replacement Shuttle",
+            "A replacement shuttle has arrived to collect the CryoRegenesis clients. Load them before it leaves.",
+            LetterDefOf.NeutralEvent,
+            new LookTargets(shuttle));
 #else
-        this.DepartByTransportShip(map, pawns, faction);
+        Thing shuttle = QuestGen_Shuttle.GenerateShuttle(
+            owningFaction: null,
+            requiredPawns: living,
+            hideControls: false);
+
+        if (shuttle == null)
+        {
+            Log.Error("[CryoRegenesis] Pickup shuttle generation failed; destroying clients off-map.");
+            this.DestroyClientsOffMap(living);
+            return true;
+        }
+
+        TransportShip ship = TransportShipMaker.MakeTransportShip(
+            TransportShipDefOf.Ship_Shuttle,
+            null,
+            shuttle);
+
+        ShipJob_Arrive arrive = (ShipJob_Arrive)ShipJobMaker.MakeShipJob(ShipJobDefOf.Arrive);
+        arrive.mapParent = map.Parent;
+        arrive.factionForArrival = faction ?? Faction.OfPlayer;
+        if (living[0].MapHeld == map)
+        {
+            arrive.mapOfPawn = living[0];
+        }
+
+        ship.AddJob(arrive);
+
+        ShipJob_WaitTime wait = (ShipJob_WaitTime)ShipJobMaker.MakeShipJob(ShipJobDefOf.WaitTime);
+        wait.duration = ShuttleLeaveDelayDays * GenDate.TicksPerDay;
+        wait.leaveImmediatelyWhenSatisfied = true;
+        wait.showGizmos = true;
+        wait.sendAwayIfAllDespawned = living.Cast<Thing>().ToList();
+        ship.AddJob(wait);
+
+        ship.AddJob(ShipJobDefOf.FlyAway);
+        ship.Start();
+
+        this.contractTransportShip = ship;
+        this.contractShuttle = shuttle;
+        this.pickupShuttleSpawned = true;
+        this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
+
+        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+
+        this.RefreshClientAgeProgress();
+        this.LogRoyaltyDebug(
+            "Pickup shuttle (TransportShip) started. waitDays=" + ShuttleLeaveDelayDays
+            + " leaveImmediatelyWhenSatisfied=true"
+            + " allReady=" + this.pickupAllClientsReady
+            + " ship=" + (ship != null)
+            + " shuttleThing=" + (shuttle?.LabelCap ?? "null"));
+
+        Find.LetterStack.ReceiveLetter(
+            "Regenesis Replacement Shuttle",
+            "A replacement shuttle has arrived to collect the CryoRegenesis clients. Load them before it leaves.",
+            LetterDefOf.NeutralEvent,
+            new LookTargets(shuttle));
+#endif
+
+        return true;
+    }
+
+    private void ClearContractShuttle()
+    {
+        this.contractShuttle = null;
+#if !RIMWORLD12
+        this.contractTransportShip = null;
 #endif
     }
 
@@ -878,9 +1422,219 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
+    /// <summary>
+    /// Recompute age latches for every living client and update <see cref="pickupAllClientsReady"/>.
+    /// Once a client has ever hit the padded target, that fact is sticky for the contract.
+    /// </summary>
+    private void RefreshClientAgeProgress()
+    {
+        if (!this.activeClients.Any())
+        {
+            return;
+        }
+
+        bool anyNew = false;
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client == null)
+            {
+                continue;
+            }
+
+            if (client.everReachedDesiredAge)
+            {
+                continue;
+            }
+
+            if (this.EvaluateAgeAgainstTarget(client, out _, out _, out _))
+            {
+                client.everReachedDesiredAge = true;
+                anyNew = true;
+                Pawn p = client.pawn;
+                this.LogRoyaltyDebug(
+                    "Client FIRST reached target: "
+                    + (p?.Name?.ToStringShort ?? "?")
+                    + " bioTicks=" + (p?.ageTracker?.AgeBiologicalTicks ?? -1)
+                    + " desired=" + client.desiredAgeTicks
+                    + " years=" + (p?.ageTracker?.AgeBiologicalYears.ToString() ?? "?")
+                    + "→" + (client.desiredAgeTicks / GenDate.TicksPerYear));
+
+                if (p != null && !p.Destroyed)
+                {
+                    Find.LetterStack.ReceiveLetter(
+                        "Regenesis client ready",
+                        p.Name.ToStringShort + " has reached the contracted target age of "
+                        + ((float)client.desiredAgeTicks / GenDate.TicksPerYear).ToString("0.#")
+                        + ". Their part of the contract is fulfilled.",
+                        LetterDefOf.PositiveEvent,
+                        new LookTargets(p));
+                }
+            }
+        }
+
+        bool allEver = this.activeClients.All(c => c != null && c.everReachedDesiredAge);
+        if (allEver && !this.pickupAllClientsReady)
+        {
+            this.pickupAllClientsReady = true;
+            this.LogRoyaltyDebug("All clients have latched everReachedDesiredAge → pickupAllClientsReady=true");
+            this.MarkContractQuestCompleted();
+        }
+        else if (anyNew)
+        {
+            this.LogRoyaltyDebug(
+                "Age progress: ready "
+                + this.activeClients.Count(c => c.everReachedDesiredAge)
+                + "/" + this.activeClients.Count
+                + " pickupAllClientsReady=" + this.pickupAllClientsReady);
+        }
+    }
+
+    /// <summary>
+    /// Logs the contract quest as completed the moment every client has reached their
+    /// target age. Success is banked here, no matter how long the departure takes —
+    /// departure and pickup afterwards are cleanup only.
+    /// </summary>
+    private void MarkContractQuestCompleted()
+    {
+        if (this.contractCompletionLogged)
+        {
+            return;
+        }
+
+        this.contractCompletionLogged = true;
+        this.LogRoyaltyDebug(
+            "All clients reached target age → contract quest completed now (stage=" + this.activeContractStage + ").");
+        this.EndActiveContractQuest(QuestEndOutcome.Success);
+
+        if (this.activeClients.Any(client => client != null && client.triggerRoyalAscent))
+        {
+            this.stage = RoyaltyRegenesisStage.Completed;
+            this.royalAscentTriggered = true;
+            this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+            this.CompleteChainQuest();
+            this.TryMakeRoyalAscentAvailable();
+            return;
+        }
+
+        this.CompleteActiveContract();
+    }
+
+    /// <summary>
+    /// True when this client has ever met the contracted age (sticky), or currently meets it.
+    /// </summary>
     private bool ClientReachedDesiredAge(RoyaltyRegenesisClient client)
     {
-        return client.pawn.ageTracker.AgeBiologicalTicks <= client.desiredAgeTicks + CheckIntervalTicks;
+        if (client == null)
+        {
+            return false;
+        }
+
+        if (client.everReachedDesiredAge)
+        {
+            return true;
+        }
+
+        if (this.EvaluateAgeAgainstTarget(client, out _, out _, out _))
+        {
+            client.everReachedDesiredAge = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Current bio age is at/below contracted target, padded by elapsed contract time so
+    /// natural aging while waiting to depart does not fail a finished regen.
+    /// </summary>
+    private bool EvaluateAgeAgainstTarget(
+        RoyaltyRegenesisClient client,
+        out long currentTicks,
+        out long allowedTicks,
+        out long agePadTicks)
+    {
+        currentTicks = -1;
+        allowedTicks = -1;
+        agePadTicks = CheckIntervalTicks;
+
+        if (client?.pawn?.ageTracker == null)
+        {
+            return false;
+        }
+
+        if (this.contractStartTick >= 0)
+        {
+            agePadTicks += Math.Max(0, Find.TickManager.TicksGame - this.contractStartTick);
+        }
+
+        // Also allow the full contracted stay window (deadline - start) so a client who
+        // finished on day 1 and ages until a late deadline still counts.
+        if (this.contractStartTick >= 0 && this.contractDeadlineTick > this.contractStartTick)
+        {
+            agePadTicks = Math.Max(agePadTicks, (long)(this.contractDeadlineTick - this.contractStartTick) + CheckIntervalTicks);
+        }
+
+        currentTicks = client.pawn.ageTracker.AgeBiologicalTicks;
+        allowedTicks = client.desiredAgeTicks + agePadTicks;
+        return currentTicks <= allowedTicks;
+    }
+
+    private void LogRoyaltyDebug(string message)
+    {
+        Log.Message("[CryoRegenesis Royalty] t=" + Find.TickManager.TicksGame + " " + message);
+    }
+
+    private void LogClientAgeSnapshot(string context)
+    {
+        int now = Find.TickManager.TicksGame;
+        long elapsed = this.contractStartTick >= 0 ? Math.Max(0, now - this.contractStartTick) : -1;
+        this.LogRoyaltyDebug(
+            "Age snapshot (" + context + "): clients=" + this.activeClients.Count
+            + " start=" + this.contractStartTick
+            + " deadline=" + this.contractDeadlineTick
+            + " elapsedTicks=" + elapsed
+            + " elapsedDays=" + (elapsed >= 0 ? (elapsed / (float)GenDate.TicksPerDay).ToString("0.00") : "?")
+            + " pickupSpawned=" + this.pickupShuttleSpawned
+            + " allReady=" + this.pickupAllClientsReady);
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client == null)
+            {
+                this.LogRoyaltyDebug("  • (null client entry)");
+                continue;
+            }
+
+            Pawn pawn = client.pawn;
+            if (pawn == null || pawn.Destroyed)
+            {
+                this.LogRoyaltyDebug(
+                    "  • " + (client.role ?? "?")
+                    + " pawn=null/destroyed everReached=" + client.everReachedDesiredAge
+                    + " desiredTicks=" + client.desiredAgeTicks);
+                continue;
+            }
+
+            bool meets = this.EvaluateAgeAgainstTarget(client, out long cur, out long allowed, out long pad);
+            string holder = pawn.ParentHolder != null ? pawn.ParentHolder.GetType().Name : "none";
+            this.LogRoyaltyDebug(
+                "  • " + pawn.Name.ToStringShort
+                + " role=" + (client.role ?? "?")
+                + " bioYears=" + pawn.ageTracker.AgeBiologicalYearsFloat.ToString("0.000")
+                + " targetYears=" + ((double)client.desiredAgeTicks / GenDate.TicksPerYear).ToString("0.000")
+                + " bioTicks=" + cur
+                + " desiredTicks=" + client.desiredAgeTicks
+                + " padTicks=" + pad
+                + " allowedTicks=" + allowed
+                + " overBy=" + (cur - client.desiredAgeTicks)
+                + " meetsNow=" + meets
+                + " everReached=" + client.everReachedDesiredAge
+                + " dead=" + pawn.Dead
+                + " spawned=" + pawn.Spawned
+                + " onMap=" + this.IsClientAvailableOnMap(pawn)
+                + " inTransport=" + this.IsClientInReturnTransport(pawn)
+                + " holder=" + holder);
+        }
     }
 
     private void CompleteActiveContract()
@@ -936,7 +1690,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
         Find.LetterStack.ReceiveLetter(
             "CryoRegenesis contract complete",
-            "The CryoRegenesis clients reached the requested regression age and have departed by shuttle. Check the Quests tab for chain progress.",
+            "The CryoRegenesis clients have reached the requested regression age — the contract is fulfilled. "
+            + "They will board their shuttle and depart. Check the Quests tab for chain progress.",
             LetterDefOf.PositiveEvent);
     }
 
@@ -1007,8 +1762,10 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         {
             sb.AppendLine();
             sb.AppendLine("Active contract clients: " + this.activeClients.Count);
-            int earliestReturn = this.activeClients.Min(c => c.returnByTick);
-            sb.AppendLine("Next return deadline: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn));
+            int deadline = this.contractDeadlineTick > 0
+                ? this.contractDeadlineTick
+                : this.activeClients.Min(c => c.returnByTick);
+            sb.AppendLine("Shuttle departs: " + RoyaltyRegenesisQuestFactory.FormatGameTickDate(deadline));
         }
         else if (this.stage != RoyaltyRegenesisStage.Completed && this.nextEventTick > Find.TickManager.TicksGame)
         {
@@ -1028,10 +1785,14 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         StringBuilder sb = new StringBuilder();
-        int earliestReturn = this.activeClients.Min(c => c.returnByTick);
-        int ticksLeft = Math.Max(0, earliestReturn - Find.TickManager.TicksGame);
-        sb.AppendLine("Return shuttle: " + RoyaltyRegenesisQuestFactory.FormatTickDate(earliestReturn)
-            + " (" + ticksLeft.ToStringTicksToPeriod() + " remaining)");
+        int deadline = this.contractDeadlineTick > 0
+            ? this.contractDeadlineTick
+            : this.activeClients.Min(c => c.returnByTick);
+        int ticksLeft = Math.Max(0, deadline - Find.TickManager.TicksGame);
+        sb.AppendLine(this.pickupShuttleSpawned
+            ? "Shuttle: boarding — load the clients; it leaves once all are aboard."
+            : "Shuttle departs: " + RoyaltyRegenesisQuestFactory.FormatGameTickDate(deadline)
+                + " (" + ticksLeft.ToStringTicksToPeriod() + " remaining)");
         sb.AppendLine();
 
         foreach (RoyaltyRegenesisClient client in this.activeClients)
@@ -1042,23 +1803,30 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             }
 
             Pawn pawn = client.pawn;
-            int currentYears = pawn.ageTracker.AgeBiologicalYears;
-            int targetYears = (int)(client.desiredAgeTicks / GenDate.TicksPerYear);
+            float currentYears = pawn.ageTracker.AgeBiologicalYearsFloat;
+            double targetYears = (double)client.desiredAgeTicks / GenDate.TicksPerYear;
             bool done = this.ClientReachedDesiredAge(client);
             string location = pawn.ParentHolder is Building_CryoRegenesis
                 ? "in CryoRegenesis"
                 : (pawn.Spawned ? "on map" : "held");
+            TrueAgeTracker tracker = pawn.health?.hediffSet?
+                .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+            string percent = tracker != null
+                ? " (" + tracker.GetContractProgressPercent().ToString("0") + "% there)"
+                : string.Empty;
 
             sb.AppendLine("• " + pawn.Name.ToStringShort
-                + " — bio " + currentYears + " → " + targetYears
+                + " — bio " + currentYears.ToString("0.00") + " → " + targetYears.ToString("0.00")
+                + percent
                 + (done ? " [ready]" : " [treating]")
+                + (client.everReachedDesiredAge && !done ? " [was ready]" : "")
                 + " (" + location + ")");
         }
 
         sb.AppendLine();
-        sb.AppendLine(this.activeClients.All(this.ClientReachedDesiredAge)
+        sb.AppendLine(this.pickupAllClientsReady || this.activeClients.All(this.ClientReachedDesiredAge)
             ? "All clients ready for return."
-            : "Keep treating until each client reaches their target age before pickup.");
+            : "Keep treating until each client reaches their target age before the shuttle departs.");
         return sb.ToString().TrimEnd();
     }
 
@@ -1090,8 +1858,16 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.EnsureChainQuest();
         this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
 
-        int returnByTick = this.activeClients.Any()
-            ? this.activeClients.Max(c => c.returnByTick)
+        if (this.contractStartTick < 0)
+        {
+            this.contractStartTick = Find.TickManager.TicksGame;
+        }
+
+        this.EnsureContractDeadline();
+        this.pickupShuttleSpawned = false;
+
+        int returnByTick = this.contractDeadlineTick > 0
+            ? this.contractDeadlineTick
             : Find.TickManager.TicksGame + MinContractDays * GenDate.TicksPerDay;
 
         string description = RoyaltyRegenesisQuestFactory.BuildContractDescription(
@@ -1137,6 +1913,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
 
         this.ClearContractFlags(this.activeClients);
         this.activeClients.Clear();
+        this.ClearContractShuttle();
+        this.ClearContractTiming();
 
         this.trustBreaks++;
         this.lastTrustBreakReason = shortReason;
@@ -1458,7 +2236,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     {
         Find.LetterStack.ReceiveLetter(
             "Imperial CryoRegenesis complete",
-            "The Emperor has reached age 20 and departed by shuttle. Royal Ascent endgame protocols are now being activated.",
+            "The Emperor has been restored to age 20. Royal Ascent endgame protocols are now being activated.",
             LetterDefOf.PositiveEvent);
 
         QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");
@@ -1544,6 +2322,11 @@ public class RoyaltyRegenesisClient : IExposable
     public int returnByTick;
     public bool isPrisoner;
     public Faction sourceFaction;
+    /// <summary>
+    /// Latched the first time this client meets the contracted age (with wait pad).
+    /// Survives subsequent natural aging so pickup success is not lost.
+    /// </summary>
+    public bool everReachedDesiredAge;
 
     public void ExposeData()
     {
@@ -1554,6 +2337,7 @@ public class RoyaltyRegenesisClient : IExposable
         Scribe_Values.Look(ref this.returnByTick, "returnByTick", 0);
         Scribe_Values.Look(ref this.isPrisoner, "isPrisoner", false);
         Scribe_References.Look(ref this.sourceFaction, "sourceFaction");
+        Scribe_Values.Look(ref this.everReachedDesiredAge, "everReachedDesiredAge", false);
     }
 }
 
@@ -1615,36 +2399,38 @@ public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
     }
 }
 
-/// <summary>
-/// Regen-contract pawns never recruit voluntarily. If recruitment still happens,
-/// punish relations with their sending faction.
-/// </summary>
-[HarmonyPatch]
-/*
+/**
+ * Regen-contract pawns never recruit voluntarily. If recruitment still happens,
+ * punish relations with their sending faction.
+ *
+ * =============================================================================
  * CRITICAL — TargetMethod() MUST resolve on EVERY supported RimWorld version
- * or this patch (and historically the whole assembly) fails to apply.
+ * =============================================================================
  *
  * Incident (2026-07, RW 1.2):
  *   This patch originally looked up only the 1.3+ DoRecruit overloads
  *   (no float recruitChance). On 1.2, AccessTools.Method returned null,
  *   harmony.PatchAll() threw, and *all* mod Harmony patches failed to apply —
- *   including Carry-to-CryoRegenesis float menu orders.
+ *   including the Carry-to-CryoRegenesis float menu. The carry feature looked
+ *   broken; the failure was this method resolution.
  *
- * Signature shapes:
+ * Signature map (verify before changing):
  *   1.2:     DoRecruit(Pawn, Pawn, float recruitChance, out string, out string, bool, bool)
  *            DoRecruit(Pawn, Pawn, float recruitChance, bool)
  *   1.3–1.6: DoRecruit(Pawn, Pawn, out string, out string, bool, bool)
  *            DoRecruit(Pawn, Pawn, bool)
  *
- * Rules:
+ * How not to repeat this:
  *   - Always try the 1.2 (float) overloads first, then 1.3+ shapes.
  *   - Never return null from TargetMethod without a compile-time version gate;
  *     a null target aborts batch PatchAll (mitigated in CryoRegenesis ctor by
  *     per-type CreateClassProcessor, but a null target still means THIS patch
- *     never runs).
+ *     does nothing and used to kill everything).
  *   - After any DoRecruit / recruit API change, boot RW 1.2 and confirm no
  *     "[CryoRegenesis] Harmony patch failed on ...Patch_DoRecruit_RegenContract".
+ * =============================================================================
  */
+[HarmonyPatch]
 public static class Patch_DoRecruit_RegenContract
 {
     private static MethodBase TargetMethod()

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -205,14 +205,20 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        if (!this.CanRunCampaign())
+        // Always process existing clients/contracts even if the last casket
+        // has been destroyed or uninstalled. Deadlines, deaths, and cleanup
+        // must still run.
+        this.CheckActiveClients();
+
+        if (this.activeClients.Any())
         {
             return;
         }
 
-        this.CheckActiveClients();
-
-        if (this.activeClients.Any())
+        // Casket (and other campaign prerequisites) only gate *starting*
+        // or advancing new campaign stages, not the processing of an
+        // already-active contract.
+        if (!this.CanRunCampaign())
         {
             return;
         }
@@ -728,18 +734,26 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 #endif
     }
 
-    /// Allows enough time for the slowest requested regression at the casket's
-    /// normal rate, with a day for loading, unloading, and treatment setup.
+    /// Budgets wall-clock time for every active client to finish regression at
+    /// a single casket's normal rate. The empire only knows the colony has a
+    /// CryoRegenesis facility — not how many caskets the player built — so
+    /// multi-client contracts are always scheduled sequentially. One day is
+    /// added for loading, unloading, and treatment setup.
     private int CalculateContractDays()
     {
-        long longestRegressionTicks = this.activeClients
+        long wallClockRegressionTicks = this.activeClients
             .Where(client => client?.pawn?.ageTracker != null)
             .Select(client => Math.Max(0L, client.pawn.ageTracker.AgeBiologicalTicks - client.desiredAgeTicks))
-            .DefaultIfEmpty(0L)
-            .Max();
+            .Where(ticks => ticks > 0)
+            .Sum();
+
+        if (wallClockRegressionTicks <= 0)
+        {
+            return MinContractDays;
+        }
 
         int regressionDays = (int)Math.Ceiling(
-            (double)longestRegressionTicks
+            (double)wallClockRegressionTicks
             / RegressionTicksPerGameTick
             / GenDate.TicksPerDay);
 
@@ -1383,11 +1397,15 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
     private void FailContractAfterPickupTimeout()
     {
-        // Ages banked → still succeed when the loading window ends without everyone aboard.
+        // Ages banked means treatment finished, not that the contract is done. Finalization
+        // only happens when the shuttle actually leaves (HasContractShuttleLeftMap) or every
+        // client is gone with it. Do not succeed here — clients may still be stranded on the
+        // map (blocked path, inaccessible shuttle), and finishing would clear the contract /
+        // unlock Royal Ascent while they remain.
         if (this.IsDepartureSuccessBanked())
         {
-            this.LogRoyaltyDebug("Pickup window expired after success was banked — success on departure.");
-            this.FinishContractAfterDeparture(true);
+            this.LogRoyaltyDebug(
+                "Pickup window expired after success was banked — waiting for real shuttle departure.");
             return;
         }
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -7,9 +7,6 @@
  * This file is licensed under the MIT License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using HarmonyLib;
@@ -34,9 +31,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     private const int MinContractDays = 2;
     private const int MajorResetMinDays = 60;
     private const int MajorResetMaxDays = 90;
-    /// <summary>
-    /// Vanilla hospitality pickup grace (Script_Hospitality_Worker shuttleLeaveDelayTicks = 3*60000).
-    /// </summary>
+    /// Vanilla hospitality pickup grace period (Script_Hospitality_Worker shuttleLeaveDelayTicks = 3*60000).
     private const int ShuttleLeaveDelayDays = 3;
 
     private RoyaltyRegenesisStage stage = RoyaltyRegenesisStage.NotStarted;
@@ -51,25 +46,29 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
     private Quest chainQuest;
     private Quest activeContractQuest;
-    /// <summary>TicksGame when the current contract was opened.</summary>
+
+    /// TicksGame when the current contract was opened.
     private int contractStartTick = -1;
-    /// <summary>TicksGame when the return/pickup shuttle is due.</summary>
+
+    /// TicksGame when the return/pickup shuttle is due.
     private int contractDeadlineTick = -1;
 #if !RIMWORLD12
-    /// <summary>Active contract shuttle transport (delivery or pickup).</summary>
+    /// Active contract shuttle transport (delivery or pickup).
     private TransportShip contractTransportShip;
 #endif
     private Thing contractShuttle;
-    /// <summary>True once the send-off (pickup) shuttle has been spawned for this contract.</summary>
+
+    /// True once the send-off (pickup) shuttle has been spawned for this contract.
     private bool pickupShuttleSpawned;
-    /// <summary>TicksGame when the pickup shuttle became available for loading.</summary>
+
+    /// TicksGame when the pickup shuttle became available for loading.
     private int pickupShuttleSpawnTick = -1;
-    /// <summary>True once every active client has reached the requested age during pickup.</summary>
+
+    /// True once every active client has reached the requested age during pickup.
     private bool pickupAllClientsReady;
-    /// <summary>
+
     /// True once the contract quest has been logged as completed (every client reached
     /// their target age). Success is banked here — shuttle logistics can no longer fail it.
-    /// </summary>
     private bool contractCompletionLogged;
 
     public RoyaltyRegenesisQuestSystem(Game game)
@@ -569,10 +568,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.EnsureContractDeadline();
     }
 
-    /// <summary>
     /// Syncs <see cref="contractDeadlineTick"/> from client return ticks.
     /// Only repairs clearly invalid (≤ 0) deadlines — does not push a live timer forward.
-    /// </summary>
     private void EnsureContractDeadline()
     {
         if (!this.activeClients.Any())
@@ -700,12 +697,10 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return RoyaltyRegenesisQuestFactory.FormatGameTickDate(returnTick);
     }
 
-    /// <summary>
     /// Contract shuttle: GenerateShuttle → Arrive → Unload → park for the entire contract.
     /// The same shuttle carries the clients home — <see cref="BoardAndSendShuttle"/> flips it
     /// to leave-when-loaded when treatment completes or the deadline hits.
     /// Faction is left unset so CompShuttle shows Autoload.
-    /// </summary>
     private void DeliverClientsByShuttle(Map map, List<Pawn> pawns, Faction faction, string label, string text)
     {
         if (map == null || pawns == null || !pawns.Any())
@@ -724,10 +719,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
     }
 
 #if RIMWORLD12
-    /// <summary>
     /// RimWorld 1.2: <see cref="QuestGen_Shuttle.GenerateShuttle"/> + ShuttleIncoming.
     /// Parks after drop-off for the whole contract with Autoload/Send for the return trip.
-    /// </summary>
     private void DeliverByLegacyShuttle(Map map, List<Pawn> pawns, Faction faction, int stayTicks)
     {
         // No owningFaction: player-facing guest controls (Autoload) require null/player faction.
@@ -763,10 +756,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             ThingPlaceMode.Near);
     }
 #else
-    /// <summary>
     /// RimWorld 1.3+: contract shuttle (Arrive → Unload → WaitForever with gizmos → FlyAway).
     /// It stays parked until <see cref="BoardAndSendShuttle"/> tells it to leave with the clients.
-    /// </summary>
     private void DeliverByTransportShip(Map map, List<Pawn> pawns, Faction faction)
     {
         // Match Util_TransportShip_Pickup: no owningFaction so Autoload gizmos appear.
@@ -1117,10 +1108,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return now >= this.contractDeadlineTick;
     }
 
-    /// <summary>
     /// True when the client is map-reachable (spawned, in a casket, or walking) — not still
     /// aboard an incoming delivery shuttle / skyfaller.
-    /// </summary>
     private bool IsClientAvailableOnMap(Pawn pawn)
     {
         if (pawn == null || pawn.Destroyed || pawn.Dead)
@@ -1163,10 +1152,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return Find.TickManager.TicksGame >= this.pickupShuttleSpawnTick + ShuttleLeaveDelayDays * GenDate.TicksPerDay;
     }
 
-    /// <summary>
     /// Send clients home aboard the contract shuttle that has been parked on site the whole
     /// stay. A replacement shuttle is spawned only if the parked one was lost (destroyed, etc.).
-    /// </summary>
     private bool DepartClients(Map map, List<Pawn> pawns, Faction faction)
     {
         this.RefreshClientAgeProgress();
@@ -1422,10 +1409,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
-    /// <summary>
     /// Recompute age latches for every living client and update <see cref="pickupAllClientsReady"/>.
     /// Once a client has ever hit the padded target, that fact is sticky for the contract.
-    /// </summary>
     private void RefreshClientAgeProgress()
     {
         if (!this.activeClients.Any())
@@ -1489,11 +1474,9 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
-    /// <summary>
     /// Logs the contract quest as completed the moment every client has reached their
     /// target age. Success is banked here, no matter how long the departure takes —
     /// departure and pickup afterwards are cleanup only.
-    /// </summary>
     private void MarkContractQuestCompleted()
     {
         if (this.contractCompletionLogged)
@@ -1519,9 +1502,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.CompleteActiveContract();
     }
 
-    /// <summary>
     /// True when this client has ever met the contracted age (sticky), or currently meets it.
-    /// </summary>
     private bool ClientReachedDesiredAge(RoyaltyRegenesisClient client)
     {
         if (client == null)
@@ -1543,10 +1524,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return false;
     }
 
-    /// <summary>
     /// Current bio age is at/below contracted target, padded by elapsed contract time so
     /// natural aging while waiting to depart does not fail a finished regen.
-    /// </summary>
     private bool EvaluateAgeAgainstTarget(
         RoyaltyRegenesisClient client,
         out long currentTicks,
@@ -1903,10 +1882,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.chainQuest = null;
     }
 
-    /// <summary>
     /// Death, recruitment, or loss of clients: fail the contract, wipe chain progress,
     /// and force a long cooldown before anyone will trust you again.
-    /// </summary>
     private void MajorTrustReset(string letterText, Faction offendedFaction, string shortReason)
     {
         this.EndActiveContractQuest(QuestEndOutcome.Fail);
@@ -2088,10 +2065,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         return null;
     }
 
-    /// <summary>
     /// Other planetary factions only — never Ancients, never Empire.
     /// Empire contracts begin only after these succeed.
-    /// </summary>
     private Faction RandomPlanetarySenderFaction()
     {
         return Find.FactionManager.AllFactionsListForReading
@@ -2322,10 +2297,9 @@ public class RoyaltyRegenesisClient : IExposable
     public int returnByTick;
     public bool isPrisoner;
     public Faction sourceFaction;
-    /// <summary>
+
     /// Latched the first time this client meets the contracted age (with wait pad).
     /// Survives subsequent natural aging so pickup success is not lost.
-    /// </summary>
     public bool everReachedDesiredAge;
 
     public void ExposeData()
@@ -2396,108 +2370,5 @@ public class QuestNode_StartRoyaltyRegenesisChain : QuestNode
 
     protected override void RunInt()
     {
-    }
-}
-
-/**
- * Regen-contract pawns never recruit voluntarily. If recruitment still happens,
- * punish relations with their sending faction.
- *
- * =============================================================================
- * CRITICAL — TargetMethod() MUST resolve on EVERY supported RimWorld version
- * =============================================================================
- *
- * Incident (2026-07, RW 1.2):
- *   This patch originally looked up only the 1.3+ DoRecruit overloads
- *   (no float recruitChance). On 1.2, AccessTools.Method returned null,
- *   harmony.PatchAll() threw, and *all* mod Harmony patches failed to apply —
- *   including the Carry-to-CryoRegenesis float menu. The carry feature looked
- *   broken; the failure was this method resolution.
- *
- * Signature map (verify before changing):
- *   1.2:     DoRecruit(Pawn, Pawn, float recruitChance, out string, out string, bool, bool)
- *            DoRecruit(Pawn, Pawn, float recruitChance, bool)
- *   1.3–1.6: DoRecruit(Pawn, Pawn, out string, out string, bool, bool)
- *            DoRecruit(Pawn, Pawn, bool)
- *
- * How not to repeat this:
- *   - Always try the 1.2 (float) overloads first, then 1.3+ shapes.
- *   - Never return null from TargetMethod without a compile-time version gate;
- *     a null target aborts batch PatchAll (mitigated in CryoRegenesis ctor by
- *     per-type CreateClassProcessor, but a null target still means THIS patch
- *     does nothing and used to kill everything).
- *   - After any DoRecruit / recruit API change, boot RW 1.2 and confirm no
- *     "[CryoRegenesis] Harmony patch failed on ...Patch_DoRecruit_RegenContract".
- * =============================================================================
- */
-[HarmonyPatch]
-public static class Patch_DoRecruit_RegenContract
-{
-    private static MethodBase TargetMethod()
-    {
-        // RimWorld 1.2: DoRecruit(..., float recruitChance, out string, out string, bool, bool)
-        MethodInfo rw12 = AccessTools.Method(
-            typeof(InteractionWorker_RecruitAttempt),
-            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
-            new[]
-            {
-                typeof(Pawn),
-                typeof(Pawn),
-                typeof(float),
-                typeof(string).MakeByRefType(),
-                typeof(string).MakeByRefType(),
-                typeof(bool),
-                typeof(bool),
-            });
-
-        if (rw12 != null)
-        {
-            return rw12;
-        }
-
-        // RimWorld 1.3+: recruitChance argument was removed.
-        MethodInfo full = AccessTools.Method(
-            typeof(InteractionWorker_RecruitAttempt),
-            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
-            new[]
-            {
-                typeof(Pawn),
-                typeof(Pawn),
-                typeof(string).MakeByRefType(),
-                typeof(string).MakeByRefType(),
-                typeof(bool),
-                typeof(bool),
-            });
-
-        if (full != null)
-        {
-            return full;
-        }
-
-        // Last-resort short overloads.
-        MethodInfo short12 = AccessTools.Method(
-            typeof(InteractionWorker_RecruitAttempt),
-            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
-            new[] { typeof(Pawn), typeof(Pawn), typeof(float), typeof(bool) });
-
-        if (short12 != null)
-        {
-            return short12;
-        }
-
-        return AccessTools.Method(
-            typeof(InteractionWorker_RecruitAttempt),
-            nameof(InteractionWorker_RecruitAttempt.DoRecruit),
-            new[] { typeof(Pawn), typeof(Pawn), typeof(bool) });
-    }
-
-    public static void Prefix(Pawn recruiter, Pawn recruitee)
-    {
-        if (!RoyaltyRegenesisQuestSystem.IsActiveRegenContractPawn(recruitee))
-        {
-            return;
-        }
-
-        RoyaltyRegenesisQuestSystem.CurrentSystem?.NotifyClientRecruited(recruitee);
     }
 }

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -923,6 +923,8 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             }
         }
 
+        this.EnsureGuestClientsAreQuestLodgers();
+
         if (this.activeClients.Any(client => client.pawn.Dead))
         {
             Pawn dead = this.activeClients.First(client => client.pawn.Dead).pawn;
@@ -994,6 +996,91 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
                 + " allReady=" + this.pickupAllClientsReady
                 + " shuttle=" + (this.contractShuttle?.LabelCap ?? "null"));
         }
+    }
+
+    /// Vanilla Royalty hospitality guests are temporary player-faction pawns whose
+    /// original faction is retained by QuestPart_ExtraFaction. A guest tracker alone
+    /// only creates an uncontrolled visitor, with no bed assignment or Operations UI.
+    private void EnsureGuestClientsAreQuestLodgers()
+    {
+        if (this.pickupShuttleSpawned || this.activeContractQuest == null || this.activeContractQuest.Historical)
+        {
+            return;
+        }
+
+        foreach (IGrouping<Faction, RoyaltyRegenesisClient> factionClients in this.activeClients
+                     .Where(client => client != null && !client.isPrisoner && client.pawn != null)
+                     .GroupBy(client => client.sourceFaction))
+        {
+            Faction homeFaction = factionClients.Key;
+            List<Pawn> pawns = factionClients.Select(client => client.pawn).Distinct().ToList();
+            QuestPart_ExtraFaction extraFactionPart = this.activeContractQuest.PartsListForReading
+                .OfType<QuestPart_ExtraFaction>()
+                .FirstOrDefault(part =>
+                    part.extraFaction != null &&
+                    part.extraFaction.faction == homeFaction &&
+                    part.extraFaction.factionType == ExtraFactionType.HomeFaction);
+
+            if (extraFactionPart == null)
+            {
+                extraFactionPart = this.activeContractQuest.ExtraFaction(
+                    homeFaction,
+                    pawns,
+                    ExtraFactionType.HomeFaction);
+            }
+            else
+            {
+                extraFactionPart.affectedPawns.AddRange(
+                    pawns.Where(pawn => !extraFactionPart.affectedPawns.Contains(pawn)));
+            }
+
+            foreach (Pawn pawn in pawns)
+            {
+                this.ReleaseFromCurrentLord(pawn);
+                if (pawn.Faction != Faction.OfPlayer)
+                {
+                    pawn.SetFaction(Faction.OfPlayer);
+                }
+            }
+        }
+    }
+
+    private void RestoreGuestClientFactions()
+    {
+        foreach (RoyaltyRegenesisClient client in this.activeClients.Where(client => client != null && !client.isPrisoner))
+        {
+            Pawn pawn = client.pawn;
+            if (pawn != null && !pawn.Destroyed && client.sourceFaction != null && pawn.Faction == Faction.OfPlayer)
+            {
+                this.ReleaseFromCurrentLord(pawn);
+                pawn.SetFaction(client.sourceFaction);
+                this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner: false);
+            }
+        }
+    }
+
+    private void AssignExitOnShuttleLord(Map map, Thing shuttle, List<Pawn> pawns, Faction faction)
+    {
+        this.RestoreGuestClientFactions();
+        this.ReleaseFromCurrentLords(pawns);
+        LordMaker.MakeNewLord(
+            faction ?? Faction.OfPlayer,
+            new LordJob_ExitOnShuttle(shuttle),
+            map,
+            pawns);
+    }
+
+    private void ReleaseFromCurrentLords(IEnumerable<Pawn> pawns)
+    {
+        foreach (Pawn pawn in pawns)
+        {
+            this.ReleaseFromCurrentLord(pawn);
+        }
+    }
+
+    private void ReleaseFromCurrentLord(Pawn pawn)
+    {
+        pawn?.GetLord()?.Notify_PawnLost(pawn, PawnLostCondition.ForcedToJoinOtherLord);
     }
 
     private void FinishContractAfterDeparture(bool success)
@@ -1254,7 +1341,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         }
 #endif
 
-        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+        this.AssignExitOnShuttleLord(map, shuttle, living, faction);
         this.pickupShuttleSpawned = true;
         this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
         this.RefreshClientAgeProgress();
@@ -1308,7 +1395,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             return true;
         }
 
-        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+        this.AssignExitOnShuttleLord(map, shuttle, living, faction);
 
         this.RefreshClientAgeProgress();
         this.LogRoyaltyDebug(
@@ -1363,7 +1450,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         this.pickupShuttleSpawned = true;
         this.pickupShuttleSpawnTick = Find.TickManager.TicksGame;
 
-        LordMaker.MakeNewLord(faction ?? Faction.OfPlayer, new LordJob_ExitOnShuttle(shuttle), map, living);
+        this.AssignExitOnShuttleLord(map, shuttle, living, faction);
 
         this.RefreshClientAgeProgress();
         this.LogRoyaltyDebug(
@@ -1860,10 +1947,16 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
             title,
             description,
             this.chainQuest);
+
+        if (!isPrisoner)
+        {
+            this.EnsureGuestClientsAreQuestLodgers();
+        }
     }
 
     private void EndActiveContractQuest(QuestEndOutcome outcome, bool sendLetter = true)
     {
+        this.RestoreGuestClientFactions();
         RoyaltyRegenesisQuestFactory.EndQuestSafe(this.activeContractQuest, outcome, sendLetter);
         this.activeContractQuest = null;
     }

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -489,6 +489,7 @@ public class RoyaltyRegenesisQuestSystem : GameComponent
         {
             tracker.desiredAgeTicks = desiredAgeTicks;
             tracker.underRegenContract = true;
+            tracker.contractStartAgeTicks = pawn.ageTracker.AgeBiologicalTicks;
         }
 
         this.ApplyGuestOrPrisonerStatus(pawn, isPrisoner);

--- a/Source/Thought_RegenesisBodyPositivity.cs
+++ b/Source/Thought_RegenesisBodyPositivity.cs
@@ -33,10 +33,8 @@ public class Thought_RegenesisBodyPositivity : Thought_DurationBased
         base.Init();
     }
 
-    /// <summary>
     /// Always add a new stack; MemoryThoughtHandler drops the oldest past stackLimit.
     /// Default Thought_Memory merge only Renew()s the oldest and discards new years/duration.
-    /// </summary>
     public override bool TryMergeWithExistingMemory(out bool showBubble)
     {
         showBubble = true;

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -46,6 +46,11 @@ public class TrueAgeTracker : HediffWithComps
     public bool aliveYearsInitialized = false;
     public long consciousAliveTicks = 0;
     public long cryoRegenesisRemovedAgeTicks = 0;
+    public long desiredAgeTicks = 0;
+
+    /// True while this pawn is under an active Royalty Regenesis return contract.
+    /// Contract clients must not become voluntarily recruitable.
+    public bool underRegenContract = false;
 
     public override void ExposeData()
     {
@@ -54,6 +59,8 @@ public class TrueAgeTracker : HediffWithComps
         Scribe_Values.Look(ref this.aliveYearsInitialized, "aliveYearsInitialized", false);
         Scribe_Values.Look(ref this.consciousAliveTicks, "consciousAliveTicks", 0L);
         Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
+        Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
+        Scribe_Values.Look(ref this.underRegenContract, "underRegenContract", false);
     }
 
     public override void Tick()

--- a/Source/TrueAgeTracker.cs
+++ b/Source/TrueAgeTracker.cs
@@ -9,6 +9,8 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
+using System.Text;
 using RimWorld;
 using Verse;
 
@@ -52,6 +54,10 @@ public class TrueAgeTracker : HediffWithComps
     /// Contract clients must not become voluntarily recruitable.
     public bool underRegenContract = false;
 
+    /// Biological age (ticks) when the current regen contract began.
+    /// Used to compute regression progress toward <see cref="desiredAgeTicks"/>.
+    public long contractStartAgeTicks = 0;
+
     public override void ExposeData()
     {
         base.ExposeData();
@@ -61,6 +67,7 @@ public class TrueAgeTracker : HediffWithComps
         Scribe_Values.Look(ref this.cryoRegenesisRemovedAgeTicks, "cryoRegenesisRemovedAgeTicks", 0L);
         Scribe_Values.Look(ref this.desiredAgeTicks, "desiredAgeTicks", 0L);
         Scribe_Values.Look(ref this.underRegenContract, "underRegenContract", false);
+        Scribe_Values.Look(ref this.contractStartAgeTicks, "contractStartAgeTicks", 0L);
     }
 
     public override void Tick()
@@ -129,5 +136,84 @@ public class TrueAgeTracker : HediffWithComps
         return (float)ticks / 3600000f;
     }
 
-    public override bool Visible => false;
+    private bool UnderActiveContract =>
+        this.underRegenContract && this.desiredAgeTicks > 0 && this.pawn?.ageTracker != null;
+
+    public float GetContractTargetAgeYears()
+    {
+        return AgeTicksToYears(this.desiredAgeTicks);
+    }
+
+    /// 0–100% of the contracted regression completed (100 once at/below the target age).
+    /// Falls back to 0 when no contract start age was recorded (pre-existing saves).
+    public float GetContractProgressPercent()
+    {
+        if (!this.UnderActiveContract)
+        {
+            return 0f;
+        }
+
+        long currentTicks = this.pawn.ageTracker.AgeBiologicalTicks;
+        if (currentTicks <= this.desiredAgeTicks)
+        {
+            return 100f;
+        }
+
+        if (this.contractStartAgeTicks <= this.desiredAgeTicks)
+        {
+            return 0f;
+        }
+
+        float progress = (this.contractStartAgeTicks - currentTicks)
+            / (float)(this.contractStartAgeTicks - this.desiredAgeTicks) * 100f;
+        return Math.Max(0f, Math.Min(100f, progress));
+    }
+
+    /// Only shown on the Health tab while under an active Regenesis contract, so the
+    /// player can see the contracted target age and how close the pawn is to it.
+    public override bool Visible => this.UnderActiveContract;
+
+    public override string LabelBase => this.UnderActiveContract ? "Regenesis contract" : base.LabelBase;
+
+    public override string LabelInBrackets
+    {
+        get
+        {
+            if (!this.UnderActiveContract)
+            {
+                return base.LabelInBrackets;
+            }
+
+            return "target age " + this.GetContractTargetAgeYears().ToString("0.#")
+                + ", " + this.GetContractProgressPercent().ToString("0") + "% there";
+        }
+    }
+
+    public override string TipStringExtra
+    {
+        get
+        {
+            string baseTip = base.TipStringExtra;
+            if (!this.UnderActiveContract)
+            {
+                return baseTip;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            if (!baseTip.NullOrEmpty())
+            {
+                sb.AppendLine(baseTip.TrimEnd());
+            }
+
+            float currentYears = this.pawn.ageTracker.AgeBiologicalYearsFloat;
+            float targetYears = this.GetContractTargetAgeYears();
+            sb.AppendLine("Current biological age: " + currentYears.ToString("0.00"));
+            sb.AppendLine("Contracted target age: " + targetYears.ToString("0.00"));
+            sb.AppendLine("Regression progress: " + this.GetContractProgressPercent().ToString("0.0") + "%");
+            sb.AppendLine(currentYears > targetYears
+                ? "Years left to remove: " + (currentYears - targetYears).ToString("0.00")
+                : "Target age reached — ready to board the shuttle home.");
+            return sb.ToString().TrimEnd();
+        }
+    }
 }


### PR DESCRIPTION
## **CodeAnt-AI Description**
Add the Imperial Rejuvenation campaign with contracted CryoRegenesis clients

### What Changed
- Royalty-enabled colonies with a CryoRegenesis casket can progress through a staged campaign of foreign prisoners, planetary rulers, Imperial nobles, the Stellarch, and the Emperor.
- Contract clients arrive and return by shuttle with fixed deadlines; recruitment or death breaks trust, resets campaign progress, and applies goodwill penalties.
- Each client receives a requested target age, with live treatment progress shown in quests, health details, and casket inspection text.
- Contracts succeed only after all clients reach their targets and depart safely, then advance the campaign and provide tiered rewards; the Emperor stage unlocks Royal Ascent.
- Contract clients remain protected from recruitment, are not ejected early when healed, and completed treatment is preserved while shuttle departure is pending.
- Withdrawal now visibly and gradually resolves through three severity stages, while rejuvenation memories continue to reflect successful age regression.

### Impact
`✅ Playable Imperial rejuvenation campaign`
`✅ Clearer contract age targets and deadlines`
`✅ Protected client contracts with trust consequences`
`✅ Rewards for successful noble and imperial treatments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Royalty Regenesis quest chain with staged contracts, shuttle deliveries, client progression, and return objectives.
  * Added contract progress details, target-age tracking, and treatment status in quest and health interfaces.
  * Added completion rewards, including resources and randomized bonus caches.
  * Added visible withdrawal effects that gradually diminish over time.

* **Bug Fixes**
  * Improved treatment completion tracking and shuttle recovery.
  * Prevented contracted pawns from being recruited and unwanted ejection after treatment completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->