### PR TITLE
Regen Quests Emperor Entourage: Final Imperial party with Stellarch, wives, and guards.

### DIFF
--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -1,0 +1,313 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Builds the final Imperial Rejuvenation party: High Stellarch + Emperor,
+/// each with 1–4 wives, plus Stellic security guards (no regen contracts).
+///
+/// The Emperor and wives are not world pawns — they are created with
+/// <see cref="SpawnStoryHuman"/>. The High Stellarch is the Empire faction leader
+/// when available; otherwise a story-human Stellarch is generated.
+public static class RoyaltyEmperor
+{
+    public const int LeaderTargetAgeYears = 30;
+    public const int WifeTargetAgeYears = 20;
+
+    /// Men younger than their regen target are aged to a random age above this.
+    public const int MaleAgeFloorYears = 35;
+
+    /// Women younger than their regen target are aged randomly under this (and above the wife target).
+    public const int FemaleAgeCeilingYears = 35;
+
+    public const int MinWivesPerNoble = 1;
+    public const int MaxWivesPerNoble = 4;
+
+    public const int GuardRangedCount = 2;
+    public const int GuardMeleeCount = 2;
+
+    public sealed class RegenMember
+    {
+        public Pawn pawn;
+        public string role;
+        public long desiredAgeTicks;
+        public bool triggerRoyalAscent;
+    }
+
+    public sealed class Party
+    {
+        public readonly List<RegenMember> regenMembers = new List<RegenMember>();
+        public readonly List<Pawn> escorts = new List<Pawn>();
+
+        public Pawn highStellarch;
+        public Pawn emperor;
+        public int wifeCount;
+        public int guardCount;
+
+        /// Every pawn that arrives on the delivery shuttle (regen + escorts).
+        public List<Pawn> AllArrivalPawns
+        {
+            get
+            {
+                List<Pawn> all = new List<Pawn>();
+                foreach (RegenMember member in this.regenMembers)
+                {
+                    if (member?.pawn != null)
+                    {
+                        all.Add(member.pawn);
+                    }
+                }
+
+                all.AddRange(this.escorts.Where(p => p != null));
+                return all;
+            }
+        }
+
+        public string BuildLetterBody(string returnDeadlineText)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The High Stellarch and the Emperor have arrived by imperial shuttle for CryoRegenesis. ");
+            sb.Append($"Both will regress to age {LeaderTargetAgeYears}. ");
+            if (this.wifeCount > 0)
+            {
+                sb.Append($"They brought {this.wifeCount} wife/wives, each to regress to age {WifeTargetAgeYears}. ");
+            }
+
+            if (this.guardCount > 0)
+            {
+                sb.Append($"A detail of {this.guardCount} Stellic security guards accompanies them (no treatment). ");
+            }
+
+            sb.Append($"Treat the contracted guests by {returnDeadlineText}. ");
+            sb.Append("A pickup shuttle arrives when treatment is finished.");
+            return sb.ToString();
+        }
+    }
+
+    /// Assemble the Emperor-stage party. <paramref name="highStellarch"/> may be the
+    /// Empire faction leader (world pawn) or null to generate a story Stellarch.
+    public static Party Build(Faction empire, Pawn highStellarch = null)
+    {
+        Party party = new Party();
+        if (empire == null)
+        {
+            return party;
+        }
+
+        // --- High Stellarch ---
+        Pawn stellarch = highStellarch;
+        if (stellarch == null || stellarch.Dead || stellarch.Destroyed)
+        {
+            stellarch = SpawnStoryHuman.GenerateImperial(
+                empire,
+                Gender.Male,
+                RandomMaleArrivalAgeYears(),
+                royalTitleDefName: "Stellarch",
+                kind: NamedKind("Empire_Royal_Stellarch", empire));
+        }
+        else
+        {
+            EnsureAgeForRegen(stellarch, LeaderTargetAgeYears);
+            SpawnStoryHuman.TrySetRoyalTitle(stellarch, empire, "Stellarch");
+        }
+
+        party.highStellarch = stellarch;
+        party.regenMembers.Add(new RegenMember
+        {
+            pawn = stellarch,
+            role = "high stellarch",
+            desiredAgeTicks = LeaderTargetAgeYears * (long)GenDate.TicksPerYear,
+            triggerRoyalAscent = false,
+        });
+
+        // --- Emperor (always generated; vanilla never has one on the world) ---
+        Pawn emperor = SpawnStoryHuman.GenerateImperial(
+            empire,
+            Gender.Male,
+            RandomMaleArrivalAgeYears(),
+            royalTitleDefName: "Emperor",
+            kind: NamedKind("Empire_Royal_Stellarch", empire));
+        SpawnStoryHuman.TrySetRoyalTitle(emperor, empire, "Emperor");
+
+        party.emperor = emperor;
+        party.regenMembers.Add(new RegenMember
+        {
+            pawn = emperor,
+            role = "emperor",
+            desiredAgeTicks = LeaderTargetAgeYears * (long)GenDate.TicksPerYear,
+            triggerRoyalAscent = true,
+        });
+
+        // --- Wives (1–4 each for Stellarch and Emperor) ---
+        party.wifeCount += AddWives(party, stellarch, empire, "stellarch wife");
+        party.wifeCount += AddWives(party, emperor, empire, "imperial wife");
+
+        // --- Security guards (no regen contracts) ---
+        AddGuards(party, empire);
+
+        return party;
+    }
+
+    private static int AddWives(Party party, Pawn husband, Faction empire, string role)
+    {
+        if (husband == null)
+        {
+            return 0;
+        }
+
+        int desired = Rand.RangeInclusive(MinWivesPerNoble, MaxWivesPerNoble);
+        int created = 0;
+
+        for (int i = 0; i < desired; i++)
+        {
+            Pawn wife = SpawnStoryHuman.GenerateImperial(
+                empire,
+                Gender.Female,
+                RandomFemaleArrivalAgeYears(),
+                royalTitleDefName: null,
+                kind: NamedKind("Empire_Royal_NobleWimp", empire));
+
+            EnsureAgeForRegen(wife, WifeTargetAgeYears);
+            SpawnStoryHuman.Marry(husband, wife);
+
+            party.regenMembers.Add(new RegenMember
+            {
+                pawn = wife,
+                role = role,
+                desiredAgeTicks = WifeTargetAgeYears * (long)GenDate.TicksPerYear,
+                triggerRoyalAscent = false,
+            });
+            created++;
+        }
+
+        return created;
+    }
+
+    private static void AddGuards(Party party, Faction empire)
+    {
+        PawnKindDef ranged = NamedKind("Empire_Fighter_StellicGuardRanged", empire)
+            ?? NamedKind("Empire_Fighter_Janissary", empire)
+            ?? NamedKind("Empire_Fighter_Trooper", empire);
+
+        PawnKindDef melee = NamedKind("Empire_Fighter_StellicGuardMelee", empire)
+            ?? NamedKind("Empire_Fighter_Champion", empire)
+            ?? ranged;
+
+        for (int i = 0; i < GuardRangedCount; i++)
+        {
+            AddGuard(party, empire, ranged);
+        }
+
+        for (int i = 0; i < GuardMeleeCount; i++)
+        {
+            AddGuard(party, empire, melee);
+        }
+
+        party.guardCount = party.escorts.Count;
+    }
+
+    private static void AddGuard(Party party, Faction empire, PawnKindDef kind)
+    {
+        if (kind == null)
+        {
+            return;
+        }
+
+        // Adult combat age; no regen contract.
+        float age = Rand.RangeInclusive(22, 45);
+        Pawn guard = SpawnStoryHuman.Generate(
+            kind,
+            empire,
+            gender: null,
+            biologicalAgeYears: age,
+            options: new SpawnStoryHuman.Options
+            {
+                Faction = empire,
+                HostFaction = Faction.OfPlayer,
+                StoryGuestStatus = SpawnStoryHuman.StoryGuestStatus.Guest,
+                CanGeneratePawnRelations = false,
+            });
+
+        if (guard != null)
+        {
+            party.escorts.Add(guard);
+        }
+    }
+
+    /// If the pawn is younger than the contracted target age, push them into a
+    /// sensible arrival age so there is something to regress.
+    /// Men: random ticks above age 35. Women: random age under 35 (above target).
+    public static void EnsureAgeForRegen(Pawn pawn, int targetAgeYears)
+    {
+        if (pawn?.ageTracker == null)
+        {
+            return;
+        }
+
+        if (pawn.ageTracker.AgeBiologicalYears >= targetAgeYears + 1)
+        {
+            return;
+        }
+
+        long newTicks;
+        if (pawn.gender == Gender.Male)
+        {
+            // Strictly above MaleAgeFloorYears (35).
+            int years = Rand.RangeInclusive(MaleAgeFloorYears + 1, 90);
+            long partial = Rand.Range(0, GenDate.TicksPerYear);
+            newTicks = years * (long)GenDate.TicksPerYear + partial;
+        }
+        else
+        {
+            // Under 35, but old enough that regressing to the wife target is meaningful.
+            int minYears = Math.Max(targetAgeYears + 1, 21);
+            int maxYears = FemaleAgeCeilingYears - 1; // 34
+            if (maxYears < minYears)
+            {
+                maxYears = minYears;
+            }
+
+            int years = Rand.RangeInclusive(minYears, maxYears);
+            long partial = Rand.Range(0, GenDate.TicksPerYear);
+            newTicks = years * (long)GenDate.TicksPerYear + partial;
+        }
+
+        pawn.ageTracker.AgeBiologicalTicks = newTicks;
+    }
+
+    private static float RandomMaleArrivalAgeYears()
+    {
+        // Always above 35 so leaders have headroom down to age 30.
+        return Rand.RangeInclusive(MaleAgeFloorYears + 1, 90) + Rand.Value;
+    }
+
+    private static float RandomFemaleArrivalAgeYears()
+    {
+        // Under 35, above the wife target of 20.
+        return Rand.RangeInclusive(WifeTargetAgeYears + 1, FemaleAgeCeilingYears - 1) + Rand.Value;
+    }
+
+    private static PawnKindDef NamedKind(string defName, Faction faction)
+    {
+        PawnKindDef kind = DefDatabase<PawnKindDef>.GetNamedSilentFail(defName);
+        if (kind != null)
+        {
+            return kind;
+        }
+
+        return faction?.def?.basicMemberKind;
+    }
+}

