### PR TITLE
[Quests] Increased contract uranium rewards to 500-600 per treated client.

### DIFF
--- a/Source/Quests/RoyaltyRegenesisQuestRewards.cs
+++ b/Source/Quests/RoyaltyRegenesisQuestRewards.cs
@@ -17,12 +17,19 @@ namespace BetterRimworlds.CryoRegenesis;
 /// with one additional cache selected at random for its contract tier.
 public partial class RoyaltyRegenesisQuestSystem
 {
-    private const int GuaranteedUranium = 50;
+    /// Uranium paid per treated client on contract completion (inclusive range).
+    private const int UraniumPerPersonMin = 500;
+    private const int UraniumPerPersonMax = 600;
     private bool completionRewardGranted;
+
+    /// Party size of the current contract, recorded as clients are prepared.
+    /// Read at grant time, when activeClients may already be cleared/emptied.
+    private int completionRewardClientCount;
 
     private void ExposeCompletionRewardData()
     {
         Scribe_Values.Look(ref this.completionRewardGranted, "crRoyalCompletionRewardGranted", false);
+        Scribe_Values.Look(ref this.completionRewardClientCount, "crRoyalCompletionRewardClientCount", 0);
     }
 
     private void ResetCompletionRewardState()
@@ -44,12 +51,23 @@ public partial class RoyaltyRegenesisQuestSystem
             return;
         }
 
+        // Nobles arrive 2-10 per contract; luciferium/bonus for that tier pay out per client.
+        // Uranium always scales with every treated client (500-600 each).
+        int treatedClients = Math.Max(1, this.completionRewardClientCount);
+        int payoutMultiplier = contractStage == RoyaltyRegenesisStage.LowerNobility
+            ? treatedClients
+            : 1;
+
         RewardEntry bonus = tier.bonuses.RandomElement();
+        int luciferiumCount = tier.luciferium * payoutMultiplier;
+        int uraniumPerPerson = Rand.RangeInclusive(UraniumPerPersonMin, UraniumPerPersonMax);
+        int uraniumCount = uraniumPerPerson * treatedClients;
+        int bonusCount = bonus.count * payoutMultiplier;
         List<RewardEntry> rewards = new List<RewardEntry>
         {
-            new RewardEntry(ThingDefOf.Luciferium, tier.luciferium, "Luciferium"),
-            new RewardEntry(ThingDefOf.Uranium, GuaranteedUranium, "uranium"),
-            bonus,
+            new RewardEntry(ThingDefOf.Luciferium, luciferiumCount, "Luciferium"),
+            new RewardEntry(ThingDefOf.Uranium, uraniumCount, "uranium"),
+            new RewardEntry(bonus.def, bonusCount, bonus.label),
         };
 
         List<Thing> delivered = new List<Thing>();
@@ -59,11 +77,15 @@ public partial class RoyaltyRegenesisQuestSystem
         }
 
         this.completionRewardGranted = true;
+        string clientCountText = treatedClients > 1
+            ? " for " + treatedClients + " clients"
+            : string.Empty;
         Find.LetterStack.ReceiveLetter(
             "CryoRegenesis contract reward",
-            "In gratitude for completing the " + tier.name + " contract, the client has delivered "
-            + tier.luciferium + " Luciferium, " + GuaranteedUranium + " uranium, and a random bonus cache: "
-            + bonus.count + " " + bonus.label + ".",
+            "In gratitude for completing the " + tier.name + " contract" + clientCountText
+            + ", the client has delivered "
+            + luciferiumCount + " Luciferium, " + uraniumCount + " uranium, and a random bonus cache: "
+            + bonusCount + " " + bonus.label + ".",
             LetterDefOf.PositiveEvent,
             delivered.Any() ? new LookTargets(delivered) : null);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quest completion rewards now scale based on the number of clients treated.
  * Uranium rewards are calculated per client, with randomized amounts within defined limits.
  * Certain rewards receive additional scaling for lower-nobility contracts.
  * Completion messages now show the treated-client count and the exact rewards granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->