--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -198,12 +198,14 @@ public static class RoyaltyEmperor
 
     private static void AddGuards(Party party, Faction empire)
     {
-        PawnKindDef ranged = NamedKind("Empire_Fighter_StellicGuardRanged", empire)
-            ?? NamedKind("Empire_Fighter_Janissary", empire)
-            ?? NamedKind("Empire_Fighter_Trooper", empire);
+        // Strict lookups so the chain can advance; basic member only as last resort.
+        PawnKindDef ranged = TryNamedKind("Empire_Fighter_StellicGuardRanged")
+            ?? TryNamedKind("Empire_Fighter_Janissary")
+            ?? TryNamedKind("Empire_Fighter_Trooper")
+            ?? empire?.def?.basicMemberKind;
 
-        PawnKindDef melee = NamedKind("Empire_Fighter_StellicGuardMelee", empire)
-            ?? NamedKind("Empire_Fighter_Champion", empire)
+        PawnKindDef melee = TryNamedKind("Empire_Fighter_StellicGuardMelee")
+            ?? TryNamedKind("Empire_Fighter_Champion")
             ?? ranged;
 
         for (int i = 0; i < GuardRangedCount; i++)
@@ -300,14 +302,15 @@ public static class RoyaltyEmperor
         return Rand.RangeInclusive(WifeTargetAgeYears + 1, FemaleAgeCeilingYears - 1) + Rand.Value;
     }
 
+    /// Returns the named pawn kind, or null if the def is missing (no faction fallback).
+    private static PawnKindDef TryNamedKind(string defName)
+    {
+        return DefDatabase<PawnKindDef>.GetNamedSilentFail(defName);
+    }
+
+    /// Named kind, falling back to the faction's basic member when the def is missing.
     private static PawnKindDef NamedKind(string defName, Faction faction)
     {
-        PawnKindDef kind = DefDatabase<PawnKindDef>.GetNamedSilentFail(defName);
-        if (kind != null)
-        {
-            return kind;
-        }
-
-        return faction?.def?.basicMemberKind;
+        return TryNamedKind(defName) ?? faction?.def?.basicMemberKind;
     }
 }

--- a/Source/Quests/SpawnStoryHuman.cs
+++ b/Source/Quests/SpawnStoryHuman.cs
@@ -178,13 +178,15 @@ public static class SpawnStoryHuman
             request.FixedChronologicalAge = biologicalAgeYears.Value;
         }
 
-        TrySetFixedTitle(request, options?.RoyalTitleDefName, faction);
+        TrySetFixedTitle(ref request, options?.RoyalTitleDefName, faction);
 
         return PawnGenerator.GeneratePawn(request);
     }
 
     /// FixedTitle is available on Royalty installs; set by reflection when present.
-    private static void TrySetFixedTitle(PawnGenerationRequest request, string titleDefName, Faction faction)
+    /// PawnGenerationRequest is a struct, so PropertyInfo.SetValue must mutate a
+    /// boxed copy and write it back — otherwise the caller's request is unchanged.
+    private static void TrySetFixedTitle(ref PawnGenerationRequest request, string titleDefName, Faction faction)
     {
         if (titleDefName.NullOrEmpty())
         {
@@ -200,7 +202,9 @@ public static class SpawnStoryHuman
         PropertyInfo prop = typeof(PawnGenerationRequest).GetProperty("FixedTitle");
         if (prop != null && prop.CanWrite)
         {
-            prop.SetValue(request, title, null);
+            object boxed = request;
+            prop.SetValue(boxed, title, null);
+            request = (PawnGenerationRequest)boxed;
         }
     }
 
@@ -311,11 +315,14 @@ public static class SpawnStoryHuman
 
         if (pawn.story.traits != null)
         {
+            // Rebuild the list silently, then invalidate once. GainTrait per trait
+            // would notify N times; Clear alone never notifies.
             pawn.story.traits.allTraits.Clear();
             foreach (string traitDefName in definition.Traits)
             {
                 AddTraitIfFound(pawn, traitDefName);
             }
+            NotifyTraitsRebuilt(pawn);
         }
 
 #if RIMWORLD12 || RIMWORLD13
@@ -482,9 +489,11 @@ public static class SpawnStoryHuman
         pawn.relations?.ClearAllRelations();
     }
 
+    /// Adds a trait to the list without firing GainTrait side-effects.
+    /// Call <see cref="NotifyTraitsRebuilt"/> once after a batch rebuild.
     private static void AddTraitIfFound(Pawn pawn, string traitDefName)
     {
-        if (traitDefName.NullOrEmpty())
+        if (traitDefName.NullOrEmpty() || pawn?.story?.traits == null)
         {
             return;
         }
@@ -496,7 +505,57 @@ public static class SpawnStoryHuman
             return;
         }
 
-        pawn.story.traits.GainTrait(new Trait(traitDef));
+        if (pawn.story.traits.HasTrait(traitDef))
+        {
+            return;
+        }
+
+        Trait trait = new Trait(traitDef);
+        trait.pawn = pawn;
+        pawn.story.traits.allTraits.Add(trait);
+    }
+
+    /// Same cache invalidation GainTrait runs after a trait list change, once per rebuild.
+    private static void NotifyTraitsRebuilt(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return;
+        }
+
+        pawn.Notify_DisabledWorkTypesChanged();
+
+        if (pawn.skills != null)
+        {
+            pawn.skills.Notify_SkillDisablesChanged();
+#if RIMWORLD15 || RIMWORLD16
+            pawn.skills.DirtyAptitudes();
+#endif
+        }
+
+        if (!pawn.Dead && pawn.RaceProps.Humanlike && pawn.needs?.mood != null)
+        {
+            pawn.needs.mood.thoughts.situational.Notify_SituationalThoughtsDirty();
+        }
+
+        MeditationFocusTypeAvailabilityCache.ClearFor(pawn);
+
+        // Private on TraitSet; name changed across versions (RecacheTraits vs Cache…).
+        if (pawn.story?.traits != null)
+        {
+            MethodInfo recache = typeof(TraitSet).GetMethod(
+                "RecacheTraits",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (recache == null)
+            {
+                recache = typeof(TraitSet).GetMethod(
+                    "CacheAnyTraitHasIngestibleOverrides",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+            }
+            recache?.Invoke(pawn.story.traits, null);
+        }
+
+        pawn.needs?.AddOrRemoveNeedsAsAppropriate();
     }
 
     private static void SetSkill(Pawn pawn, SkillSpec skillSpec)

--- a/Source/Quests/SpawnStoryHuman.cs
+++ b/Source/Quests/SpawnStoryHuman.cs
@@ -65,7 +65,6 @@ public static class SpawnStoryHuman
 #if RIMWORLD12 || RIMWORLD13
         public CrownType CrownType = CrownType.Average;
 #endif
-        public string HeadGraphicPath;
         public string HairDefName;
         public Color HairColor = Color.white;
         public float Melanin = 0.5f;

--- a/Source/Quests/SpawnStoryHuman.cs
+++ b/Source/Quests/SpawnStoryHuman.cs
@@ -1,0 +1,520 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ *
+ * Adapted from BetterRimworlds.Stargate.Utilities.SpawnStoryHuman.
+ */
+
+using System.Collections.Generic;
+using System.Reflection;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Creates fully scripted story humans or lightly-configured dynamic guests.
+/// Used by royalty quest content that needs pawns who never exist as world pawns
+/// (the Emperor, imperial wives, etc.).
+public static class SpawnStoryHuman
+{
+    public enum StoryGuestStatus
+    {
+        None = -1,
+        Guest = 0,
+        Prisoner = 1,
+        Slave = 2
+    }
+
+    public sealed class Options
+    {
+        public Faction Faction = Faction.OfPlayer;
+
+        public StoryGuestStatus StoryGuestStatus = StoryGuestStatus.None;
+
+        /// Used when GuestStatus is Guest or Prisoner. Defaults to Faction.OfPlayer.
+        public Faction HostFaction = Faction.OfPlayer;
+
+        /// If greater than zero, marks the pawn guilty for this many ticks.
+        public int GuiltyTicks = 0;
+
+        /// Clears generated apparel, equipment, inventory, and relations.
+        public bool StripGeneratedGear = false;
+
+        /// Optional royal title to apply after generation (defName, e.g. "Emperor").
+        public string RoyalTitleDefName;
+
+        /// When false, generation skips auto-relations so callers can marry pawns deliberately.
+        public bool CanGeneratePawnRelations = true;
+    }
+
+    public sealed class Definition
+    {
+        public string FirstName;
+        public string NickName;
+        public string LastName;
+
+        public string ChildhoodBackstory;
+        public string AdulthoodBackstory;
+
+        public BodyTypeDef BodyType = BodyTypeDefOf.Male;
+#if RIMWORLD12 || RIMWORLD13
+        public CrownType CrownType = CrownType.Average;
+#endif
+        public string HeadGraphicPath;
+        public string HairDefName;
+        public Color HairColor = Color.white;
+        public float Melanin = 0.5f;
+        public string BirthLastName;
+
+        public long AgeBiologicalTicks;
+        public long BirthAbsTicks = -1;
+
+        public readonly List<string> Traits = new List<string>();
+        public readonly List<SkillSpec> Skills = new List<SkillSpec>();
+    }
+
+    public sealed class SkillSpec
+    {
+        public SkillDef SkillDef;
+        public int Level;
+        public Passion Passion;
+        public float XpSinceLastLevel;
+
+        public SkillSpec(SkillDef skillDef, int level, Passion passion = Passion.None, float xpSinceLastLevel = 0f)
+        {
+            SkillDef = skillDef;
+            Level = level;
+            Passion = passion;
+            XpSinceLastLevel = xpSinceLastLevel;
+        }
+    }
+
+    /// Fully scripted pawn from a <see cref="Definition"/> (names, backstories, skills).
+    public static Pawn Create(Definition definition, Options options = null)
+    {
+        if (definition == null)
+        {
+            Log.Error("[CryoRegenesis] SpawnStoryHuman.Create called with a null definition.");
+            return null;
+        }
+
+        options ??= new Options();
+        Faction faction = options.Faction ?? Faction.OfPlayer;
+        PawnKindDef kind = faction.def?.basicMemberKind ?? PawnKindDefOf.Colonist;
+
+        Pawn pawn = GenerateRaw(kind, faction, gender: null, biologicalAgeYears: null, options);
+        ApplyDefinition(pawn, definition);
+        ApplyOptions(pawn, options);
+        return pawn;
+    }
+
+    /// Dynamic guest / noble / guard generation. Prefer this for royalty quest NPCs
+    /// that do not need a hand-authored name and skill sheet.
+    public static Pawn Generate(
+        PawnKindDef kind,
+        Faction faction,
+        Gender? gender = null,
+        float? biologicalAgeYears = null,
+        Options options = null)
+    {
+        options ??= new Options();
+        options.Faction = faction ?? options.Faction;
+
+        PawnKindDef resolvedKind = kind
+            ?? faction?.def?.basicMemberKind
+            ?? PawnKindDefOf.Colonist;
+
+        Pawn pawn = GenerateRaw(resolvedKind, options.Faction ?? Faction.OfPlayer, gender, biologicalAgeYears, options);
+        ApplyOptions(pawn, options);
+        return pawn;
+    }
+
+    /// Convenience: generate an imperial humanlike of the given gender and age years.
+    public static Pawn GenerateImperial(
+        Faction empire,
+        Gender gender,
+        float biologicalAgeYears,
+        string royalTitleDefName = null,
+        PawnKindDef kind = null,
+        bool guest = true)
+    {
+        Options options = new Options
+        {
+            Faction = empire,
+            HostFaction = Faction.OfPlayer,
+            StoryGuestStatus = guest ? StoryGuestStatus.Guest : StoryGuestStatus.None,
+            CanGeneratePawnRelations = false,
+            RoyalTitleDefName = royalTitleDefName,
+        };
+
+        return Generate(kind, empire, gender, biologicalAgeYears, options);
+    }
+
+    private static Pawn GenerateRaw(
+        PawnKindDef kind,
+        Faction faction,
+        Gender? gender,
+        float? biologicalAgeYears,
+        Options options)
+    {
+        PawnGenerationRequest request = new PawnGenerationRequest(kind, faction);
+        request.ForceGenerateNewPawn = true;
+        request.CanGeneratePawnRelations = options?.CanGeneratePawnRelations ?? true;
+        request.AllowDead = false;
+        request.AllowDowned = false;
+
+        if (gender.HasValue)
+        {
+            request.FixedGender = gender;
+        }
+
+        if (biologicalAgeYears.HasValue)
+        {
+            request.FixedBiologicalAge = biologicalAgeYears.Value;
+            request.FixedChronologicalAge = biologicalAgeYears.Value;
+        }
+
+        TrySetFixedTitle(request, options?.RoyalTitleDefName, faction);
+
+        return PawnGenerator.GeneratePawn(request);
+    }
+
+    /// FixedTitle is available on Royalty installs; set by reflection when present.
+    private static void TrySetFixedTitle(PawnGenerationRequest request, string titleDefName, Faction faction)
+    {
+        if (titleDefName.NullOrEmpty())
+        {
+            return;
+        }
+
+        RoyalTitleDef title = DefDatabase<RoyalTitleDef>.GetNamedSilentFail(titleDefName);
+        if (title == null)
+        {
+            return;
+        }
+
+        PropertyInfo prop = typeof(PawnGenerationRequest).GetProperty("FixedTitle");
+        if (prop != null && prop.CanWrite)
+        {
+            prop.SetValue(request, title, null);
+        }
+    }
+
+    public static void TrySetRoyalTitle(Pawn pawn, Faction faction, string titleDefName)
+    {
+        if (pawn == null || faction == null || titleDefName.NullOrEmpty())
+        {
+            return;
+        }
+
+        RoyalTitleDef title = DefDatabase<RoyalTitleDef>.GetNamedSilentFail(titleDefName);
+        if (title == null || pawn.royalty == null)
+        {
+            return;
+        }
+
+        try
+        {
+            pawn.royalty.SetTitle(faction, title, grantRewards: false, rewardsOnlyForNewestTitle: false, sendLetter: false);
+        }
+        catch (System.Exception ex)
+        {
+            Log.Warning($"[CryoRegenesis] Failed to set royal title {titleDefName} for {pawn.LabelShort}: {ex.Message}");
+        }
+    }
+
+    public static void Marry(Pawn husband, Pawn wife)
+    {
+        if (husband?.relations == null || wife?.relations == null)
+        {
+            return;
+        }
+
+        if (!husband.relations.DirectRelationExists(PawnRelationDefOf.Spouse, wife))
+        {
+            husband.relations.AddDirectRelation(PawnRelationDefOf.Spouse, wife);
+        }
+    }
+
+    private static void ApplyDefinition(Pawn pawn, Definition definition)
+    {
+        if (pawn == null)
+        {
+            return;
+        }
+
+        if (!definition.FirstName.NullOrEmpty() || !definition.LastName.NullOrEmpty())
+        {
+            pawn.Name = new NameTriple(
+                definition.FirstName ?? string.Empty,
+                definition.NickName ?? definition.FirstName ?? string.Empty,
+                definition.LastName ?? string.Empty);
+        }
+
+        ApplyStory(pawn, definition);
+        ApplyAge(pawn, definition);
+        ApplySkills(pawn, definition);
+    }
+
+    private static void ApplyStory(Pawn pawn, Definition definition)
+    {
+        if (pawn.story == null)
+        {
+            return;
+        }
+
+        ApplyBackstories(pawn, definition);
+
+        if (definition.BodyType != null)
+        {
+            pawn.story.bodyType = definition.BodyType;
+        }
+
+#if RIMWORLD12 || RIMWORLD13
+        pawn.story.crownType = definition.CrownType;
+#endif
+
+        if (!definition.HairDefName.NullOrEmpty())
+        {
+            HairDef hairDef = DefDatabase<HairDef>.GetNamedSilentFail(definition.HairDefName);
+            if (hairDef != null)
+            {
+                pawn.story.hairDef = hairDef;
+            }
+            else
+            {
+                Log.Warning("[CryoRegenesis] HairDef not found: " + definition.HairDefName);
+            }
+        }
+
+#if RIMWORLD12 || RIMWORLD13
+        pawn.story.hairColor = definition.HairColor;
+        pawn.story.melanin = definition.Melanin;
+#else
+        pawn.story.HairColor = definition.HairColor;
+        // Skin color is gene-driven on later versions; melanin override is best-effort only.
+        try
+        {
+            PropertyInfo melanin = pawn.story.GetType().GetProperty("melanin")
+                ?? pawn.story.GetType().GetProperty("Melanin");
+            melanin?.SetValue(pawn.story, definition.Melanin, null);
+        }
+        catch
+        {
+            // ignore — cosmetics only
+        }
+#endif
+
+        if (pawn.story.traits != null)
+        {
+            pawn.story.traits.allTraits.Clear();
+            foreach (string traitDefName in definition.Traits)
+            {
+                AddTraitIfFound(pawn, traitDefName);
+            }
+        }
+
+#if RIMWORLD12 || RIMWORLD13
+        if (!definition.BirthLastName.NullOrEmpty())
+        {
+            pawn.story.birthLastName = definition.BirthLastName;
+        }
+#endif
+    }
+
+    private static void ApplyBackstories(Pawn pawn, Definition definition)
+    {
+#if RIMWORLD12 || RIMWORLD13
+        if (!definition.ChildhoodBackstory.NullOrEmpty())
+        {
+            Backstory childhood;
+            if (BackstoryDatabase.allBackstories.TryGetValue(definition.ChildhoodBackstory, out childhood))
+            {
+                pawn.story.childhood = childhood;
+            }
+            else
+            {
+                Log.Warning("[CryoRegenesis] Backstory not found: " + definition.ChildhoodBackstory);
+            }
+        }
+
+        if (!definition.AdulthoodBackstory.NullOrEmpty())
+        {
+            Backstory adulthood;
+            if (BackstoryDatabase.allBackstories.TryGetValue(definition.AdulthoodBackstory, out adulthood))
+            {
+                pawn.story.adulthood = adulthood;
+            }
+            else
+            {
+                Log.Warning("[CryoRegenesis] Backstory not found: " + definition.AdulthoodBackstory);
+            }
+        }
+#else
+        if (!definition.ChildhoodBackstory.NullOrEmpty())
+        {
+            BackstoryDef childhood = DefDatabase<BackstoryDef>.GetNamedSilentFail(definition.ChildhoodBackstory);
+            if (childhood != null)
+            {
+                pawn.story.Childhood = childhood;
+            }
+            else
+            {
+                Log.Warning("[CryoRegenesis] BackstoryDef not found: " + definition.ChildhoodBackstory);
+            }
+        }
+
+        if (!definition.AdulthoodBackstory.NullOrEmpty())
+        {
+            BackstoryDef adulthood = DefDatabase<BackstoryDef>.GetNamedSilentFail(definition.AdulthoodBackstory);
+            if (adulthood != null)
+            {
+                pawn.story.Adulthood = adulthood;
+            }
+            else
+            {
+                Log.Warning("[CryoRegenesis] BackstoryDef not found: " + definition.AdulthoodBackstory);
+            }
+        }
+#endif
+    }
+
+    private static void ApplyAge(Pawn pawn, Definition definition)
+    {
+        if (pawn.ageTracker == null || definition.AgeBiologicalTicks <= 0)
+        {
+            return;
+        }
+
+        pawn.ageTracker.AgeBiologicalTicks = definition.AgeBiologicalTicks;
+        if (definition.BirthAbsTicks != 0)
+        {
+            pawn.ageTracker.BirthAbsTicks = definition.BirthAbsTicks;
+        }
+    }
+
+    private static void ApplySkills(Pawn pawn, Definition definition)
+    {
+        if (pawn.skills == null || definition.Skills == null)
+        {
+            return;
+        }
+
+        foreach (SkillSpec skillSpec in definition.Skills)
+        {
+            SetSkill(pawn, skillSpec);
+        }
+    }
+
+    private static void ApplyOptions(Pawn pawn, Options options)
+    {
+        if (pawn == null || options == null)
+        {
+            return;
+        }
+
+        if (options.StripGeneratedGear)
+        {
+            StripGeneratedGear(pawn);
+        }
+
+        ApplyGuestStatus(pawn, options);
+
+        if (options.GuiltyTicks > 0 && pawn.guilt != null)
+        {
+#if RIMWORLD12
+            pawn.guilt.Notify_Guilty();
+#else
+            pawn.guilt.Notify_Guilty(options.GuiltyTicks);
+#endif
+        }
+
+        // Apply title after generation in case FixedTitle was unavailable.
+        if (!options.RoyalTitleDefName.NullOrEmpty())
+        {
+            TrySetRoyalTitle(pawn, options.Faction, options.RoyalTitleDefName);
+        }
+    }
+
+    private static void ApplyGuestStatus(Pawn pawn, Options options)
+    {
+        if (pawn.guest == null || options.StoryGuestStatus == StoryGuestStatus.None)
+        {
+            return;
+        }
+
+        Faction hostFaction = options.HostFaction ?? Faction.OfPlayer;
+
+#if RIMWORLD12
+        switch (options.StoryGuestStatus)
+        {
+            case StoryGuestStatus.Guest:
+                pawn.guest.SetGuestStatus(hostFaction, false);
+                return;
+            case StoryGuestStatus.Prisoner:
+            case StoryGuestStatus.Slave:
+                pawn.guest.SetGuestStatus(hostFaction, true);
+                pawn.guest.interactionMode = PrisonerInteractionModeDefOf.NoInteraction;
+                return;
+        }
+#else
+        pawn.guest.SetGuestStatus(hostFaction, (GuestStatus)options.StoryGuestStatus);
+        if (options.StoryGuestStatus == StoryGuestStatus.Prisoner)
+        {
+#if RIMWORLD13 || RIMWORLD14
+            pawn.guest.interactionMode = PrisonerInteractionModeDefOf.NoInteraction;
+#else
+            pawn.guest.SetNoInteraction();
+#endif
+        }
+#endif
+    }
+
+    private static void StripGeneratedGear(Pawn pawn)
+    {
+        pawn.equipment?.DestroyAllEquipment();
+        pawn.apparel?.DestroyAll();
+        pawn.inventory?.innerContainer?.ClearAndDestroyContents();
+        pawn.relations?.ClearAllRelations();
+    }
+
+    private static void AddTraitIfFound(Pawn pawn, string traitDefName)
+    {
+        if (traitDefName.NullOrEmpty())
+        {
+            return;
+        }
+
+        TraitDef traitDef = DefDatabase<TraitDef>.GetNamedSilentFail(traitDefName);
+        if (traitDef == null)
+        {
+            Log.Warning("[CryoRegenesis] TraitDef not found: " + traitDefName);
+            return;
+        }
+
+        pawn.story.traits.GainTrait(new Trait(traitDef));
+    }
+
+    private static void SetSkill(Pawn pawn, SkillSpec skillSpec)
+    {
+        if (skillSpec?.SkillDef == null || pawn.skills == null)
+        {
+            return;
+        }
+
+        SkillRecord skill = pawn.skills.GetSkill(skillSpec.SkillDef);
+        if (skill == null)
+        {
+            return;
+        }
+
+        skill.Level = skillSpec.Level;
+        skill.passion = skillSpec.Passion;
+        skill.xpSinceLastLevel = skillSpec.XpSinceLastLevel;
+    }
+}

--- a/Source/RoyaltyRegenesisQuestParts.cs
+++ b/Source/RoyaltyRegenesisQuestParts.cs
@@ -127,8 +127,7 @@ public static class RoyaltyRegenesisQuestFactory
         string roleSummary,
         Faction sender,
         bool isPrisoner,
-        int returnByTick,
-        IEnumerable<Pawn> clients)
+        int returnByTick)
     {
         StringBuilder sb = new StringBuilder();
         sb.AppendLine(roleSummary);
@@ -144,19 +143,135 @@ public static class RoyaltyRegenesisQuestFactory
         sb.AppendLine("Contract deadline: " + FormatGameTickDate(returnByTick));
         sb.AppendLine("Logistics: drop-off leaves after unload; pickups arrive when clients finish (or at the deadline).");
         sb.AppendLine();
-        sb.AppendLine("Clients:");
-        foreach (Pawn pawn in clients.Where(p => p != null))
-        {
-            sb.AppendLine("• " + pawn.Name.ToStringFull + " (bio age " + pawn.ageTracker.AgeBiologicalYears + ")");
-        }
-
-        sb.AppendLine();
         sb.AppendLine("Objectives:");
         sb.AppendLine("1. Place clients in a CryoRegenesis casket.");
         sb.AppendLine("2. Reach their requested regression age before the contract deadline.");
         sb.AppendLine("3. When a client is ready, a pickup shuttle is called — load finished clients and Send.");
         sb.AppendLine("4. Death or recruitment of a client under contract resets the whole chain.");
         return sb.ToString().TrimEnd();
+    }
+
+    /// Player-facing client label: optional royal title prefix, then name, then
+    /// "(Title's Wife)" when the client is a wife of a titled (or role-known) spouse.
+    public static string FormatContractClientName(Pawn pawn, string role = null)
+    {
+        if (pawn == null)
+        {
+            return "Unknown";
+        }
+
+        string name = pawn.Name?.ToStringShort ?? pawn.LabelShortCap;
+        string title = TryGetRoyalTitleLabel(pawn);
+        if (!title.NullOrEmpty())
+        {
+            name = title + " " + name;
+        }
+
+        string husbandTitle = TryGetHusbandTitleForWifePostfix(pawn, role);
+        if (!husbandTitle.NullOrEmpty())
+        {
+            name += " (" + husbandTitle + "'s Wife)";
+        }
+
+        return name;
+    }
+
+    /// Highest royal title label for <paramref name="pawn"/>, or null.
+    public static string TryGetRoyalTitleLabel(Pawn pawn)
+    {
+        if (pawn?.royalty == null)
+        {
+            return null;
+        }
+
+        RoyalTitle senior = pawn.royalty.MostSeniorTitle;
+        if (senior?.def != null)
+        {
+            return senior.def.GetLabelCapFor(pawn);
+        }
+
+        RoyalTitleDef main = pawn.royalty.MainTitle();
+        return main != null ? main.GetLabelCapFor(pawn) : null;
+    }
+
+    /// When <paramref name="pawn"/> is a wife (by role or Spouse relation), returns the
+    /// husband-side title used in "(Title's Wife)" — e.g. Emperor, Stellarch, Count.
+    public static string TryGetHusbandTitleForWifePostfix(Pawn pawn, string role = null)
+    {
+        if (pawn == null)
+        {
+            return null;
+        }
+
+        // Generated Emperor-stage roles are authoritative even before relations settle.
+        if (!role.NullOrEmpty())
+        {
+            string roleLower = role.ToLowerInvariant();
+            if (roleLower.Contains("imperial wife"))
+            {
+                return "Emperor";
+            }
+
+            if (roleLower.Contains("stellarch wife"))
+            {
+                return "Stellarch";
+            }
+        }
+
+        // Only wives (Spouse), not lovers or fiancés.
+        if (pawn.relations?.DirectRelations == null)
+        {
+            return null;
+        }
+
+        foreach (DirectPawnRelation relation in pawn.relations.DirectRelations)
+        {
+            if (relation?.def != PawnRelationDefOf.Spouse || relation.otherPawn == null)
+            {
+                continue;
+            }
+
+            // Prefer the titled spouse (Emperor / Stellarch / noble husband).
+            Pawn spouse = relation.otherPawn;
+            string spouseTitle = TryGetRoyalTitleLabel(spouse);
+            if (!spouseTitle.NullOrEmpty())
+            {
+                return spouseTitle;
+            }
+
+            // Planetary rulers and other primaries often have no royal title.
+            if (spouse.Faction != null && spouse.Faction.leader == spouse)
+            {
+                return "Ruler";
+            }
+        }
+
+        // Companion roles that are wives of an untitled primary (e.g. ruler companion).
+        if (!role.NullOrEmpty()
+            && pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Spouse) != null)
+        {
+            string roleLower = role.ToLowerInvariant();
+            if (roleLower.Contains("wife")
+                || (pawn.gender == Gender.Female && roleLower.Contains("companion")))
+            {
+                if (roleLower.Contains("stellarch"))
+                {
+                    return "Stellarch";
+                }
+
+                if (roleLower.Contains("ruler"))
+                {
+                    return "Ruler";
+                }
+
+                if (roleLower.Contains("noble"))
+                {
+                    return "Noble";
+                }
+            }
+        }
+
+        return null;
     }
 
     /// Formats a <see cref="TickManager.TicksGame"/> value as a calendar date.

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -53,6 +53,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     private int trustBreaks;
     private string lastTrustBreakReason = string.Empty;
     private List<RoyaltyRegenesisClient> activeClients = new List<RoyaltyRegenesisClient>();
+
+    /// Non-regen escorts (e.g. Emperor-stage Stellic guards). Arrive/leave with the party
+    /// but never receive a CryoRegenesis contract.
+    private List<Pawn> contractEscorts = new List<Pawn>();
+
     private Quest chainQuest;
     private Quest activeContractQuest;
 
@@ -168,7 +173,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             .Where(client => client?.pawn != null && !client.pawn.Destroyed)
             .Select(client => client.pawn);
 
-        return RoyaltyRegenesisQuestPartners.IsNonExDirectRelationOfAny(pawn, clients);
+        if (RoyaltyRegenesisQuestPartners.IsNonExDirectRelationOfAny(pawn, clients))
+        {
+            return true;
+        }
+
+        // Emperor-stage Stellic guards and other non-regen escorts.
+        return system.contractEscorts != null && system.contractEscorts.Contains(pawn);
     }
 
     /// Called by a CryoRegenesis casket on the exact tick that a pawn reaches its target.
@@ -211,6 +222,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.trustBreaks, "crRoyalTrustBreaks", 0);
         Scribe_Values.Look(ref this.lastTrustBreakReason, "crRoyalLastTrustBreakReason");
         Scribe_Collections.Look(ref this.activeClients, "crRoyalActiveClients", LookMode.Deep);
+        Scribe_Collections.Look(ref this.contractEscorts, "crRoyalContractEscorts", LookMode.Reference);
         Scribe_References.Look(ref this.chainQuest, "crRoyalChainQuest");
         Scribe_References.Look(ref this.activeContractQuest, "crRoyalActiveContractQuest");
         Scribe_Values.Look(ref this.contractStartTick, "crRoyalContractStartTick", -1);
@@ -236,6 +248,15 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             if (this.activeClients == null)
             {
                 this.activeClients = new List<RoyaltyRegenesisClient>();
+            }
+
+            if (this.contractEscorts == null)
+            {
+                this.contractEscorts = new List<Pawn>();
+            }
+            else
+            {
+                this.contractEscorts.RemoveAll(p => p == null || p.Destroyed);
             }
 
             if (this.returnedClientPawnIds == null)
@@ -666,37 +687,62 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        Pawn emperor = this.GetFactionLeader(empire, 21);
-        if (emperor == null)
+        // High Stellarch = Empire faction leader when available; Emperor + wives are
+        // always generated (they never exist as world pawns) via SpawnStoryHuman.
+        Pawn highStellarch = this.GetFactionLeader(empire, 0);
+        RoyaltyEmperor.Party party = RoyaltyEmperor.Build(empire, highStellarch);
+        if (party.emperor == null || !party.regenMembers.Any())
         {
-            this.ScheduleRetry("Emperor unavailable", "The Empire's leader is unavailable for a CryoRegenesis stay. Retrying later.");
+            this.ScheduleRetry(
+                "Emperor party unavailable",
+                "Could not assemble the High Stellarch / Emperor CryoRegenesis party. Retrying later.");
             return;
         }
 
-        List<Pawn> party = new List<Pawn> { emperor };
-        long targetTicks = 20L * GenDate.TicksPerYear;
+        this.contractEscorts.Clear();
         int contractDays = MinContractDays;
-        this.PrepareClient(emperor, targetTicks, "emperor", empire, isPrisoner: false, contractDays: contractDays, triggerRoyalAscent: true);
-        party.AddRange(this.PrepareRomanticPartners(
-            emperor,
-            empire,
-            "imperial companion",
-            isPrisoner: false,
-            contractDays: contractDays));
+
+        foreach (RoyaltyEmperor.RegenMember member in party.regenMembers)
+        {
+            if (member?.pawn == null)
+            {
+                continue;
+            }
+
+            this.PrepareClient(
+                member.pawn,
+                member.desiredAgeTicks,
+                member.role,
+                empire,
+                isPrisoner: false,
+                contractDays: contractDays,
+                triggerRoyalAscent: member.triggerRoyalAscent);
+        }
+
+        foreach (Pawn escort in party.escorts)
+        {
+            if (escort == null)
+            {
+                continue;
+            }
+
+            // Guests only — no PrepareClient / no regen tracker.
+            this.ApplyGuestOrPrisonerStatus(escort, isPrisoner: false);
+            this.LockRecruitment(escort);
+            this.contractEscorts.Add(escort);
+        }
+
         contractDays = this.CalculateContractDays();
         this.SetActiveContractDeadlineDays(contractDays);
 
         this.activeContractStage = RoyaltyRegenesisStage.EmperorArrival;
         string returnText = this.FormatReturnDeadline(contractDays);
-        string letterBody =
-            $"The Emperor has arrived by shuttle for CryoRegenesis and will regress to age 20."
-            + RoyaltyRegenesisQuestPartners.CompanionArrivalText(party.Count - 1)
-            + $" Treat them by {returnText}. A pickup shuttle arrives when treatment is finished.";
+        string letterBody = party.BuildLetterBody(returnText);
         this.DeliverClientsByShuttle(
             map,
-            party,
+            party.AllArrivalPawns,
             empire,
-            "The Emperor has arrived",
+            "The High Stellarch and the Emperor have arrived",
             letterBody);
         this.BeginContractQuest(
             "CryoRegenesis: The Emperor",
@@ -840,6 +886,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.nextWavePickupTick = -1;
         this.clientsSuccessfullyReturned = 0;
         this.returnedClientPawnIds.Clear();
+        this.contractEscorts.Clear();
         this.ResetCompletionRewardState();
     }
 
@@ -1692,13 +1739,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         if (readyOnlyIfAnyReady && ready.Any())
         {
             // Only finished clients — Send works once they board; unfinished never block launch.
-            required = ready;
+            // Living escorts (guards) leave with the ready wave when possible.
+            required = ready.Concat(this.GetMapHeldEscorts()).Distinct().ToList();
         }
         else
         {
             // Nobody ready yet: keep full map-held list so the delivery ship cannot be
             // Sent away empty mid-contract.
-            required = this.GetMapHeldContractPawns();
+            required = this.GetMapHeldContractPawns().Concat(this.GetMapHeldEscorts()).Distinct().ToList();
         }
 
         // Drop stale/world/returned refs that would keep AllRequiredThingsLoaded false forever.
@@ -1871,6 +1919,20 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return transporter != null && transporter.innerContainer.Contains(pawn);
     }
 
+    /// Living non-regen escorts still on the map (Emperor-stage guards, etc.).
+    private List<Pawn> GetMapHeldEscorts()
+    {
+        if (this.contractEscorts == null || !this.contractEscorts.Any())
+        {
+            return new List<Pawn>();
+        }
+
+        return this.contractEscorts
+            .Where(p => p != null && !p.Destroyed && !p.Dead && this.IsClientAvailableOnMap(p))
+            .Distinct()
+            .ToList();
+    }
+
     /// Vanilla Royalty hospitality guests are temporary player-faction pawns whose
     /// original faction is retained by QuestPart_ExtraFaction. A guest tracker alone
     /// only creates an uncontrolled visitor, with no bed assignment or Operations UI.
@@ -1887,6 +1949,15 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         {
             Faction homeFaction = factionClients.Key;
             List<Pawn> pawns = factionClients.Select(client => client.pawn).Distinct().ToList();
+
+            // Escorts share the clients' home faction for this contract.
+            if (homeFaction != null)
+            {
+                pawns.AddRange(
+                    this.contractEscorts.Where(p =>
+                        p != null && !p.Destroyed && p.Faction == homeFaction));
+            }
+
             QuestPart_ExtraFaction extraFactionPart = this.activeContractQuest.PartsListForReading
                 .OfType<QuestPart_ExtraFaction>()
                 .FirstOrDefault(part =>
@@ -3520,7 +3591,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     {
         Find.LetterStack.ReceiveLetter(
             "Imperial CryoRegenesis complete",
-            "The Emperor has been restored to age 20. Royal Ascent endgame protocols are now being activated.",
+            "The Emperor has been restored to age 30. Royal Ascent endgame protocols are now being activated.",
             LetterDefOf.PositiveEvent);
 
         QuestScriptDef questDef = DefDatabase<QuestScriptDef>.GetNamedSilentFail("EndGame_RoyalAscent");

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -2759,9 +2759,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
                 if (p != null && !p.Destroyed)
                 {
+                    string clientLabel = RoyaltyRegenesisQuestFactory.FormatContractClientName(p, client.role);
                     Find.LetterStack.ReceiveLetter(
                         "Regenesis client ready",
-                        p.Name.ToStringShort + " has reached the contracted target age of "
+                        clientLabel + " has reached the contracted target age of "
                         + ((float)client.desiredAgeTicks / GenDate.TicksPerYear).ToString("0.#")
                         + ". Their part of the contract is fulfilled.",
                         LetterDefOf.PositiveEvent,
@@ -3138,7 +3139,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 ? " (" + tracker.GetContractProgressPercent().ToString("0") + "% there)"
                 : string.Empty;
 
-            sb.AppendLine("• " + pawn.Name.ToStringShort
+            sb.AppendLine(
+                "• " + RoyaltyRegenesisQuestFactory.FormatContractClientName(pawn, client.role)
                 + " — bio " + currentYears.ToString("0.00") + " → " + targetYears.ToString("0.00")
                 + percent
                 + (done ? " [ready]" : " [treating]")
@@ -3202,8 +3204,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             roleSummary,
             sender,
             isPrisoner,
-            returnByTick,
-            this.activeClients.Select(c => c.pawn));
+            returnByTick);
 
         this.activeContractQuest = RoyaltyRegenesisQuestFactory.MakeContractQuest(
             title,

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -2898,8 +2898,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 }
                 break;
             case RoyaltyRegenesisStage.StellarchArrival:
-                this.stage = RoyaltyRegenesisStage.EmperorNotice;
-                this.nextEventTick = Find.TickManager.TicksGame + Rand.RangeInclusive(30, 90) * GenDate.TicksPerDay;
+                // The restored Stellarch reports back the moment the shuttle departs — no waiting
+                // period before word reaches the Emperor. Only the interstellar travel itself takes time.
+                int emperorTravelYears = Rand.RangeInclusive(1, 10);
+                this.SendTravelNotice(
+                    "The Emperor is coming",
+                    $"The restored Stellarch's report has reached the Emperor. The imperial household has committed to the journey, but interstellar travel will take {emperorTravelYears} year(s).");
+                this.stage = RoyaltyRegenesisStage.EmperorArrival;
+                this.nextEventTick = Find.TickManager.TicksGame + emperorTravelYears * GenDate.TicksPerYear;
                 break;
         }
 


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a multi-stage royal contract questline with visiting nobles, companions, pickup shuttles, deadlines, and progress tracking.
  * Added contract-based age regression targets, completion handling, and visible progress details.
  * Added Imperial Rejuvenation arrivals featuring nobles, spouses, and guards.
  * Added completion rewards, including luciferium, uranium, and bonus items.
  * Added clearer quest descriptions, client names, titles, dates, and arrival messaging.

* **Bug Fixes**
  * Restricted shuttle boarding to approved contract participants.
  * Prevented active contract participants from being ejected or recruited prematurely.
  * Improved handling of partial shuttle departures, follow-up pickups, and missed deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add the final Imperial CryoRegenesis party and dispatch it without delay

### What Changed
- The finale now brings the High Stellarch, Emperor, 1–4 wives for each ruler, and four Stellic guards to the colony.
- The Stellarch and Emperor regress to age 30, wives regress to age 20, and guards accompany the party without treatment.
- Contract lists, progress displays, and ready letters now show royal titles and wife roles.
- The restored Stellarch reports immediately, starting the Emperor’s journey without an extra waiting period.
- Royal Ascent becomes available after the Emperor reaches age 30, and guards leave with the returning party.

### Impact
`✅ Complete imperial household finale`
`✅ Immediate Emperor dispatch after Stellarch restoration`
`✅ Clearer royal roles in contract progress`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
