### PR TITLE
Regen Quests Emperor Endings: Court victory, usurpation, and death End Games for the Emperor stage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-27 16:34:16 EEST]** [Quests] Prune dead guests from the evacuation manifest in Assassin end game (found by OpenAI Codex).
 * **[2026-07-27 15:25:00 EEST]** [Quests] Hunted Assassin mark now jumps to any Knight+ who kills the Marked One.
 * **[2026-07-27 15:00:10 EEST]** [Quests] Added the Emperor "Keep What You Kill" assassination endgame.
 * **[2026-07-23 11:33:33 EEST]** Fixed simple prosthetics remaining after regeneration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-27 15:25:00 EEST]** [Quests] Hunted Assassin mark now jumps to any Knight+ who kills the Marked One.
 * **[2026-07-27 15:00:10 EEST]** [Quests] Added the Emperor "Keep What You Kill" assassination endgame.
 * **[2026-07-23 11:33:33 EEST]** Fixed simple prosthetics remaining after regeneration.
 * **[2026-07-19 09:12:20 CDT]** Repositioned the True Age to the right.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-27 15:00:10 EEST]** [Quests] Added the Emperor "Keep What You Kill" assassination endgame.
 * **[2026-07-23 11:33:33 EEST]** Fixed simple prosthetics remaining after regeneration.
 * **[2026-07-19 09:12:20 CDT]** Repositioned the True Age to the right.
 * **[2026-07-18 14:11:59 CDT]** Body positivity thoughts now stack and scale duration from lifetime True Age years erased.

--- a/CryoRegenesis/Defs/Hediffs/HuntedAssassin.xml
+++ b/CryoRegenesis/Defs/Hediffs/HuntedAssassin.xml
@@ -8,7 +8,7 @@
   <HediffDef>
     <defName>HuntedAssassin</defName>
     <label>hunted assassin</label>
-    <description>Subspace tracker nanites implanted by the Empire under its "Keep What You Kill" succession law — a mark like the old Runner contracts: wherever the bearer goes, hunters will know. The body treats the nanites as an infection and clears them over about sixty days. Survive that hunt, and Imperial custom recognizes the claim on the throne.</description>
+    <description>Subspace tracker nanites implanted by the Empire under its "Keep What You Kill" succession law — a mark like the old Runner contracts: wherever the bearer goes, hunters will know. The body treats the nanites as an infection and clears them over about sixty days. Survive that hunt, and Imperial custom recognizes the claim on the throne.\n\nIf a noble of knight rank or higher kills the Marked One, the nanites leap to the killer and begin a fresh sixty-day countdown — a succession crisis in miniature. You keep what you kill; you do not keep their leftover time.</description>
     <hediffClass>HediffWithComps</hediffClass>
     <isBad>false</isBad>
     <displayWound>false</displayWound>

--- a/CryoRegenesis/Defs/Hediffs/HuntedAssassin.xml
+++ b/CryoRegenesis/Defs/Hediffs/HuntedAssassin.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <!--
+    Flavor: Stargate SG-1 Runners (marked prey, galaxy-wide hunt) + the Necromonger
+    Way from the Riddick universe ("You keep what you kill"). Planned for a later
+    Stargate DLC split; lives here for the Emperor assassination endgame.
+  -->
+  <HediffDef>
+    <defName>HuntedAssassin</defName>
+    <label>hunted assassin</label>
+    <description>Subspace tracker nanites implanted by the Empire under its "Keep What You Kill" succession law — a mark like the old Runner contracts: wherever the bearer goes, hunters will know. The body treats the nanites as an infection and clears them over about sixty days. Survive that hunt, and Imperial custom recognizes the claim on the throne.</description>
+    <hediffClass>HediffWithComps</hediffClass>
+    <isBad>false</isBad>
+    <displayWound>false</displayWound>
+    <makesSickThought>false</makesSickThought>
+    <everCurableByItem>false</everCurableByItem>
+    <tendable>false</tendable>
+    <defaultLabelColor>(0.72, 0.28, 0.82)</defaultLabelColor>
+    <lethalSeverity>-1</lethalSeverity>
+    <comps>
+      <!-- 60 days (GenDate.TicksPerDay * 60). Clears like an immune response, not a permanent implant. -->
+      <li Class="HediffCompProperties_Disappears">
+        <disappearsAfterTicks>3600000</disappearsAfterTicks>
+        <showRemainingTime>true</showRemainingTime>
+      </li>
+    </comps>
+  </HediffDef>
+</Defs>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ![CryoRegenesis: Live forever!](https://raw.githubusercontent.com/BetterRimworlds/CryoRegenesis/master/CryoRegenesis/About/Preview.png)
 
-With this Glittertech, all of your colonists (and pets, and even enemies, if you're so
-inclined!) can live forever young!
+With this Glittertech, all of your colonists (and pets, and even enemies, if you're so inclined!) can live forever young!
 
-CryoRegenesis sarcophagi not only restore your pawns to their youthful vigor, they also
-cure all age-related infirmities as well as every physical injury!
+CryoRegenesis sarcophagi not only restore your pawns to their youthful vigor, they also cure all age-related infirmities as
+well as every physical injury!
 
  * No more aging. Everyone can be in their 20s!
  * Heals bad backs, permanent scars, even dementia, Alzheimer's and bullets to the brain!
@@ -17,20 +16,24 @@ cure all age-related infirmities as well as every physical injury!
 
 ## Inspiration: The Goa'uld Sarcophagus
 
-CryoRegenesis is a RimWorld port of the **Goa'uld sarcophagus** from *Stargate* (the motion picture) and *Stargate SG-1*. In the show, those devices rapidly heal injuries, reverse aging, extend life, and can even resurrect the recently dead — at a steep psychological and addictive cost. The Tok'ra refuse to use them for that reason.
+CryoRegenesis is a RimWorld port of the **Goa'uld sarcophagus** from *Stargate* (the motion picture) and *Stargate SG-1*. In
+the show, those devices rapidly heal injuries, reverse aging, extend life, and can even resurrect the recently dead — at a
+steep psychological and addictive cost. The Tok'ra refuse to use them for that reason.
 
-This mod maps that artifact onto RimWorld's systems: cryptosleep chassis, glittertech nanites, and **Luciferium** as the Faustian price of coming back from the dead (the body only keeps working if the mechanites keep flowing).
+This mod maps that artifact onto RimWorld's systems: cryptosleep chassis, glittertech nanites, and **Luciferium** as the
+Faustian price of coming back from the dead (the body only keeps working if the mechanites keep flowing).
 
 | Goa'uld sarcophagus | CryoRegenesis |
 |---|---|
 | Heals injury and disease | Heals hediffs, old-age failures, and wounds |
 | Extends life / reverses aging | De-ages pawns (and animals) to youthful prime |
-| Resurrects the recently dead | Resurrects if the brain is intact and the corpse has been unrefrigerated for less than 1 day |
+| Resurrects the recently dead | Brain intact; corpse unrefrigerated under 1 day |
 | Narcotic / addictive side effects | Permanent Luciferium addiction on resurrection |
 | Tok'ra refuse it because it "takes the soul" | Expensive glittertech with a lasting cost, not free immortality |
 | Body restored, mind altered | Mood highs and "Grateful to be alive!" after revival |
 
-Part of the [Better Rimworlds](https://github.com/BetterRimworlds) collection — Stargate-inspired tech for multi-century hub-world colonies.
+Part of the [Better Rimworlds](https://github.com/BetterRimworlds) collection — Stargate-inspired tech for multi-century
+hub-world colonies.
 
 ## Supported RimWorld Versions
 
@@ -49,8 +52,8 @@ Stock up on Uranium. You'll need a whole lot of it!
 
 ![Cargo](https://github.com/BetterRimworlds/CryoRegenesis/assets/1125541/e76d8ca0-2616-44d6-9f7e-f89fa014a633)
 
-Here's our illustrious pup, Cargo! He's been with the colonists 101 years and is 107 years old! He's lived
-on more Rimworlds than most humans!
+Here's our illustrious pup, Cargo! He's been with the colonists 101 years and is 107 years old! He's lived on more Rimworlds
+than most humans!
 
 ## Resurrection Costs and Consequences
 
@@ -61,7 +64,8 @@ Bringing someone back from the dead requires significant resources:
 - **50 Luciferium** - The mechanites are required to jumpstart cellular regeneration
 
 **The Price of Resurrection:**
-- All resurrected pawns will gain a **permanent Luciferium addiction**. Death is not without consequence - the mechanites that bring them back require continued doses to maintain cellular cohesion.
+- All resurrected pawns will gain a **permanent Luciferium addiction**. Death is not without consequence - the mechanites
+  that bring them back require continued doses to maintain cellular cohesion.
 - This addiction cannot be cured by the sarcophagus (as noted in features above).
 
 ## New Mood Effects
@@ -88,7 +92,32 @@ Bringing someone back from the dead requires significant resources:
 - Strong rejuvenation can make some prisoners recruitable again
 
 ### Balance Notes
-The combination of resource costs and permanent Luciferium addiction ensures resurrection remains a serious decision rather than a casual convenience. Plan accordingly and maintain a steady Luciferium supply for your immortal colonists!
+The combination of resource costs and permanent Luciferium addiction ensures resurrection remains a serious decision rather
+than a casual convenience. Plan accordingly and maintain a steady Luciferium supply for your immortal colonists!
+
+## Imperial Regeneration Quests (Royalty)
+
+With the Royalty DLC, word of your CryoRegenesis quickly spreads as rumor across the galaxy! Planetary rulers and, in time,
+the Empire itself may send clients by shuttle under fixed return contracts: regress them to the contracted age, keep them
+breathing, and **do not recruit them**.
+
+Load finished clients onto pickup shuttles when they hit target age and send them home. Complete enough contracts and the
+chain escalates — lower nobility, the Stellarch, and eventually the highest seats of Imperial power.
+
+Death or recruitment under contract shatters trust: progress resets, and patrons will stay away for a long time. Honor the
+bargain and the Empire may eventually open paths that most colonies never see.
+
+### Endings
+
+Fulfilling the Imperial chain can unlock a true endgame path off this planet — the Empire does not forget those who keep its
+elite Forever Young. How (and whether) that ending plays out depends on the choices you make when the shuttles arrive and
+leave.
+
+This entire quest system will take years and years; decades, even. The nobles will have to travel at relativistic speeds
+that reach into years, for instance.
+
+There are also… other ways the story can close. We will not spoil them here. RimWorld rewards curiosity, ambition, and the
+occasional terrible idea. The caskets keep secrets. So do we.
 
 ## Changelog
 

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -113,6 +113,10 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
     private bool IsDisconnectedFromPowerGrid => power?.PowerNet == null;
     private bool IsPowerUnavailable => power == null || !power.PowerOn || IsDisconnectedFromPowerGrid;
 
+    /// True when the pod is acting as a normal cryptosleep casket (flicked off, unpowered,
+    /// or disconnected) rather than an active CryoRegenesis chamber.
+    public bool IsUnpoweredCryptosleepMode => this.IsPowerUnavailable;
+
     public override void SpawnSetup(Map map, bool respawningAfterLoad)
     {
         base.SpawnSetup(map, respawningAfterLoad);

--- a/Source/HuntedAssassinDefOf.cs
+++ b/Source/HuntedAssassinDefOf.cs
@@ -1,0 +1,24 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+[DefOf]
+public static class HuntedAssassinDefOf
+{
+    public static HediffDef HuntedAssassin;
+
+    static HuntedAssassinDefOf()
+    {
+        DefOfHelper.EnsureInitializedInCtor(typeof(HuntedAssassinDefOf));
+    }
+}

--- a/Source/HuntedAssassinUtility.cs
+++ b/Source/HuntedAssassinUtility.cs
@@ -132,12 +132,6 @@ public static class HuntedAssassinUtility
             return false;
         }
 
-        // Already carrying the mark — no second stack; still count as inheritance for succession.
-        if (HasMark(killer))
-        {
-            return false;
-        }
-
         // Fresh sixty days for every new host — each kill restarts the crisis, not the leftover clock.
         ApplyMark(killer, freshCountdown: true);
 

--- a/Source/HuntedAssassinUtility.cs
+++ b/Source/HuntedAssassinUtility.cs
@@ -1,0 +1,166 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Hunted Assassin mark helpers: apply, query, and Don't-Kill-It inheritance.
+/// When a Knight or higher kills the Marked One, the tracker nanites jump to the killer.
+public static class HuntedAssassinUtility
+{
+    /// 60 days — must match HuntedAssassin.xml disappearsAfterTicks.
+    public const int DefaultMarkTicks = 60 * GenDate.TicksPerDay;
+
+    public static HediffDef MarkDef =>
+        HuntedAssassinDefOf.HuntedAssassin
+        ?? DefDatabase<HediffDef>.GetNamedSilentFail("HuntedAssassin");
+
+    public static bool HasMark(Pawn pawn)
+    {
+        HediffDef def = MarkDef;
+        return def != null
+            && pawn?.health?.hediffSet != null
+            && pawn.health.hediffSet.HasHediff(def);
+    }
+
+    /// Empire royal title of Knight / Dame or higher (any faction member, not only colonists).
+    public static bool IsEmpireKnightOrHigher(Pawn pawn)
+    {
+        if (pawn?.royalty == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        Faction empire = EmpireFactionOrNull();
+        RoyalTitleDef knight = DefDatabase<RoyalTitleDef>.GetNamedSilentFail("Knight");
+        if (empire == null || knight == null)
+        {
+            return false;
+        }
+
+        RoyalTitleDef title = pawn.royalty.GetCurrentTitle(empire);
+        return title != null && title.seniority >= knight.seniority;
+    }
+
+    private static Faction EmpireFactionOrNull()
+    {
+        FactionDef empireDef = DefDatabase<FactionDef>.GetNamedSilentFail("Empire");
+        if (empireDef == null || Find.FactionManager == null)
+        {
+            return null;
+        }
+
+        return Find.FactionManager.FirstFactionOfDef(empireDef);
+    }
+
+    public static int? GetRemainingMarkTicks(Pawn pawn)
+    {
+        HediffDef def = MarkDef;
+        if (def == null || pawn?.health?.hediffSet == null)
+        {
+            return null;
+        }
+
+        Hediff hediff = pawn.health.hediffSet.GetFirstHediffOfDef(def);
+        HediffComp_Disappears disappears = hediff?.TryGetComp<HediffComp_Disappears>();
+        if (disappears == null)
+        {
+            return null;
+        }
+
+        return disappears.ticksToDisappear;
+    }
+
+    /// Implant the mark. When <paramref name="freshCountdown"/> is true (inheritance),
+    /// the host always gets a full sixty-day clock — each new claimant restarts the hunt.
+    public static void ApplyMark(Pawn pawn, bool freshCountdown = false)
+    {
+        if (pawn?.health?.hediffSet == null || pawn.Dead || pawn.Destroyed)
+        {
+            return;
+        }
+
+        HediffDef def = MarkDef;
+        if (def == null)
+        {
+            Log.Warning("[CryoRegenesis] HuntedAssassin HediffDef not found.");
+            return;
+        }
+
+        Hediff existing = pawn.health.hediffSet.GetFirstHediffOfDef(def);
+        if (existing == null)
+        {
+            existing = pawn.health.AddHediff(def);
+        }
+
+        if (freshCountdown && existing != null)
+        {
+            HediffComp_Disappears disappears = existing.TryGetComp<HediffComp_Disappears>();
+            if (disappears != null)
+            {
+                disappears.ticksToDisappear = DefaultMarkTicks;
+            }
+        }
+    }
+
+    /// Don't Kill It + Year of the Four Emperors: kill the Marked One while Knight+,
+    /// inherit the nanites, and start a fresh sixty-day succession crisis clock.
+    /// Returns true when the mark jumped to the killer.
+    public static bool TryInheritFromKill(Pawn victim, Pawn killer)
+    {
+        if (victim == null || killer == null || killer == victim)
+        {
+            return false;
+        }
+
+        if (killer.Destroyed || killer.Dead)
+        {
+            return false;
+        }
+
+        if (!HasMark(victim) || !IsEmpireKnightOrHigher(killer))
+        {
+            return false;
+        }
+
+        // Already carrying the mark — no second stack; still count as inheritance for succession.
+        if (HasMark(killer))
+        {
+            return false;
+        }
+
+        // Fresh sixty days for every new host — each kill restarts the crisis, not the leftover clock.
+        ApplyMark(killer, freshCountdown: true);
+
+        Log.Message(
+            "[CryoRegenesis] HuntedAssassin mark inherited: "
+            + (victim.Name?.ToStringShort ?? victim.LabelShort)
+            + " → "
+            + (killer.Name?.ToStringShort ?? killer.LabelShort)
+            + " (fresh " + DefaultMarkTicks + " ticks).");
+
+        string victimName = victim.Name?.ToStringShort ?? victim.LabelShort;
+        string killerName = killer.Name?.ToStringShort ?? killer.LabelShort;
+        Find.LetterStack.ReceiveLetter(
+            "Keep What You Kill",
+            killerName + " has slain the Marked One (" + victimName + ").\n\n"
+            + "The Hunted Assassin subspace trackers leapt to their new host — "
+            + "as with every such mark, you keep what you kill.\n\n"
+            + "A fresh sixty-day hunt begins. Like Rome in crisis: each new claimant "
+            + "does not inherit the old countdown — they start their own race for the throne.",
+            LetterDefOf.ThreatSmall,
+            new LookTargets(killer));
+
+        RoyaltyRegenesisQuestSystem.CurrentSystem?.NotifyHuntedAssassinInherited(victim, killer);
+        return true;
+    }
+}

--- a/Source/Quests/Patch_CompShuttle_IsAllowed.cs
+++ b/Source/Quests/Patch_CompShuttle_IsAllowed.cs
@@ -20,25 +20,44 @@ namespace BetterRimworlds.CryoRegenesis;
 /// During the Emperor contract any number of colonists may leave, but only while the
 /// Imperial shuttle is open to them — the Emperor alive and aboard (or sealed in a
 /// powered-off casket) and the rest of the party finished.
+/// Assassination evacuation opens the door to free colonists and colony pets.
 [HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.IsAllowed))]
 internal static class Patch_CompShuttle_IsAllowed
 {
     [HarmonyPostfix]
     private static void Postfix(CompShuttle __instance, Thing t, ref bool __result)
     {
-        if (!__result || __instance?.parent == null)
+        if (__instance?.parent == null)
         {
             return;
         }
 
         Pawn pawn = t as Pawn;
-        if (pawn == null || !pawn.IsColonist)
+        if (pawn == null)
         {
             return;
         }
 
         RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
         if (system == null || !system.IsRegenPickupShuttle(__instance.parent))
+        {
+            return;
+        }
+
+        // Keep What You Kill assassination: assassin, free colonists, and pets may board.
+        if (system.IsEmperorAssassinationEvacuationActive()
+            && system.MayBoardAssassinationEvacuationShuttle(pawn))
+        {
+            __result = true;
+            return;
+        }
+
+        if (!__result)
+        {
+            return;
+        }
+
+        if (!pawn.IsColonist)
         {
             return;
         }

--- a/Source/Quests/Patch_CompShuttle_IsAllowed.cs
+++ b/Source/Quests/Patch_CompShuttle_IsAllowed.cs
@@ -16,7 +16,9 @@ namespace BetterRimworlds.CryoRegenesis;
 /// Regen pickup shuttles set acceptColonists so temporary player-faction guest
 /// clients can embark. That also lets every free colonist board — which would
 /// let unrelated colonists leave with the nobility. Restrict free colonists to
-/// non-ex DirectRelations of active regen clients (and the clients themselves).
+/// non-ex DirectRelations of active regen clients (and the clients themselves),
+/// except during the Emperor contract where any free colonist may leave with him
+/// (Imperial Court endgame).
 [HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.IsAllowed))]
 internal static class Patch_CompShuttle_IsAllowed
 {
@@ -40,7 +42,7 @@ internal static class Patch_CompShuttle_IsAllowed
             return;
         }
 
-        // requiredPawns / active clients always board; unrelated free colonists do not.
+        // requiredPawns / allowed companions (incl. any free colonist on Emperor pickup).
         if (__instance.IsRequired(t) || RoyaltyRegenesisQuestSystem.MayBoardRegenPickupShuttle(pawn))
         {
             return;

--- a/Source/Quests/Patch_CompShuttle_IsAllowed.cs
+++ b/Source/Quests/Patch_CompShuttle_IsAllowed.cs
@@ -16,9 +16,10 @@ namespace BetterRimworlds.CryoRegenesis;
 /// Regen pickup shuttles set acceptColonists so temporary player-faction guest
 /// clients can embark. That also lets every free colonist board — which would
 /// let unrelated colonists leave with the nobility. Restrict free colonists to
-/// non-ex DirectRelations of active regen clients (and the clients themselves),
-/// except during the Emperor contract where any free colonist may leave with him
-/// (Imperial Court endgame).
+/// non-ex DirectRelations of active regen clients (and the clients themselves).
+/// During the Emperor contract any number of colonists may leave, but only while the
+/// Imperial shuttle is open to them — the Emperor alive and aboard and the rest of the
+/// party finished.
 [HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.IsAllowed))]
 internal static class Patch_CompShuttle_IsAllowed
 {

--- a/Source/Quests/Patch_CompShuttle_IsAllowed.cs
+++ b/Source/Quests/Patch_CompShuttle_IsAllowed.cs
@@ -18,8 +18,8 @@ namespace BetterRimworlds.CryoRegenesis;
 /// let unrelated colonists leave with the nobility. Restrict free colonists to
 /// non-ex DirectRelations of active regen clients (and the clients themselves).
 /// During the Emperor contract any number of colonists may leave, but only while the
-/// Imperial shuttle is open to them — the Emperor alive and aboard and the rest of the
-/// party finished.
+/// Imperial shuttle is open to them — the Emperor alive and aboard (or sealed in a
+/// powered-off casket) and the rest of the party finished.
 [HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.IsAllowed))]
 internal static class Patch_CompShuttle_IsAllowed
 {

--- a/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
+++ b/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// When a regen pickup launches, free colonists are still in the transporter.
+/// Snapshot them here so the Imperial Court endgame still fires if they boarded
+/// and the ship left in the same tick as the last GameComponent refresh.
+[HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.SendLaunchedSignals))]
+internal static class Patch_CompShuttle_SendLaunchedSignals
+{
+    [HarmonyPrefix]
+    private static void Prefix(CompShuttle __instance)
+    {
+        if (__instance?.parent == null)
+        {
+            return;
+        }
+
+        RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+        if (system == null || !system.IsRegenPickupShuttle(__instance.parent))
+        {
+            return;
+        }
+
+        if (!system.IsEmperorRegenContractActive())
+        {
+            return;
+        }
+
+        system.NotifyEmperorPickupLaunching(__instance);
+    }
+}

--- a/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
+++ b/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
@@ -33,7 +33,8 @@ internal static class Patch_CompShuttle_SendLaunchedSignals
             return;
         }
 
-        if (!system.IsEmperorRegenContractActive())
+        if (!system.IsEmperorRegenContractActive()
+            && !system.IsEmperorAssassinationEvacuationActive())
         {
             return;
         }

--- a/Source/Quests/Patch_Pawn_Kill_EmperorAssassin.cs
+++ b/Source/Quests/Patch_Pawn_Kill_EmperorAssassin.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Capture the Emperor's killer from DamageInfo.Instigator while Kill still has it.
+/// GameComponent death handling runs later, after the DamageInfo is gone.
+[HarmonyPatch(typeof(Pawn), nameof(Pawn.Kill))]
+internal static class Patch_Pawn_Kill_EmperorAssassin
+{
+    [HarmonyPrefix]
+    private static void Prefix(Pawn __instance, DamageInfo? dinfo)
+    {
+        if (__instance == null || __instance.Dead)
+        {
+            return;
+        }
+
+        RoyaltyRegenesisQuestSystem system = RoyaltyRegenesisQuestSystem.CurrentSystem;
+        if (system == null || !system.IsEmperorRegenContractActive())
+        {
+            return;
+        }
+
+        if (!system.IsEmperorContractPawn(__instance))
+        {
+            return;
+        }
+
+        Pawn killer = dinfo?.Instigator as Pawn;
+        system.NotifyEmperorKillInstigator(killer);
+    }
+}

--- a/Source/Quests/Patch_Pawn_Kill_HuntedAssassin.cs
+++ b/Source/Quests/Patch_Pawn_Kill_HuntedAssassin.cs
@@ -1,0 +1,42 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using HarmonyLib;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Don't Kill It (2016): kill the Marked One and the mark jumps to a worthy host.
+/// Any Empire Knight (or higher) who lands the killing blow inherits HuntedAssassin
+/// while the victim is still alive enough for DamageInfo / hediff readout.
+[HarmonyPatch(typeof(Pawn), nameof(Pawn.Kill))]
+internal static class Patch_Pawn_Kill_HuntedAssassin
+{
+    [HarmonyPrefix]
+    private static void Prefix(Pawn __instance, DamageInfo? dinfo)
+    {
+        if (__instance == null || __instance.Dead)
+        {
+            return;
+        }
+
+        if (!HuntedAssassinUtility.HasMark(__instance))
+        {
+            return;
+        }
+
+        Pawn killer = dinfo?.Instigator as Pawn;
+        if (killer == null)
+        {
+            return;
+        }
+
+        HuntedAssassinUtility.TryInheritFromKill(__instance, killer);
+    }
+}

--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -158,9 +158,9 @@ public static class RoyaltyEmperor
         });
 
         // --- Wives (1–4 each for Stellarch and Emperor) ---
-        party.wifeCountEmperor = AddWives(party, stellarch, empire, "imperial wife");
+        party.wifeCountEmperor = AddWives(party, emperor, empire, "imperial wife");
         party.wifeCount += party.wifeCountEmperor;
-        party.wifeCount += AddWives(party, emperor, empire, "stellarch wife");
+        party.wifeCount += AddWives(party, stellarch, empire, "stellarch wife");
 
         // --- Security guards (no regen contracts) ---
         AddGuards(party, empire);

--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -92,7 +92,9 @@ public static class RoyaltyEmperor
             }
 
             sb.Append($"Treat the contracted guests by {returnDeadlineText}. ");
-            sb.Append("A pickup shuttle arrives when treatment is finished.");
+            sb.Append("A pickup shuttle arrives when treatment is finished. ");
+            sb.Append("Any colonist may board that shuttle with the Emperor — ");
+            sb.Append("if even one colonist leaves with him, your story ends in victory as guests of the Imperial court.");
             return sb.ToString();
         }
     }

--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -55,6 +55,7 @@ public static class RoyaltyEmperor
         public Pawn highStellarch;
         public Pawn emperor;
         public int wifeCount;
+        public int wifeCountEmperor;
         public int guardCount;
 
         /// Every pawn that arrives on the delivery shuttle (regen + escorts).
@@ -94,7 +95,8 @@ public static class RoyaltyEmperor
             sb.Append($"Treat the contracted guests by {returnDeadlineText}. ");
             sb.Append("A pickup shuttle arrives when treatment is finished. ");
             sb.Append("Any number of your colonists may board that shuttle once the Emperor is alive and aboard it ");
-            sb.Append("himself and every other guest is offworld or aboard at their target age. ");
+            sb.Append("himself (or sealed in a powered-off CryoRegenesis casket) and every other guest is offworld or ");
+            sb.Append("aboard at their target age. ");
             sb.Append("If even one colonist leaves with the Emperor, your story ends in victory as guests of the ");
             sb.Append("Imperial court.");
             return sb.ToString();
@@ -156,8 +158,9 @@ public static class RoyaltyEmperor
         });
 
         // --- Wives (1–4 each for Stellarch and Emperor) ---
-        party.wifeCount += AddWives(party, stellarch, empire, "stellarch wife");
-        party.wifeCount += AddWives(party, emperor, empire, "imperial wife");
+        party.wifeCountEmperor = AddWives(party, stellarch, empire, "imperial wife");
+        party.wifeCount += party.wifeCountEmperor;
+        party.wifeCount += AddWives(party, emperor, empire, "stellarch wife");
 
         // --- Security guards (no regen contracts) ---
         AddGuards(party, empire);

--- a/Source/Quests/RoyaltyEmperor.cs
+++ b/Source/Quests/RoyaltyEmperor.cs
@@ -83,7 +83,7 @@ public static class RoyaltyEmperor
             sb.Append($"Both will regress to age {LeaderTargetAgeYears}. ");
             if (this.wifeCount > 0)
             {
-                sb.Append($"They brought {this.wifeCount} wife/wives, each to regress to age {WifeTargetAgeYears}. ");
+                sb.Append($"They brought {this.wifeCount} {(this.wifeCount == 1 ? "wife" : "wives")} for CryoRegenesis, too. ");
             }
 
             if (this.guardCount > 0)
@@ -93,8 +93,10 @@ public static class RoyaltyEmperor
 
             sb.Append($"Treat the contracted guests by {returnDeadlineText}. ");
             sb.Append("A pickup shuttle arrives when treatment is finished. ");
-            sb.Append("Any colonist may board that shuttle with the Emperor — ");
-            sb.Append("if even one colonist leaves with him, your story ends in victory as guests of the Imperial court.");
+            sb.Append("Any number of your colonists may board that shuttle once the Emperor is alive and aboard it ");
+            sb.Append("himself and every other guest is offworld or aboard at their target age. ");
+            sb.Append("If even one colonist leaves with the Emperor, your story ends in victory as guests of the ");
+            sb.Append("Imperial court.");
             return sb.ToString();
         }
     }

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -1420,8 +1420,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         // destroy boarding passengers) — except Emperor murder, which arms a Planetkiller.
         if (this.activeClients.Any(client => client.pawn != null && client.pawn.Dead))
         {
-            RoyaltyRegenesisClient deadClient = this.activeClients
-                .First(client => client.pawn != null && client.pawn.Dead);
+            // Prefer the Emperor when any dead client is him. First(Dead) alone can pick a
+            // wife who died in the same check window and permanently skip the Emperor
+            // death endgame (assassination / Planetkiller).
+            RoyaltyRegenesisClient deadClient =
+                this.activeClients.FirstOrDefault(client =>
+                    client.pawn != null && client.pawn.Dead && client.pawn == this.emperor)
+                ?? this.activeClients.First(client => client.pawn != null && client.pawn.Dead);
             Pawn dead = deadClient.pawn;
             Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction
                 ?? deadClient.sourceFaction;
@@ -2907,7 +2912,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             $"{title} {countName} forged an alliance with the Emperor's {(wifeCount == 1 ? "wife" : "wives")}. "
             + "In the proud tradition of The Empire: \"You Keep What You Kill\": "
             + $"Now {countName} is seen across The Empire as its latest Emperor.\n\n"
-            + "The desposed emperor sleeps in a dark cryptosleep casket in a secret base "
+            + "The deposed emperor sleeps in a dark cryptosleep casket in a secret base "
             + "long abandoned. No rescue will ever come.\n\n"
             + "The choice — and the throne — is yours.";
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -485,6 +485,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_References.Look(ref this.emperorAssassin, "crRoyalEmperorAssassin");
         Scribe_Values.Look(ref this.emperorAssassinLabel, "crRoyalEmperorAssassinLabel");
         Scribe_Values.Look(ref this.emperorAssassinationEvacuationActive, "crRoyalEmperorAssassinationEvac", false);
+        Scribe_References.Look(ref this.pendingEmperorKiller, "crRoyalPendingEmperorKiller");
 #if !RIMWORLD12
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
@@ -2936,7 +2937,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (Find.StoryWatcher?.statsRecord != null)
         {
-            int launched = 1 + (this.emperorShuttleColonistEscapeeLabels?.Count ?? 0);
+            int launched = (this.emperorShuttleColonistEscapeeLabels?.Count ?? 0);
             Find.StoryWatcher.statsRecord.colonistsLaunched += Math.Max(1, launched);
         }
 

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -3053,23 +3053,54 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return this.IsKnightOrHigherColonist(killer) ? killer : null;
     }
 
-    /// Empire title of knight or higher (seniority >= Knight). Dame uses the same defName.
+    /// Free colonist with Empire title of knight or higher (Dame uses the same defName).
     private bool IsKnightOrHigherColonist(Pawn pawn)
     {
-        if (!this.IsFreeColonyColonistForEmperorEndgame(pawn) || pawn.royalty == null)
+        return this.IsFreeColonyColonistForEmperorEndgame(pawn)
+            && HuntedAssassinUtility.IsEmpireKnightOrHigher(pawn);
+    }
+
+    /// Don't Kill It: the Hunted Assassin mark jumped to a new Knight+ host. If that was
+    /// our evacuation assassin, the new bearer inherits the claim and the shuttle seat.
+    public void NotifyHuntedAssassinInherited(Pawn previousBearer, Pawn heir)
+    {
+        if (heir == null || heir.Destroyed || heir.Dead || !this.emperorAssassinationEvacuationActive)
         {
-            return false;
+            return;
         }
 
-        Faction empire = this.EmpireFaction();
-        RoyalTitleDef knight = DefDatabase<RoyalTitleDef>.GetNamedSilentFail("Knight");
-        if (empire == null || knight == null)
+        // Only rebind when the dead marked pawn was (or still is recorded as) our assassin.
+        bool previousWasAssassin = previousBearer == this.emperorAssassin
+            || (this.emperorAssassin == null
+                && previousBearer != null
+                && !this.emperorAssassinLabel.NullOrEmpty()
+                && (string.Equals(
+                        previousBearer.Name?.ToStringFull,
+                        this.emperorAssassinLabel,
+                        StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(
+                        previousBearer.LabelCap,
+                        this.emperorAssassinLabel,
+                        StringComparison.OrdinalIgnoreCase)));
+
+        if (!previousWasAssassin)
         {
-            return false;
+            return;
         }
 
-        RoyalTitleDef title = pawn.royalty.GetCurrentTitle(empire);
-        return title != null && title.seniority >= knight.seniority;
+        this.emperorAssassin = heir;
+        this.emperorAssassinLabel = heir.Name?.ToStringFull
+            ?? heir.Name?.ToStringShort
+            ?? heir.LabelShort;
+        this.LogRoyaltyDebug(
+            "Assassination succession: HuntedAssassin mark inherited by "
+            + this.emperorAssassinLabel + " — shuttle seat reassigned.");
+
+        Map map = heir.MapHeld ?? this.GetTargetMap();
+        if (map != null)
+        {
+            this.EnsureAssassinationShuttleRequirements(map, heir);
+        }
     }
 
     private static string EmpireTitleLabelFor(Pawn pawn, Faction empire)
@@ -3151,23 +3182,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
     private void ApplyHuntedAssassinHediff(Pawn assassin)
     {
-        if (assassin?.health?.hediffSet == null)
-        {
-            return;
-        }
-
-        HediffDef def = HuntedAssassinDefOf.HuntedAssassin
-            ?? DefDatabase<HediffDef>.GetNamedSilentFail("HuntedAssassin");
-        if (def == null)
-        {
-            Log.Warning("[CryoRegenesis] HuntedAssassin HediffDef not found.");
-            return;
-        }
-
-        if (!assassin.health.hediffSet.HasHediff(def))
-        {
-            assassin.health.AddHediff(def);
-        }
+        HuntedAssassinUtility.ApplyMark(assassin);
     }
 
     private void ShowKeepWhatYouKillAssassinationDialog(Pawn assassin, Faction empire)

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -105,6 +105,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// thingIDNumber of pawns that already returned successfully — never re-board or re-spawn them.
     private List<int> returnedClientPawnIds = new List<int>();
 
+    /// Labels of free colony colonists last seen aboard the Emperor-stage pickup shuttle.
+    /// Snapshotted every tick while the ship is parked so departure (which destroys
+    /// container contents) can still fire the Imperial Court endgame.
+    private List<string> emperorShuttleColonistEscapeeLabels = new List<string>();
+
+    /// True once the Imperial Court endgame countdown has been started for this run.
+    private bool emperorColonistEndgameTriggered;
+
     public RoyaltyRegenesisQuestSystem(Game game)
     {
     }
@@ -149,8 +157,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     }
 
     /// Whether a pawn may board a regen pickup shuttle under colony control.
-    /// Active contract clients always may; free colonists only when they have a
-    /// non-ex DirectRelation to one of those clients (family / current partners).
+    /// Active contract clients always may. Free colonists may board when they have a
+    /// non-ex DirectRelation to a client — or freely during the Emperor contract, where
+    /// departing with the Emperor can trigger the Imperial Court endgame.
     public static bool MayBoardRegenPickupShuttle(Pawn pawn)
     {
         if (pawn == null || pawn.Destroyed || pawn.Dead)
@@ -169,6 +178,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return false;
         }
 
+        // Emperor pickup: any free colony colonist may leave with the Emperor.
+        if (system.IsEmperorRegenContractActive() && system.IsFreeColonyColonistForEmperorEndgame(pawn))
+        {
+            return true;
+        }
+
         IEnumerable<Pawn> clients = system.activeClients
             .Where(client => client?.pawn != null && !client.pawn.Destroyed)
             .Select(client => client.pawn);
@@ -180,6 +195,42 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         // Emperor-stage Stellic guards and other non-regen escorts.
         return system.contractEscorts != null && system.contractEscorts.Contains(pawn);
+    }
+
+    /// True while the Emperor / High Stellarch regen contract is the active visit.
+    public bool IsEmperorRegenContractActive()
+    {
+        return this.activeContractStage == RoyaltyRegenesisStage.EmperorArrival
+            && this.activeClients != null
+            && this.activeClients.Any();
+    }
+
+    /// A real player colonist (not a temporary quest-lodger client/escort) eligible to
+    /// board the Emperor pickup and trigger the Imperial Court victory ending.
+    public bool IsFreeColonyColonistForEmperorEndgame(Pawn pawn)
+    {
+        if (pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        if (!pawn.IsColonist || pawn.IsQuestLodger())
+        {
+            return false;
+        }
+
+        if (IsActiveRegenContractPawn(pawn))
+        {
+            return false;
+        }
+
+        if (this.contractEscorts != null && this.contractEscorts.Contains(pawn))
+        {
+            return false;
+        }
+
+        // Free colonists only — prisoners / slaves do not count as choosing to leave.
+        return pawn.IsFreeColonist;
     }
 
     /// Called by a CryoRegenesis casket on the exact tick that a pawn reaches its target.
@@ -237,6 +288,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.nextWavePickupTick, "crRoyalNextWavePickupTick", -1);
         Scribe_Values.Look(ref this.clientsSuccessfullyReturned, "crRoyalClientsSuccessfullyReturned", 0);
         Scribe_Collections.Look(ref this.returnedClientPawnIds, "crRoyalReturnedClientPawnIds", LookMode.Value);
+        Scribe_Collections.Look(ref this.emperorShuttleColonistEscapeeLabels, "crRoyalEmperorShuttleColonistEscapees", LookMode.Value);
+        Scribe_Values.Look(ref this.emperorColonistEndgameTriggered, "crRoyalEmperorColonistEndgameTriggered", false);
 #if !RIMWORLD12
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
@@ -264,6 +317,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 this.returnedClientPawnIds = new List<int>();
             }
 
+            if (this.emperorShuttleColonistEscapeeLabels == null)
+            {
+                this.emperorShuttleColonistEscapeeLabels = new List<string>();
+            }
+
             if (this.lastTrustBreakReason == null)
             {
                 this.lastTrustBreakReason = string.Empty;
@@ -289,6 +347,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         if (!ModsConfig.RoyaltyActive)
         {
             return;
+        }
+
+        // Every tick while the Emperor pickup is parked: remember free colonists aboard
+        // so the endgame still fires after the shuttle destroys its cargo on leave.
+        if (this.pickupShuttleSpawned && this.IsEmperorRegenContractActive())
+        {
+            this.RefreshEmperorShuttleColonistSnapshot();
         }
 
         if (Find.TickManager.TicksGame % CheckIntervalTicks != 0)
@@ -887,6 +952,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.clientsSuccessfullyReturned = 0;
         this.returnedClientPawnIds.Clear();
         this.contractEscorts.Clear();
+        // Keep escapee labels / endgame flag across Clear during finish so a late
+        // TryTrigger still sees them; wipe when a brand-new contract begins.
+        if (!this.emperorColonistEndgameTriggered)
+        {
+            this.ClearEmperorShuttleColonistSnapshot();
+        }
+
         this.ResetCompletionRewardState();
     }
 
@@ -1391,6 +1463,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.RefreshClientAgeProgress();
         this.LogClientAgeSnapshot("shuttle left");
 
+        // Emperor pickup with any free colonist aboard → Imperial Court victory ending.
+        // Snapshot was taken while the ship was still loaded; do this before clearing state.
+        this.TryTriggerEmperorColonistEndgameFromSnapshot("shuttle left");
+
         List<RoyaltyRegenesisClient> remaining = new List<RoyaltyRegenesisClient>();
         List<RoyaltyRegenesisClient> departed = new List<RoyaltyRegenesisClient>();
 
@@ -1693,7 +1769,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// requiredPawns or acceptColonists is true. Enable guest embark while Send still
     /// only requires ready clients (see <see cref="UpdateShuttleRequiredPawns"/>).
     /// Free colonists are then filtered by <see cref="MayBoardRegenPickupShuttle"/>
-    /// (active clients and non-ex DirectRelations only).
+    /// (clients, non-ex DirectRelations, or any free colonist during the Emperor stage).
     private void ConfigureContractShuttleEmbarkRules(CompShuttle compShuttle)
     {
         if (compShuttle == null)
@@ -1703,7 +1779,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         // Quest lodgers embark only if they are requiredPawns or acceptColonists is true.
         // acceptColonists also opens the door to free colonists — Patch_CompShuttle_IsAllowed
-        // keeps unrelated colonists off regen pickups.
+        // keeps unrelated colonists off non-Emperor regen pickups.
         compShuttle.acceptColonists = true;
         compShuttle.onlyAcceptColonists = false;
 #if RIMWORLD14 || RIMWORLD15 || RIMWORLD16
@@ -1919,6 +1995,139 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return transporter != null && transporter.innerContainer.Contains(pawn);
     }
 
+    /// Called from CompShuttle.SendLaunchedSignals just before cargo is destroyed.
+    /// Ensures same-tick board-and-launch still records free colonists for the endgame.
+    public void NotifyEmperorPickupLaunching(CompShuttle shuttleComp)
+    {
+        if (shuttleComp?.parent == null || this.emperorColonistEndgameTriggered)
+        {
+            return;
+        }
+
+        if (!this.IsRegenPickupShuttle(shuttleComp.parent) || !this.IsEmperorRegenContractActive())
+        {
+            return;
+        }
+
+        this.CaptureFreeColonistsFromTransporter(shuttleComp.Transporter);
+    }
+
+    /// While the Emperor pickup is parked, record free colony colonists currently aboard.
+    /// Labels are stored because the shuttle destroys container contents on launch.
+    private void RefreshEmperorShuttleColonistSnapshot()
+    {
+        if (this.emperorColonistEndgameTriggered)
+        {
+            return;
+        }
+
+        Thing shuttle = this.GetContractShuttleThing();
+        if (shuttle == null || shuttle.Destroyed)
+        {
+            return;
+        }
+
+        this.CaptureFreeColonistsFromTransporter(shuttle.TryGetComp<CompTransporter>());
+    }
+
+    private void CaptureFreeColonistsFromTransporter(CompTransporter transporter)
+    {
+        if (transporter?.innerContainer == null)
+        {
+            return;
+        }
+
+        if (this.emperorShuttleColonistEscapeeLabels == null)
+        {
+            this.emperorShuttleColonistEscapeeLabels = new List<string>();
+        }
+
+        this.emperorShuttleColonistEscapeeLabels.Clear();
+        foreach (Thing thing in transporter.innerContainer)
+        {
+            Pawn pawn = thing as Pawn;
+            if (pawn != null && this.IsFreeColonyColonistForEmperorEndgame(pawn))
+            {
+                this.emperorShuttleColonistEscapeeLabels.Add(pawn.LabelCap);
+            }
+        }
+    }
+
+    /// If any free colonist left on the Emperor pickup, start the Imperial Court endgame.
+    private void TryTriggerEmperorColonistEndgameFromSnapshot(string reason)
+    {
+        if (this.emperorColonistEndgameTriggered)
+        {
+            return;
+        }
+
+        // Only the Emperor-stage contract may fire this ending.
+        if (this.activeContractStage != RoyaltyRegenesisStage.EmperorArrival)
+        {
+            return;
+        }
+
+        if (this.emperorShuttleColonistEscapeeLabels == null
+            || !this.emperorShuttleColonistEscapeeLabels.Any())
+        {
+            return;
+        }
+
+        this.TriggerEmperorColonistEndgame(this.emperorShuttleColonistEscapeeLabels, reason);
+    }
+
+    /// Victory ending: one or more free colonists left on the Emperor's regen pickup shuttle.
+    private void TriggerEmperorColonistEndgame(List<string> escapeeLabels, string reason)
+    {
+        if (this.emperorColonistEndgameTriggered || escapeeLabels == null || !escapeeLabels.Any())
+        {
+            return;
+        }
+
+        if (ShipCountdown.CountingDown)
+        {
+            return;
+        }
+
+        this.emperorColonistEndgameTriggered = true;
+        this.LogRoyaltyDebug(
+            "Imperial Court endgame: " + escapeeLabels.Count
+            + " colonist(s) left with the Emperor (" + reason + ").");
+
+        StringBuilder escapees = new StringBuilder();
+        foreach (string label in escapeeLabels)
+        {
+            if (!label.NullOrEmpty())
+            {
+                escapees.AppendLine("   " + label);
+            }
+        }
+
+        if (Find.StoryWatcher?.statsRecord != null)
+        {
+            Find.StoryWatcher.statsRecord.colonistsLaunched += escapeeLabels.Count;
+        }
+
+        string intro =
+            "You've departed with the Emperor on the Imperial shuttle!";
+        string ending =
+            "The rejuvenated Emperor welcomes your colonists into the Imperial court as honored guests of the throne.\n\n"
+            + "You may remain among the Imperial flotilla, claim titles and privileges earned by your gift of CryoRegenesis, "
+            + "or purchase a ship and set a course for home.\n\n"
+            + "The choice is yours.";
+
+        string credits = GameVictoryUtility.MakeEndCredits(intro, ending, escapees.ToString());
+        ShipCountdown.InitiateCountdown(credits);
+
+        // Completing the Emperor visit this way also finishes the Imperial Rejuvenation chain.
+        if (this.stage != RoyaltyRegenesisStage.Completed)
+        {
+            this.stage = RoyaltyRegenesisStage.Completed;
+            this.royalAscentTriggered = true;
+            this.CompleteChainQuest();
+        }
+    }
+
     /// Living non-regen escorts still on the map (Emperor-stage guards, etc.).
     private List<Pawn> GetMapHeldEscorts()
     {
@@ -2082,11 +2291,19 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         RoyaltyRegenesisStage finishedStage = this.activeContractStage;
         bool triggerEndgame = this.activeClients.Any(client => client != null && client.triggerRoyalAscent);
 
+        // Safety net: if the Emperor pickup left with free colonists and we have not
+        // already started the Imperial Court ending, do so before clearing contract state.
+        if (finishedStage == RoyaltyRegenesisStage.EmperorArrival)
+        {
+            this.TryTriggerEmperorColonistEndgameFromSnapshot("finish contract");
+        }
+
         this.LogRoyaltyDebug(
             "FinishContractAfterDeparture success=" + success
             + " stage=" + finishedStage
             + " clients=" + this.activeClients.Count
             + " triggerRoyalAscent=" + triggerEndgame
+            + " emperorColonistEndgame=" + this.emperorColonistEndgameTriggered
             + " banked=" + this.departureSuccessBanked
             + " completionLatched=" + this.contractCompletionLogged
             + " allReady=" + this.pickupAllClientsReady
@@ -2106,7 +2323,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (triggerEndgame && success)
         {
-            this.LogRoyaltyDebug("Outcome: SUCCESS + Royal Ascent endgame (shuttle departed).");
+            this.LogRoyaltyDebug(
+                this.emperorColonistEndgameTriggered
+                    ? "Outcome: SUCCESS + Imperial Court colonist endgame (shuttle departed)."
+                    : "Outcome: SUCCESS + Royal Ascent endgame (shuttle departed).");
             this.activeContractStage = finishedStage;
             this.GrantCompletionRewardIfEligible(finishedStage);
             this.EndActiveContractQuest(QuestEndOutcome.Success);
@@ -2114,7 +2334,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             this.royalAscentTriggered = true;
             this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
             this.CompleteChainQuest();
-            this.TryMakeRoyalAscentAvailable();
+            // Colonists who left with the Emperor already got the victory ending —
+            // do not also open the vanilla Royal Ascent visit quest.
+            if (!this.emperorColonistEndgameTriggered)
+            {
+                this.TryMakeRoyalAscentAvailable();
+            }
+
             return;
         }
 
@@ -2302,6 +2528,30 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             ? this.GetReadyPickupStayTicks()
             : ShuttleLeaveDelayDays * GenDate.TicksPerDay;
         this.pickupWindowEndTick = this.pickupShuttleSpawnTick + stayTicks;
+        // New boarding window — previous wave's empty/full snapshot must not carry over.
+        if (!this.emperorColonistEndgameTriggered)
+        {
+            this.ClearEmperorShuttleColonistSnapshot();
+        }
+    }
+
+    /// Pickup letter body; Emperor stage invites free colonists to board for the ending.
+    private string BuildPickupShuttleLetterText(bool longStay)
+    {
+        string body = longStay
+            ? "A shuttle has arrived because at least one CryoRegenesis client finished treatment. "
+              + "It will stay for many days — load ready clients when you want and Send. "
+              + "Unfinished clients can keep regenerating."
+            : "A shuttle has arrived for finished CryoRegenesis clients. "
+              + "Load ready clients onto it yourself (unfinished clients can stay for a later pickup).";
+
+        if (this.IsEmperorRegenContractActive())
+        {
+            body += "\n\nAny colonist may board this shuttle with the Emperor. "
+                + "If even one colonist leaves with him, your story ends in victory as guests of the Imperial court.";
+        }
+
+        return body;
     }
 
     /// Used for death/trust-break emergency leaves: eject and call a pickup if needed.
@@ -2527,12 +2777,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         Find.LetterStack.ReceiveLetter(
             "Regenesis Pickup Shuttle",
-            longStay
-                ? "A shuttle has arrived because at least one CryoRegenesis client finished treatment. "
-                  + "It will stay for many days — load ready clients when you want and Send. "
-                  + "Unfinished clients can keep regenerating."
-                : "A shuttle has arrived for finished CryoRegenesis clients. "
-                  + "Load ready clients onto it yourself (unfinished clients can stay for a later pickup).",
+            this.BuildPickupShuttleLetterText(longStay),
             LetterDefOf.NeutralEvent,
             new LookTargets(shuttle));
 #else
@@ -2613,12 +2858,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         Find.LetterStack.ReceiveLetter(
             "Regenesis Pickup Shuttle",
-            longStay
-                ? "A shuttle has arrived because at least one CryoRegenesis client finished treatment. "
-                  + "It will stay for many days — load ready clients when you want and Send. "
-                  + "Unfinished clients can keep regenerating."
-                : "A shuttle has arrived for finished CryoRegenesis clients. "
-                  + "Load ready clients onto it yourself (unfinished clients can stay for a later pickup).",
+            this.BuildPickupShuttleLetterText(longStay),
             LetterDefOf.NeutralEvent,
             new LookTargets(shuttle));
 #endif
@@ -2702,6 +2942,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 #if !RIMWORLD12
         this.contractTransportShip = null;
 #endif
+        // Do not clear emperorShuttleColonistEscapeeLabels here — FinishContractAfterDeparture
+        // may still need them after HandleContractShuttleDeparture already nulls the ship ref.
+    }
+
+    private void ClearEmperorShuttleColonistSnapshot()
+    {
+        this.emperorShuttleColonistEscapeeLabels?.Clear();
     }
 
     private void ClearContractFlags(IEnumerable<RoyaltyRegenesisClient> clients)
@@ -3092,6 +3339,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             sb.AppendLine(
                 "Shuttle: parked for ready clients (no auto-board). Load and Send when you want. "
                 + "Boarding window ~" + windowLeft.ToStringTicksToPeriod() + ".");
+            if (this.IsEmperorRegenContractActive())
+            {
+                sb.AppendLine(
+                    "Emperor pickup: any free colonist may board. One colonist leaving with him ends the game "
+                    + "as guests of the Imperial court.");
+            }
         }
         else if (this.nextWavePickupTick > 0)
         {

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -113,6 +113,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// True once any Emperor-stage victory/defeat endgame has been started for this run.
     private bool emperorColonistEndgameTriggered;
 
+    /// Best Count/Countess candidate snapshotted while the Emperor pickup is parked
+    /// (may leave on the shuttle — keep label for credits even if the pawn is destroyed).
+    private Pawn emperorUsurpationCountCandidate;
+    private string emperorUsurpationCountLabel = string.Empty;
+
     /// Colonist elevated to Special Consul when the party leaves with the Emperor: the
     /// highest-ranked passenger, and among equal ranks the one holding the most Honor.
     private Pawn emperorCourtHonoree;
@@ -125,6 +130,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     private bool emperorNobleRequirementAnnounced;
 
     private Pawn emperor;
+
+    /// The number of the Emperor's wives.
+    private int wifeCount = 0;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
@@ -252,11 +260,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// Whether the Emperor's Imperial shuttle is currently open to free colony colonists.
     /// Any number of them (none through all of them) may leave, but only while both
     /// conditions hold:
-    ///   1. The Emperor is alive and already inside the shuttle.
+    ///   1. The Emperor is alive and either already inside the shuttle or sealed in a
+    ///      powered-off CryoRegenesis casket.
     ///   2. Every other contracted guest is already offworld, or inside the shuttle after
     ///      reaching their target age.
     /// Checked live on every embark test, so the door opens the moment the last guest is
-    /// aboard and closes again if the Emperor steps out.
+    /// aboard and closes again if the Emperor is powered back up or a guest steps out.
     /// Escorting Stellic guards are not contracted guests and do not hold the door shut.
     public bool MayColonistsBoardImperialShuttle(out string blockReason)
     {
@@ -274,9 +283,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return false;
         }
 
-        if (!this.IsClientAboardContractShuttle(emperorPawn))
+        if (!this.IsClientAboardContractShuttle(emperorPawn) && !this.IsEmperorInUnpoweredCryoCasket())
         {
-            blockReason = emperorPawn.LabelShort + " is not aboard the shuttle";
+            blockReason = emperorPawn.LabelShort
+                + " is neither aboard the shuttle nor sealed in a powered-off CryoRegenesis casket";
             return false;
         }
 
@@ -422,6 +432,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.emperorColonistEndgameTriggered, "crRoyalEmperorColonistEndgameTriggered", false);
         Scribe_Values.Look(ref this.emperorNobleRequirementAnnounced, "crRoyalEmperorNobleRequirementAnnounced", false);
         Scribe_References.Look(ref this.emperor, "crRoyalEmperor");
+        Scribe_References.Look(ref this.emperorUsurpationCountCandidate, "crRoyalEmperorUsurpationCount");
+        Scribe_Values.Look(ref this.emperorUsurpationCountLabel, "crRoyalEmperorUsurpationCountLabel");
         Scribe_References.Look(ref this.emperorCourtHonoree, "crRoyalEmperorCourtHonoree");
         Scribe_Values.Look(ref this.emperorCourtHonoreeLabel, "crRoyalEmperorCourtHonoreeLabel");
 #if !RIMWORLD12
@@ -454,6 +466,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             if (this.emperorShuttleColonistEscapeeLabels == null)
             {
                 this.emperorShuttleColonistEscapeeLabels = new List<string>();
+            }
+
+            if (this.emperorUsurpationCountLabel == null)
+            {
+                this.emperorUsurpationCountLabel = string.Empty;
             }
 
             if (this.emperorCourtHonoreeLabel == null)
@@ -1636,11 +1653,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             }
         }
 
-        // Emperor-stage Imperial Court ending (before partial-wave bookkeeping can soft-continue).
+        // Emperor-stage branched endings (before partial-wave bookkeeping can soft-continue).
         if (this.activeContractStage == RoyaltyRegenesisStage.EmperorArrival
             && !this.emperorColonistEndgameTriggered)
         {
-            // Free colonists left *with* the Emperor (he must have departed too).
+            // Branch 1: sealed the living Emperor in an unpowered pod while the party fled.
+            if (this.TryTriggerYouKeepWhatYouKillEndgame(remaining, departed, "shuttle left"))
+            {
+                return;
+            }
+
+            // Branch 3: free colonists left *with* the Emperor (he must have departed too).
             if (departed.Any(client => client?.pawn == this.emperor))
             {
                 this.TryTriggerEmperorColonistEndgameFromSnapshot("shuttle left with Emperor");
@@ -1649,7 +1672,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                      && this.emperorShuttleColonistEscapeeLabels.Any())
             {
                 this.LogRoyaltyDebug(
-                    "Free colonists left without the Emperor — no Imperial Court victory.");
+                    "Free colonists left without the Emperor and without unpowered-casket usurpation — "
+                    + "no Imperial Court victory.");
             }
         }
 
@@ -1990,9 +2014,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             required = this.GetMapHeldContractPawns().Concat(this.GetMapHeldEscorts()).Distinct().ToList();
         }
 
-        // Once the Emperor is regenerated, every archon on this map must leave on the Imperial
-        // shuttle with him. They are ejected from caskets so they can actually board; nobody off
-        // this map is fetched.
+        // Once the Emperor is regenerated or sealed away, every archon on this map must leave on
+        // the Imperial shuttle — as his guest or as his successor. They are ejected from caskets
+        // so they can actually board; nobody off this map is fetched.
         List<Pawn> nobles = this.GetRequiredImperialNobleColonists(shuttle);
         if (nobles.Any())
         {
@@ -2067,6 +2091,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             }
 
             if (!client.everReachedDesiredAge)
+            {
+                continue;
+            }
+
+            // A living Emperor sealed in a powered-off casket is being left behind on purpose, so
+            // he must not sit on the manifest and lock Send. But only an archon can take a throne:
+            // with nobody eligible to usurp him he stays required, and the shuttle cannot leave
+            // without him.
+            if (client?.pawn == this.emperor
+                && this.IsEmperorInUnpoweredCryoCasket()
+                && this.GetImperialNobleColonists(shuttle).Any())
             {
                 continue;
             }
@@ -2188,9 +2223,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         CompTransporter transporter = shuttleComp.Transporter;
 
-        // Boarding conditions can be undone after colonists board — the Emperor or a guest
-        // carried back out. They must never fly off (and be destroyed with the cargo) without
-        // the ending they boarded for.
+        // Boarding conditions can be undone after colonists board — the Emperor's casket
+        // powered back up, a guest carried back out. They must never fly off (and be destroyed
+        // with the cargo) without the ending they boarded for.
         if (!this.MayColonistsBoardImperialShuttle(out string blockReason))
         {
             this.PutColonistsBackOnMapBeforeLaunch(transporter, blockReason);
@@ -2330,6 +2365,30 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             : this.activeClients?.FirstOrDefault(client => client?.pawn == this.emperor);
     }
 
+    private bool IsEmperorWifeClient(RoyaltyRegenesisClient client)
+    {
+        if (client?.role == null)
+        {
+            return false;
+        }
+
+        return client.role.IndexOf("wife", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    /// Living Emperor sealed in a flicked-off / unpowered CryoRegenesis pod (normal cryptosleep mode).
+    private bool IsEmperorInUnpoweredCryoCasket()
+    {
+        RoyaltyRegenesisClient emperor = this.GetEmperorClient();
+        Pawn pawn = emperor?.pawn;
+        if (pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        Building_CryoRegenesis casket = pawn.ParentHolder as Building_CryoRegenesis;
+        return casket != null && casket.IsUnpoweredCryptosleepMode;
+    }
+
     /// True when the living Emperor is still map-reachable (spawned or in a casket).
     private bool IsEmperorStillAvailableOnMap()
     {
@@ -2344,8 +2403,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return DefDatabase<RoyalTitleDef>.GetNamedSilentFail("Count");
     }
 
-    /// A free colonist holding at least the archon rank. More senior colony titles (dominus,
-    /// consul) qualify as well. Once the Emperor is regenerated, these nobles must board.
+    /// A colonist who could take the Imperial throne: one of our own free colonists holding at
+    /// least the archon rank. More senior colony titles (dominus, consul) qualify as well.
     private bool IsImperialNobleColonist(Pawn pawn)
     {
         if (pawn == null || pawn.Dead || pawn.Destroyed || pawn.royalty == null)
@@ -2413,10 +2472,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     }
 
     /// Throne-eligible colonists who must be aboard before the Imperial shuttle may launch.
-    /// Empty until the Emperor is regenerated — earlier waves must not drag nobility along.
+    /// Empty until the Emperor's fate is settled — earlier waves must not drag nobility along.
     private List<Pawn> GetRequiredImperialNobleColonists(Thing shuttle)
     {
-        if (!this.IsEmperorRegenContractActive() || !this.IsEmperorRegenerated())
+        if (!this.IsEmperorRegenContractActive() || !this.IsEmperorRegeneratedOrSealed())
         {
             return new List<Pawn>();
         }
@@ -2424,9 +2483,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return this.GetImperialNobleColonists(shuttle);
     }
 
-    /// True once the Emperor is alive and fully regenerated. From that moment the colony's
-    /// archons leave on the Imperial shuttle at his side.
-    private bool IsEmperorRegenerated()
+    /// True once the Emperor's fate is settled either way: he is alive and either fully
+    /// regenerated or shut inside a powered-off casket. From that moment the colony's archons
+    /// leave on the Imperial shuttle — at his side, or over his sleeping body.
+    private bool IsEmperorRegeneratedOrSealed()
     {
         RoyaltyRegenesisClient emperor = this.GetEmperorClient();
         Pawn pawn = emperor?.pawn;
@@ -2435,7 +2495,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return false;
         }
 
-        return emperor.everReachedDesiredAge;
+        return emperor.everReachedDesiredAge || this.IsEmperorInUnpoweredCryoCasket();
     }
 
     /// Empire rank of a colonist for endgame selection; 0 when untitled.
@@ -2472,6 +2532,29 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
+    /// Colonist who could take the throne: aboard the shuttle first — the usurper named in the
+    /// credits has to be someone who actually leaves — then the highest rank, and where ranks
+    /// tie, the one holding the most Honor.
+    private Pawn FindColonyArchon(CompTransporter alsoSearch = null)
+    {
+        Faction empire = this.EmpireFaction();
+        if (empire == null || ArchonTitleDef() == null)
+        {
+            return null;
+        }
+
+        HashSet<Pawn> aboard = new HashSet<Pawn>(
+            PawnsAboard(alsoSearch).Where(this.IsImperialNobleColonist));
+
+        return this.GetImperialNobleColonists(this.GetContractShuttleThing())
+            .Concat(aboard)
+            .Distinct()
+            .OrderByDescending(p => aboard.Contains(p))
+            .ThenByDescending(p => this.ImperialSeniorityOf(p, empire))
+            .ThenByDescending(p => this.ImperialHonorOf(p, empire))
+            .FirstOrDefault();
+    }
+
     /// The colonist the Empire elevates at the Imperial Court ending: the highest-ranked one
     /// aboard the shuttle, and where several share that rank, the one with the most Honor.
     private Pawn FindImperialCourtHonoree(CompTransporter transporter)
@@ -2489,10 +2572,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             .FirstOrDefault();
     }
 
-    /// The Court honoree is chosen while the shuttle is still parked, because launching it
+    /// Both endgame honours are chosen while the shuttle is still parked, because launching it
     /// destroys the cargo the choice is made from.
     private void RefreshEmperorEndgameCandidates(CompTransporter transporter = null)
     {
+        Pawn archon = this.FindColonyArchon(transporter);
+        if (archon != null)
+        {
+            this.emperorUsurpationCountCandidate = archon;
+            this.emperorUsurpationCountLabel = archon.Name?.ToStringShort ?? archon.LabelShort;
+        }
+
         // The honoree must be aboard, so this tracks the manifest both ways — someone stepping
         // back off the ship gives up the title.
         Pawn honoree = this.FindImperialCourtHonoree(transporter);
@@ -2526,6 +2616,237 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         return this.emperorCourtHonoreeLabel;
+    }
+
+    private Pawn ResolveUsurpationCount()
+    {
+        if (this.emperorUsurpationCountCandidate != null
+            && !this.emperorUsurpationCountCandidate.Destroyed
+            && !this.emperorUsurpationCountCandidate.Dead)
+        {
+            return this.emperorUsurpationCountCandidate;
+        }
+
+        return this.FindColonyArchon();
+    }
+
+    private List<string> GetEmperorWifeLabels(IEnumerable<RoyaltyRegenesisClient> clients = null)
+    {
+        IEnumerable<RoyaltyRegenesisClient> source = clients ?? this.activeClients;
+        List<string> labels = new List<string>();
+        foreach (RoyaltyRegenesisClient client in source.Where(this.IsEmperorWifeClient))
+        {
+            Pawn pawn = client?.pawn;
+            string label = pawn != null && !pawn.Destroyed
+                ? pawn.LabelShort
+                : (client.role ?? "imperial wife");
+            if (!label.NullOrEmpty() && !labels.Contains(label))
+            {
+                labels.Add(label);
+            }
+        }
+
+        return labels;
+    }
+
+    /// Branch 1: shuttle left while the living Emperor is sealed in an unpowered CryoRegenesis
+    /// casket, and the colony has a Count/Countess → "You Keep What You Kill" victory.
+    private bool TryTriggerYouKeepWhatYouKillEndgame(
+        List<RoyaltyRegenesisClient> remaining,
+        List<RoyaltyRegenesisClient> departed,
+        string reason)
+    {
+        if (this.emperorColonistEndgameTriggered
+            || this.activeContractStage != RoyaltyRegenesisStage.EmperorArrival)
+        {
+            return false;
+        }
+
+        if (!this.IsEmperorInUnpoweredCryoCasket())
+        {
+            return false;
+        }
+
+        // Emperor must still be among remaining map clients (sealed, not aboard).
+        if (!remaining.Any(client => client?.pawn == this.emperor))
+        {
+            return false;
+        }
+
+        Pawn count = this.ResolveUsurpationCount();
+        bool hasCount = count != null
+            || !this.emperorUsurpationCountLabel.NullOrEmpty();
+        if (!hasCount)
+        {
+            this.LogRoyaltyDebug(
+                "Emperor sealed in unpowered casket but colony has no Count/Countess — no usurpation ending.");
+            return false;
+        }
+
+        List<RoyaltyRegenesisClient> allKnown = remaining
+            .Concat(departed ?? Enumerable.Empty<RoyaltyRegenesisClient>())
+            .Where(c => c != null)
+            .ToList();
+        this.TriggerYouKeepWhatYouKillEndgame(count, allKnown, reason);
+        this.FinishEmperorUsurpationContract(departed);
+        return true;
+    }
+
+    private static int CountLivingWives(Pawn human)
+    {
+        if (human?.relations == null)
+        {
+            return 0;
+        }
+
+        int count = 0;
+        foreach (DirectPawnRelation rel in human.relations.DirectRelations)
+        {
+            if (rel.def == PawnRelationDefOf.Spouse
+                && rel.otherPawn != null
+                && rel.otherPawn.gender == Gender.Female
+                && !rel.otherPawn.Dead)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// Victory: Count forges an alliance with the Emperor's wives and is recognized as Emperor.
+    private void TriggerYouKeepWhatYouKillEndgame(
+        Pawn count,
+        List<RoyaltyRegenesisClient> knownClients,
+        string reason)
+    {
+        if (this.emperorColonistEndgameTriggered)
+        {
+            return;
+        }
+
+        if (ShipCountdown.CountingDown)
+        {
+            return;
+        }
+
+        this.emperorColonistEndgameTriggered = true;
+        List<string> wifeLabels = this.GetEmperorWifeLabels(knownClients);
+        string countName = count != null && !count.Destroyed
+            ? (count.Name?.ToStringShort ?? count.LabelShort)
+            : (this.emperorUsurpationCountLabel.NullOrEmpty()
+                ? "your Count"
+                : this.emperorUsurpationCountLabel);
+        string wivesText = wifeLabels.Any()
+            ? string.Join(", ", wifeLabels)
+            : "the Emperor's wives";
+
+        this.LogRoyaltyDebug(
+            "You Keep What You Kill endgame: Count " + countName
+            + " / wives=[" + wivesText + "] (" + reason + ").");
+
+        Faction empire = this.EmpireFaction();
+        if (empire != null && count != null && !count.Destroyed && !count.Dead)
+        {
+            // Crown the usurper before the credits.
+            SpawnStoryHuman.TrySetRoyalTitle(count, empire, "Emperor");
+            // Reflection fallback for older title-set paths.
+            this.TrySetRoyalTitle(count, empire, "Emperor");
+        }
+
+        wifeCount = CountLivingWives(emperor);
+
+        #if RIMWORLD16
+        string title = "Archon";
+        #else
+        string title = "Count";
+        #endif
+
+        string intro = "You Keep What You Kill.\n\n";
+        string ending =
+            $"{title} {countName} forged an alliance with the Emperor's {(wifeCount == 1 ? "wife" : "wives")}. "
+            + "In the proud tradition of The Empire: \"You Keep What You Kill\": "
+            + $"Now {countName} is seen across The Empire as its latest Emperor.\n\n"
+            + "The desposed emperor sleeps in a dark cryptosleep casket in a secret base "
+            + "long abandoned. No rescue will ever come.\n\n"
+            + "The choice — and the throne — is yours.";
+
+        // Escapee line: the Count (and any free colonists who left with the wives).
+        StringBuilder escapees = new StringBuilder();
+        if (count != null && !count.Destroyed)
+        {
+            escapees.AppendLine("   " + count.LabelCap);
+        }
+        else if (!this.emperorUsurpationCountLabel.NullOrEmpty())
+        {
+            escapees.AppendLine("   " + this.emperorUsurpationCountLabel);
+        }
+
+        if (this.emperorShuttleColonistEscapeeLabels != null)
+        {
+            foreach (string label in this.emperorShuttleColonistEscapeeLabels)
+            {
+                if (!label.NullOrEmpty()
+                    && !string.Equals(label, countName, StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(label, count?.LabelCap, StringComparison.OrdinalIgnoreCase))
+                {
+                    escapees.AppendLine("   " + label);
+                }
+            }
+        }
+
+        if (Find.StoryWatcher?.statsRecord != null)
+        {
+            int launched = 1 + (this.emperorShuttleColonistEscapeeLabels?.Count ?? 0);
+            Find.StoryWatcher.statsRecord.colonistsLaunched += Math.Max(1, launched);
+        }
+
+        string credits = GameVictoryUtility.MakeEndCredits(intro, ending, escapees.ToString());
+        ShipCountdown.InitiateCountdown(credits);
+
+        this.stage = RoyaltyRegenesisStage.Completed;
+        this.royalAscentTriggered = true;
+        this.CompleteChainQuest();
+    }
+
+    /// After usurpation: wives (and other departed) are gone; seal the Emperor out of the
+    /// contract so trust does not break; finish the Emperor visit as a dark success.
+    private void FinishEmperorUsurpationContract(List<RoyaltyRegenesisClient> departed)
+    {
+        RoyaltyRegenesisClient emperor = this.GetEmperorClient();
+        Pawn emperorPawn = emperor?.pawn;
+
+        // Credit the departing wave (wives / stellarch / escorts) without requiring the Emperor.
+        int readyDeparted = departed?.Count(c => c != null && c.everReachedDesiredAge) ?? 0;
+        this.clientsSuccessfullyReturned += readyDeparted;
+        if (departed != null)
+        {
+            this.FinalizeDepartedWaveClients(departed);
+        }
+
+        // Emperor remains sealed — drop contract flags so death/leave logic stops tracking him.
+        if (emperorPawn != null)
+        {
+            this.ClearContractFlags(new[] { emperor });
+            this.RemoveClientFromContractQuest(emperorPawn);
+            // Leave him in the dark casket; do not eject.
+        }
+
+        this.GrantCompletionRewardIfEligible(RoyaltyRegenesisStage.EmperorArrival);
+        this.EndActiveContractQuest(QuestEndOutcome.Success, sendLetter: false);
+        this.activeClients.Clear();
+        this.ClearContractShuttle();
+        this.ClearContractTiming();
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = RoyaltyRegenesisStage.Completed;
+
+        Find.LetterStack.ReceiveLetter(
+            "You Keep What You Kill",
+            "The Imperial shuttle has fled without the Emperor. He remains sealed in an unpowered "
+            + "CryoRegenesis casket — a secret tomb no one will ever find.\n\n"
+            + "The Empire recognizes a new Emperor among your Counts.",
+            LetterDefOf.PositiveEvent,
+            emperorPawn != null ? new LookTargets(emperorPawn) : null);
     }
 
     /// Branch 3: free colonists left on the Emperor pickup *with* the Emperor → Imperial Court.
@@ -2779,10 +3100,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         RoyaltyRegenesisStage finishedStage = this.activeContractStage;
         bool triggerEndgame = this.activeClients.Any(client => client != null && client.triggerRoyalAscent);
 
-        // Safety net only when the Emperor himself is no longer on the map (he left with the
-        // shuttle). Never fire Imperial Court for an abandoned Emperor.
+        // Safety net for Branch 3 only when the Emperor himself is no longer on the map
+        // (he left with the shuttle). Never fire Imperial Court for an abandoned Emperor.
         if (finishedStage == RoyaltyRegenesisStage.EmperorArrival
             && !this.emperorColonistEndgameTriggered
+            && !this.IsEmperorInUnpoweredCryoCasket()
             && !this.IsEmperorStillAvailableOnMap())
         {
             this.TryTriggerEmperorColonistEndgameFromSnapshot("finish contract with Emperor gone");
@@ -3449,6 +3771,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.emperorShuttleColonistEscapeeLabels?.Clear();
         if (!this.emperorColonistEndgameTriggered)
         {
+            this.emperorUsurpationCountCandidate = null;
+            this.emperorUsurpationCountLabel = string.Empty;
             this.emperorCourtHonoree = null;
             this.emperorCourtHonoreeLabel = string.Empty;
         }

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -108,7 +108,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// Labels of free colony colonists last seen aboard the Emperor-stage pickup shuttle.
     /// Snapshotted every tick while the ship is parked so departure (which destroys
     /// container contents) can still fire the Imperial Court endgame.
+    /// During assassination evacuation this list also includes colony pets for credits.
     private List<string> emperorShuttleColonistEscapeeLabels = new List<string>();
+
+    /// Humanlike passengers recorded for the assassination shuttle launch statistic.
+    /// Pets stay on the label list for credits but must not inflate colonistsLaunched.
+    private int emperorAssassinationHumanEscapeeCount;
 
     /// True once any Emperor-stage victory/defeat endgame has been started for this run.
     private bool emperorColonistEndgameTriggered;
@@ -136,6 +141,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
     /// The number of the Emperor's wives.
     private int wifeCount = 0;
+
+    /// Killer recorded from <see cref="Pawn.Kill"/> while DamageInfo is still available.
+    private Pawn pendingEmperorKiller;
+
+    /// Knight-or-higher colonist who assassinated the Emperor under "Keep What You Kill".
+    private Pawn emperorAssassin;
+    private string emperorAssassinLabel = string.Empty;
+
+    /// True while the assassination evacuation is open: Planetkiller is armed and the
+    /// Imperial shuttle will carry the assassin, free colonists, and colony pets.
+    private bool emperorAssassinationEvacuationActive;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
@@ -203,6 +219,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return false;
         }
 
+        // Assassination evacuation: free colonists may board freely (assassin must leave before
+        // the Planetkiller hits; companions and pets are optional).
+        if (system.IsEmperorAssassinationEvacuationActive()
+            && system.IsFreeColonyColonistForEmperorEndgame(pawn))
+        {
+            return true;
+        }
+
         // Emperor pickup: free colony colonists may leave with the Imperial shuttle, but only
         // while the Emperor is secured and the rest of the party is done. This is the only rule
         // for colonists during the Emperor stage — relatives of a client get no side door.
@@ -230,6 +254,24 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return this.activeContractStage == RoyaltyRegenesisStage.EmperorArrival
             && this.activeClients != null
             && this.activeClients.Any();
+    }
+
+    /// True while the living Emperor under contract is this pawn.
+    public bool IsEmperorContractPawn(Pawn pawn)
+    {
+        return pawn != null && this.emperor != null && pawn == this.emperor;
+    }
+
+    /// True after a Knight+ colonist killed the Emperor and the evacuation window is open.
+    public bool IsEmperorAssassinationEvacuationActive()
+    {
+        return this.emperorAssassinationEvacuationActive;
+    }
+
+    /// Records the Emperor's killer from the Kill call (DamageInfo.Instigator).
+    public void NotifyEmperorKillInstigator(Pawn killer)
+    {
+        this.pendingEmperorKiller = killer;
     }
 
     /// A real player colonist (not a temporary quest-lodger client/escort) eligible to
@@ -432,6 +474,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.clientsSuccessfullyReturned, "crRoyalClientsSuccessfullyReturned", 0);
         Scribe_Collections.Look(ref this.returnedClientPawnIds, "crRoyalReturnedClientPawnIds", LookMode.Value);
         Scribe_Collections.Look(ref this.emperorShuttleColonistEscapeeLabels, "crRoyalEmperorShuttleColonistEscapees", LookMode.Value);
+        Scribe_Values.Look(ref this.emperorAssassinationHumanEscapeeCount, "crRoyalEmperorAssassinationHumanEscapees", 0);
         Scribe_Values.Look(ref this.emperorColonistEndgameTriggered, "crRoyalEmperorColonistEndgameTriggered", false);
         Scribe_Values.Look(ref this.emperorNobleRequirementAnnounced, "crRoyalEmperorNobleRequirementAnnounced", false);
         Scribe_References.Look(ref this.emperor, "crRoyalEmperor");
@@ -439,6 +482,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.emperorUsurpationCountLabel, "crRoyalEmperorUsurpationCountLabel");
         Scribe_References.Look(ref this.emperorCourtHonoree, "crRoyalEmperorCourtHonoree");
         Scribe_Values.Look(ref this.emperorCourtHonoreeLabel, "crRoyalEmperorCourtHonoreeLabel");
+        Scribe_References.Look(ref this.emperorAssassin, "crRoyalEmperorAssassin");
+        Scribe_Values.Look(ref this.emperorAssassinLabel, "crRoyalEmperorAssassinLabel");
+        Scribe_Values.Look(ref this.emperorAssassinationEvacuationActive, "crRoyalEmperorAssassinationEvac", false);
 #if !RIMWORLD12
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
@@ -481,6 +527,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 this.emperorCourtHonoreeLabel = string.Empty;
             }
 
+            if (this.emperorAssassinLabel == null)
+            {
+                this.emperorAssassinLabel = string.Empty;
+            }
+
             if (this.lastTrustBreakReason == null)
             {
                 this.lastTrustBreakReason = string.Empty;
@@ -513,10 +564,22 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         // Every tick while the Emperor pickup is parked: remember free colonists aboard
         // so the endgame still fires after the shuttle destroys its cargo on leave.
-        if (this.pickupShuttleSpawned && this.IsEmperorRegenContractActive())
+        if (this.pickupShuttleSpawned
+            && (this.IsEmperorRegenContractActive() || this.emperorAssassinationEvacuationActive))
         {
             this.RefreshEmperorShuttleColonistSnapshot();
-            this.LogImperialShuttleBoardingChanges();
+            if (this.IsEmperorRegenContractActive())
+            {
+                this.LogImperialShuttleBoardingChanges();
+            }
+        }
+
+        // Assassination evacuation outlives the contract client list — keep the shuttle
+        // open and resolve the ending when it leaves (or when the assassin dies).
+        if (this.emperorAssassinationEvacuationActive
+            && Find.TickManager.TicksGame % CheckIntervalTicks == 0)
+        {
+            this.TickAssassinationEvacuation();
         }
 
         if (Find.TickManager.TicksGame % CheckIntervalTicks != 0)
@@ -529,7 +592,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         // must still run.
         this.CheckActiveClients();
 
-        if (this.activeClients.Any())
+        if (this.activeClients.Any() || this.emperorAssassinationEvacuationActive)
         {
             return;
         }
@@ -2226,12 +2289,22 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        if (!this.IsRegenPickupShuttle(shuttleComp.parent) || !this.IsEmperorRegenContractActive())
+        bool assassination = this.emperorAssassinationEvacuationActive;
+        if (!this.IsRegenPickupShuttle(shuttleComp.parent)
+            || (!this.IsEmperorRegenContractActive() && !assassination))
         {
             return;
         }
 
         CompTransporter transporter = shuttleComp.Transporter;
+
+        if (assassination)
+        {
+            // Assassin is a required passenger; companions and pets may leave freely.
+            this.CaptureFreeColonistsFromTransporter(transporter);
+            this.CaptureAssassinationPassengers(transporter);
+            return;
+        }
 
         // Boarding conditions can be undone after colonists board — the Emperor's casket
         // powered back up, a guest carried back out. They must never fly off (and be destroyed
@@ -2243,6 +2316,62 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         this.CaptureFreeColonistsFromTransporter(transporter);
         this.RefreshEmperorEndgameCandidates(transporter);
+    }
+
+    /// Records assassin + free colonists + colony pets aboard the assassination shuttle.
+    private void CaptureAssassinationPassengers(CompTransporter transporter)
+    {
+        if (transporter?.innerContainer == null)
+        {
+            return;
+        }
+
+        if (this.emperorShuttleColonistEscapeeLabels == null)
+        {
+            this.emperorShuttleColonistEscapeeLabels = new List<string>();
+        }
+
+        this.emperorShuttleColonistEscapeeLabels.Clear();
+        this.emperorAssassinationHumanEscapeeCount = 0;
+        bool assassinRecorded = false;
+        foreach (Thing thing in transporter.innerContainer)
+        {
+            Pawn pawn = thing as Pawn;
+            if (pawn == null)
+            {
+                continue;
+            }
+
+            if (this.MayBoardAssassinationEvacuationShuttle(pawn)
+                || this.IsFreeColonyColonistForEmperorEndgame(pawn)
+                || pawn == this.emperorAssassin)
+            {
+                // Credits list keeps pets; launch stat counts humanlikes only.
+                this.emperorShuttleColonistEscapeeLabels.Add(pawn.LabelCap);
+                if (pawn.RaceProps != null && pawn.RaceProps.Humanlike)
+                {
+                    this.emperorAssassinationHumanEscapeeCount++;
+                }
+
+                if (pawn == this.emperorAssassin)
+                {
+                    assassinRecorded = true;
+                }
+            }
+        }
+
+        // Guarantee the assassin is recorded if they are aboard but were missed by the
+        // boarding predicates above. Do not re-add when they were already listed under
+        // LabelCap — emperorAssassinLabel is Name.ToStringFull and often differs, which
+        // would print and count the same pawn twice in the ending.
+        if (!assassinRecorded
+            && this.emperorAssassin != null
+            && transporter.innerContainer.Contains(this.emperorAssassin)
+            && !this.emperorAssassinLabel.NullOrEmpty())
+        {
+            this.emperorShuttleColonistEscapeeLabels.Add(this.emperorAssassinLabel);
+            this.emperorAssassinationHumanEscapeeCount++;
+        }
     }
 
     /// Unloads free colony colonists from the Imperial shuttle just before it launches when
@@ -2859,16 +2988,25 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             emperorPawn != null ? new LookTargets(emperorPawn) : null);
     }
 
-    /// Branch 2: the Emperor died under contract — survivors evacuate immediately and a
-    /// Planetkiller is armed for two days. Trust is destroyed.
+    /// Branch 2: the Emperor died under contract.
+    /// Knight+ colonist assassin → Keep What You Kill assassination evacuation.
+    /// Otherwise survivors evacuate immediately and a Planetkiller is armed for two days.
     private void HandleEmperorDeathEndgame(Pawn emperor, Faction empire)
     {
-        if (this.emperorColonistEndgameTriggered)
+        if (this.emperorColonistEndgameTriggered || this.emperorAssassinationEvacuationActive)
         {
             return;
         }
 
+        Pawn assassin = this.ResolveEligibleEmperorAssassin();
+        if (assassin != null)
+        {
+            this.HandleEmperorAssassinationEndgame(emperor, assassin, empire ?? this.EmpireFaction());
+            return;
+        }
+
         this.emperorColonistEndgameTriggered = true;
+        this.pendingEmperorKiller = null;
         this.LogRoyaltyDebug(
             "Emperor death endgame: " + (emperor?.Name?.ToStringShort ?? "?")
             + " — arming Planetkiller and evacuating survivors.");
@@ -2900,6 +3038,542 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             + "Trust is shattered. The Imperial Rejuvenation chain restarts from the beginning.",
             empire ?? this.EmpireFaction(),
             "Emperor killed under contract");
+    }
+
+    /// Knight or higher free colonist who struck the killing blow, if any.
+    private Pawn ResolveEligibleEmperorAssassin()
+    {
+        Pawn killer = this.pendingEmperorKiller;
+        this.pendingEmperorKiller = null;
+        if (killer == null || killer.Destroyed || killer.Dead)
+        {
+            return null;
+        }
+
+        return this.IsKnightOrHigherColonist(killer) ? killer : null;
+    }
+
+    /// Empire title of knight or higher (seniority >= Knight). Dame uses the same defName.
+    private bool IsKnightOrHigherColonist(Pawn pawn)
+    {
+        if (!this.IsFreeColonyColonistForEmperorEndgame(pawn) || pawn.royalty == null)
+        {
+            return false;
+        }
+
+        Faction empire = this.EmpireFaction();
+        RoyalTitleDef knight = DefDatabase<RoyalTitleDef>.GetNamedSilentFail("Knight");
+        if (empire == null || knight == null)
+        {
+            return false;
+        }
+
+        RoyalTitleDef title = pawn.royalty.GetCurrentTitle(empire);
+        return title != null && title.seniority >= knight.seniority;
+    }
+
+    private static string EmpireTitleLabelFor(Pawn pawn, Faction empire)
+    {
+        if (pawn?.royalty == null || empire == null)
+        {
+            return "Noble";
+        }
+
+        RoyalTitleDef title = pawn.royalty.GetCurrentTitle(empire);
+        if (title == null)
+        {
+            return "Noble";
+        }
+
+        return title.GetLabelFor(pawn).CapitalizeFirst();
+    }
+
+    private static string GenderedPronoun(Pawn pawn)
+    {
+        return pawn?.gender == Gender.Female ? "she" : "he";
+    }
+
+    private static string GenderedPossessive(Pawn pawn)
+    {
+        return pawn?.gender == Gender.Female ? "her" : "his";
+    }
+
+    private static string GenderedObjectPronoun(Pawn pawn)
+    {
+        return pawn?.gender == Gender.Female ? "her" : "him";
+    }
+
+    /// Branch 2b: Knight+ colonist killed the Emperor → Keep What You Kill assassination.
+    /// Planetkiller still arms; the assassin (required), free colonists, and pets may board
+    /// the Imperial shuttle and must leave before the world is destroyed.
+    private void HandleEmperorAssassinationEndgame(Pawn emperor, Pawn assassin, Faction empire)
+    {
+        if (this.emperorAssassinationEvacuationActive || assassin == null)
+        {
+            return;
+        }
+
+        this.emperorAssassinationEvacuationActive = true;
+        this.emperorAssassin = assassin;
+        this.emperorAssassinLabel = assassin.Name?.ToStringFull
+            ?? assassin.Name?.ToStringShort
+            ?? assassin.LabelShort;
+        this.pendingEmperorKiller = null;
+
+        this.LogRoyaltyDebug(
+            "Emperor assassination endgame: " + this.emperorAssassinLabel
+            + " killed " + (emperor?.Name?.ToStringShort ?? "the Emperor")
+            + " — HuntedAssassin + Planetkiller + evacuation window.");
+
+        this.ApplyHuntedAssassinHediff(assassin);
+        this.ShowKeepWhatYouKillAssassinationDialog(assassin, empire);
+
+        List<Pawn> imperialSurvivors = this.activeClients
+            .Where(c => c?.pawn != null && !c.pawn.Dead && !c.pawn.Destroyed && c.pawn != emperor)
+            .Select(c => c.pawn)
+            .Concat(this.contractEscorts.Where(p => p != null && !p.Dead && !p.Destroyed))
+            .Distinct()
+            .ToList();
+
+        Map map = assassin.MapHeld
+            ?? imperialSurvivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld
+            ?? this.GetTargetMap()
+            ?? emperor?.MapHeld;
+
+        if (map != null)
+        {
+            this.PrepareAssassinationEvacuationShuttle(map, imperialSurvivors, assassin, empire);
+        }
+
+        this.SchedulePlanetkiller(EmperorDeathPlanetkillerTicks);
+        this.ApplyAssassinationTrustBreak(empire, assassin);
+    }
+
+    private void ApplyHuntedAssassinHediff(Pawn assassin)
+    {
+        if (assassin?.health?.hediffSet == null)
+        {
+            return;
+        }
+
+        HediffDef def = HuntedAssassinDefOf.HuntedAssassin
+            ?? DefDatabase<HediffDef>.GetNamedSilentFail("HuntedAssassin");
+        if (def == null)
+        {
+            Log.Warning("[CryoRegenesis] HuntedAssassin HediffDef not found.");
+            return;
+        }
+
+        if (!assassin.health.hediffSet.HasHediff(def))
+        {
+            assassin.health.AddHediff(def);
+        }
+    }
+
+    private void ShowKeepWhatYouKillAssassinationDialog(Pawn assassin, Faction empire)
+    {
+        string title = EmpireTitleLabelFor(assassin, empire);
+        string fullName = assassin.Name?.ToStringFull
+            ?? assassin.Name?.ToStringShort
+            ?? assassin.LabelCap;
+        string pronoun = GenderedPronoun(assassin);
+        string possessive = GenderedPossessive(assassin);
+
+        string body =
+            title + " " + fullName + " has just assassinated The Emperor!\n\n"
+            + "Per The Empire's \"Keep What You Kill\" system of Imperial Succession, "
+            + title + " " + fullName + " has now been implanted with \"Hunted Assassin\" "
+            + "subspace tracker nanites: No matter where " + pronoun
+            + " goes in the entire Galaxy, they will be tracked by mercenaries seeking to "
+            + "become Emperor themselves!\n\n"
+            + "After 60 days of survival, " + title + " " + fullName
+            + " will be able to claim " + possessive + " proper place on the Imperial Throne.\n\n"
+            + title + " " + fullName + " must board the Imperial shuttle and leave this world "
+            + "before the Planetkiller strikes. Free colonists and pets may flee with "
+            + GenderedObjectPronoun(assassin) + ".";
+
+        Find.TickManager.Pause();
+        Find.WindowStack.Add(new Dialog_MessageBox(
+            body,
+            "OK".Translate(),
+            null,
+            null,
+            null,
+            "Keep What You Kill"));
+    }
+
+    /// Spawn/reuse the Imperial pickup: force-load Imperial guests, require the assassin,
+    /// leave Send under player control so companions and pets can board first.
+    private void PrepareAssassinationEvacuationShuttle(
+        Map map,
+        List<Pawn> imperialSurvivors,
+        Pawn assassin,
+        Faction faction)
+    {
+        if (map == null || assassin == null)
+        {
+            return;
+        }
+
+        List<Pawn> guests = (imperialSurvivors ?? new List<Pawn>())
+            .Where(p => p != null && !p.Destroyed && !p.Dead)
+            .Distinct()
+            .ToList();
+
+        this.EjectClientsFromCaskets(map, guests.Concat(new[] { assassin }).ToList());
+
+        List<Pawn> shuttleParty = guests.Concat(new[] { assassin }).Distinct().ToList();
+        if (!this.pickupShuttleSpawned || this.GetUsableContractShuttle(map) == null)
+        {
+            this.SpawnPickupShuttle(map, shuttleParty, faction, longStay: true);
+        }
+
+        Thing shuttle = this.GetUsableContractShuttle(map) ?? this.GetContractShuttleThing();
+        CompShuttle comp = shuttle?.TryGetComp<CompShuttle>();
+        CompTransporter transporter = shuttle?.TryGetComp<CompTransporter>();
+        if (comp != null)
+        {
+            this.ConfigureContractShuttleEmbarkRules(comp);
+            // Assassin is required to leave; guests should leave with the ship when possible.
+            comp.requiredPawns.Clear();
+            comp.requiredPawns.Add(assassin);
+            foreach (Pawn guest in guests)
+            {
+                if (!comp.requiredPawns.Contains(guest))
+                {
+                    comp.requiredPawns.Add(guest);
+                }
+            }
+
+#if RIMWORLD12
+            // Player must press Send after boarding companions — do not auto-leave early.
+            comp.leaveImmediatelyWhenSatisfied = false;
+#endif
+        }
+
+#if !RIMWORLD12
+        if (this.contractTransportShip != null
+            && this.contractTransportShip.curJob is ShipJob_Wait waitJob)
+        {
+            waitJob.leaveImmediatelyWhenSatisfied = false;
+            waitJob.showGizmos = true;
+        }
+#endif
+
+        // Stuff Imperial guests only — the assassin and free colonists board themselves.
+        if (transporter != null)
+        {
+            foreach (Pawn pawn in guests)
+            {
+                if (transporter.innerContainer.Contains(pawn))
+                {
+                    continue;
+                }
+
+                if (pawn.Spawned)
+                {
+                    pawn.DeSpawn();
+                }
+
+                if (!pawn.Destroyed && !transporter.innerContainer.Contains(pawn))
+                {
+                    transporter.innerContainer.TryAddOrTransfer(pawn, false);
+                }
+            }
+        }
+
+        this.pickupShuttleSpawned = true;
+        this.LogRoyaltyDebug(
+            "Assassination evacuation shuttle ready. Required assassin="
+            + assassin.LabelShort + " imperialGuests=" + guests.Count + ".");
+    }
+
+    /// Trust is broken by the Emperor's murder, but the evacuation shuttle and assassin
+    /// state remain until the ship leaves (or the world dies).
+    private void ApplyAssassinationTrustBreak(Faction empire, Pawn assassin)
+    {
+        this.EndActiveContractQuest(QuestEndOutcome.Fail, sendLetter: false);
+
+        this.ClearContractFlags(this.activeClients);
+        this.activeClients.Clear();
+        this.contractEscorts.Clear();
+        // Keep contract shuttle / pickup flags for the evacuation window.
+        this.contractStartTick = -1;
+        this.contractDeadlineTick = -1;
+        this.pickupWindowEndTick = -1;
+        this.pickupAllClientsReady = false;
+        this.contractCompletionLogged = false;
+        this.clientsHaveArrived = false;
+        this.departureSuccessBanked = false;
+        this.nextWavePickupTick = -1;
+        this.clientsSuccessfullyReturned = 0;
+        this.returnedClientPawnIds.Clear();
+        this.emperorNobleRequirementAnnounced = false;
+        this.ResetCompletionRewardState();
+
+        this.trustBreaks++;
+        this.lastTrustBreakReason = "Emperor assassinated under contract";
+        this.rulerContractsCompleted = 0;
+        this.leaderContractsCompleted = 0;
+        this.nobleContractsCompleted = 0;
+        this.royalAscentTriggered = false;
+        this.activeContractStage = RoyaltyRegenesisStage.NotStarted;
+        this.stage = RoyaltyRegenesisStage.RulerPrisoners;
+        this.nextEventTick = Find.TickManager.TicksGame
+            + Rand.RangeInclusive(MajorResetMinDays, MajorResetMaxDays) * GenDate.TicksPerDay;
+
+        if (empire != null && empire != Faction.OfPlayer)
+        {
+            this.ApplyTrustBreakGoodwillPenalty(empire);
+        }
+
+        this.EnsureChainQuest();
+        if (this.chainQuest != null && !this.chainQuest.Historical)
+        {
+            string assassinName = assassin?.Name?.ToStringShort ?? this.emperorAssassinLabel;
+            this.chainQuest.description =
+                RoyaltyRegenesisQuestFactory.BuildChainDescriptionBody()
+                + "\n\nKEEP WHAT YOU KILL: " + assassinName
+                + " assassinated the Emperor and must flee before the Planetkiller strikes.";
+        }
+    }
+
+    private void TickAssassinationEvacuation()
+    {
+        if (!this.emperorAssassinationEvacuationActive)
+        {
+            return;
+        }
+
+        // Resolve leave first — launching destroys passengers, so the assassin ref dies with the ship.
+        if (this.pickupShuttleSpawned && this.HasContractShuttleLeftMap())
+        {
+            this.ResolveAssassinationShuttleDeparture();
+            return;
+        }
+
+        Pawn assassin = this.emperorAssassin;
+        if (assassin == null || assassin.Destroyed || assassin.Dead)
+        {
+            this.LogRoyaltyDebug(
+                "Assassination evacuation aborted — assassin is dead or missing. Planetkiller stands.");
+            this.ClearAssassinationEvacuationState(clearShuttle: true);
+            return;
+        }
+
+        Map map = assassin.MapHeld ?? this.GetTargetMap();
+        if (map != null)
+        {
+            this.EnsureAssassinationShuttleRequirements(map, assassin);
+        }
+    }
+
+    private void EnsureAssassinationShuttleRequirements(Map map, Pawn assassin)
+    {
+        Thing shuttle = this.GetUsableContractShuttle(map) ?? this.GetContractShuttleThing();
+        if (shuttle == null || shuttle.Destroyed)
+        {
+            // Shuttle was lost — call another one for the assassin.
+            this.SpawnPickupShuttle(map, new List<Pawn> { assassin }, this.EmpireFaction(), longStay: true);
+            shuttle = this.GetUsableContractShuttle(map) ?? this.GetContractShuttleThing();
+        }
+
+        CompShuttle comp = shuttle?.TryGetComp<CompShuttle>();
+        if (comp == null)
+        {
+            return;
+        }
+
+        this.ConfigureContractShuttleEmbarkRules(comp);
+        if (!comp.requiredPawns.Contains(assassin))
+        {
+            comp.requiredPawns.RemoveAll(p => p == null || p.Destroyed || p.Dead);
+            if (!comp.requiredPawns.Contains(assassin))
+            {
+                comp.requiredPawns.Add(assassin);
+            }
+        }
+
+#if !RIMWORLD12
+        if (this.contractTransportShip != null
+            && this.contractTransportShip.curJob is ShipJob_Wait waitJob)
+        {
+            waitJob.leaveImmediatelyWhenSatisfied = false;
+            waitJob.showGizmos = true;
+        }
+#endif
+    }
+
+    private void ResolveAssassinationShuttleDeparture()
+    {
+        if (!this.emperorAssassinationEvacuationActive)
+        {
+            return;
+        }
+
+        bool assassinEscaped = this.emperorShuttleColonistEscapeeLabels != null
+            && this.emperorShuttleColonistEscapeeLabels.Any(label =>
+                !label.NullOrEmpty()
+                && (string.Equals(label, this.emperorAssassin?.LabelCap, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(label, this.emperorAssassinLabel, StringComparison.OrdinalIgnoreCase)
+                    || (!this.emperorAssassinLabel.NullOrEmpty()
+                        && label.IndexOf(this.emperorAssassinLabel, StringComparison.OrdinalIgnoreCase) >= 0)));
+
+        // Also trust a still-alive assassin no longer map-held (left with the ship).
+        if (!assassinEscaped
+            && this.emperorAssassin != null
+            && !this.emperorAssassin.Destroyed
+            && !this.emperorAssassin.Dead
+            && !this.IsClientAvailableOnMap(this.emperorAssassin))
+        {
+            assassinEscaped = true;
+        }
+
+        if (assassinEscaped)
+        {
+            this.TriggerYouKeepWhatYouKillAssassinationEndgame("shuttle left with assassin");
+        }
+        else
+        {
+            this.LogRoyaltyDebug(
+                "Assassination shuttle left without the assassin — no Keep What You Kill escape ending.");
+            Find.LetterStack.ReceiveLetter(
+                "Left behind",
+                "The Imperial shuttle departed without the Emperor's assassin. "
+                + "The Planetkiller will finish what the Empire started.",
+                LetterDefOf.NegativeEvent);
+            this.ClearAssassinationEvacuationState(clearShuttle: true);
+        }
+    }
+
+    /// Victory: the hunted assassin escaped the Planetkiller on the Imperial shuttle.
+    private void TriggerYouKeepWhatYouKillAssassinationEndgame(string reason)
+    {
+        if (this.emperorColonistEndgameTriggered)
+        {
+            this.ClearAssassinationEvacuationState(clearShuttle: true);
+            return;
+        }
+
+        if (ShipCountdown.CountingDown)
+        {
+            return;
+        }
+
+        this.emperorColonistEndgameTriggered = true;
+        Pawn assassin = this.emperorAssassin;
+        Faction empire = this.EmpireFaction();
+        string title = EmpireTitleLabelFor(assassin, empire);
+        string name = assassin != null && !assassin.Destroyed
+            ? (assassin.Name?.ToStringShort ?? assassin.LabelShort)
+            : (this.emperorAssassinLabel.NullOrEmpty() ? "your assassin" : this.emperorAssassinLabel);
+        string possessive = GenderedPossessive(assassin);
+
+        this.LogRoyaltyDebug(
+            "You Keep What You Kill assassination endgame: " + title + " " + name
+            + " (" + reason + ").");
+
+        StringBuilder escapees = new StringBuilder();
+        if (assassin != null && !assassin.Destroyed)
+        {
+            escapees.AppendLine("   " + assassin.LabelCap);
+        }
+        else if (!this.emperorAssassinLabel.NullOrEmpty())
+        {
+            escapees.AppendLine("   " + this.emperorAssassinLabel);
+        }
+
+        if (this.emperorShuttleColonistEscapeeLabels != null)
+        {
+            foreach (string label in this.emperorShuttleColonistEscapeeLabels)
+            {
+                if (label.NullOrEmpty())
+                {
+                    continue;
+                }
+
+                // Skip the assassin under either LabelCap or the snapshotted full name so
+                // they are not listed twice when those strings differ.
+                if (assassin != null
+                    && string.Equals(label, assassin.LabelCap, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!this.emperorAssassinLabel.NullOrEmpty()
+                    && string.Equals(label, this.emperorAssassinLabel, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                escapees.AppendLine("   " + label);
+            }
+        }
+
+        if (Find.StoryWatcher?.statsRecord != null)
+        {
+            // Labels may include colony pets for credits; only humanlikes count as launched colonists.
+            int launched = Math.Max(1, this.emperorAssassinationHumanEscapeeCount);
+            Find.StoryWatcher.statsRecord.colonistsLaunched += launched;
+        }
+
+        string intro = "You Keep What You Kill.\n\n";
+        string ending =
+            title + " " + name + " struck down the Emperor and fled the Planetkiller on the "
+            + "Imperial shuttle, bearing the Hunted Assassin mark.\n\n"
+            + "In the proud tradition of The Empire — \"You Keep What You Kill\" — "
+            + possessive + " claim is written in blood and nanites. Survive sixty days under the "
+            + "hunt while the tracker nanites burn out, and the Imperial Throne is "
+            + possessive + " by right.\n\n"
+            + "The choice — and the chase — is yours.";
+
+        string credits = GameVictoryUtility.MakeEndCredits(intro, ending, escapees.ToString());
+        ShipCountdown.InitiateCountdown(credits);
+
+        this.stage = RoyaltyRegenesisStage.Completed;
+        this.royalAscentTriggered = true;
+        this.CompleteChainQuest();
+        this.ClearAssassinationEvacuationState(clearShuttle: true);
+    }
+
+    private void ClearAssassinationEvacuationState(bool clearShuttle)
+    {
+        this.emperorAssassinationEvacuationActive = false;
+        this.emperorAssassin = null;
+        // Keep assassin label for any late credits resolution.
+        if (clearShuttle)
+        {
+            this.ClearContractShuttle();
+            this.pickupShuttleSpawned = false;
+            this.pickupShuttleSpawnTick = -1;
+        }
+    }
+
+    /// Whether a pawn may board the assassination evacuation shuttle (colonists, assassin, pets).
+    public bool MayBoardAssassinationEvacuationShuttle(Pawn pawn)
+    {
+        if (!this.emperorAssassinationEvacuationActive || pawn == null || pawn.Destroyed || pawn.Dead)
+        {
+            return false;
+        }
+
+        if (pawn == this.emperorAssassin)
+        {
+            return true;
+        }
+
+        if (this.IsFreeColonyColonistForEmperorEndgame(pawn))
+        {
+            return true;
+        }
+
+        // Colony pets and other player animals.
+        if (pawn.Faction == Faction.OfPlayer && pawn.RaceProps != null && pawn.RaceProps.Animal)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     /// Board surviving contract guests and force the pickup to leave as soon as possible.

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -123,6 +123,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     private Pawn emperorCourtHonoree;
     private string emperorCourtHonoreeLabel = string.Empty;
 
+    /// Planetkiller duration after the Emperor is murdered under contract (2 days).
+    private const int EmperorDeathPlanetkillerTicks = 60_000 * 2;
+
     /// Last logged state of the Imperial shuttle's colonist door (log-only, not saved).
     private bool? emperorColonistBoardingOpen;
 
@@ -1350,7 +1353,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.UpdateClientsArrivedFlag();
 
         // Death always hard-resets trust (before shuttle-leave accounting, which may
-        // destroy boarding passengers).
+        // destroy boarding passengers) — except Emperor murder, which arms a Planetkiller.
         if (this.activeClients.Any(client => client.pawn != null && client.pawn.Dead))
         {
             RoyaltyRegenesisClient deadClient = this.activeClients
@@ -1358,6 +1361,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             Pawn dead = deadClient.pawn;
             Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction
                 ?? deadClient.sourceFaction;
+
+            if (this.activeContractStage == RoyaltyRegenesisStage.EmperorArrival
+                && deadClient?.pawn == this.emperor)
+            {
+                this.HandleEmperorDeathEndgame(dead, sender);
+                return;
+            }
 
             List<Pawn> survivors = this.activeClients
                 .Where(client => client.pawn != null && !client.pawn.Dead)
@@ -2847,6 +2857,155 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             + "The Empire recognizes a new Emperor among your Counts.",
             LetterDefOf.PositiveEvent,
             emperorPawn != null ? new LookTargets(emperorPawn) : null);
+    }
+
+    /// Branch 2: the Emperor died under contract — survivors evacuate immediately and a
+    /// Planetkiller is armed for two days. Trust is destroyed.
+    private void HandleEmperorDeathEndgame(Pawn emperor, Faction empire)
+    {
+        if (this.emperorColonistEndgameTriggered)
+        {
+            return;
+        }
+
+        this.emperorColonistEndgameTriggered = true;
+        this.LogRoyaltyDebug(
+            "Emperor death endgame: " + (emperor?.Name?.ToStringShort ?? "?")
+            + " — arming Planetkiller and evacuating survivors.");
+
+        List<Pawn> survivors = this.activeClients
+            .Where(c => c?.pawn != null && !c.pawn.Dead && !c.pawn.Destroyed)
+            .Select(c => c.pawn)
+            .Concat(this.contractEscorts.Where(p => p != null && !p.Dead && !p.Destroyed))
+            .Distinct()
+            .ToList();
+
+        Map map = survivors.FirstOrDefault(p => p.MapHeld != null)?.MapHeld
+            ?? this.GetTargetMap()
+            ?? emperor?.MapHeld;
+
+        if (map != null && survivors.Any())
+        {
+            // Eject anyone still in caskets and force an immediate imperial evacuation.
+            this.ForceImmediateImperialEvacuation(map, survivors, empire ?? this.EmpireFaction());
+        }
+
+        this.SchedulePlanetkiller(EmperorDeathPlanetkillerTicks);
+
+        string emperorName = emperor?.Name?.ToStringShort ?? "The Emperor";
+        this.MajorTrustReset(
+            emperorName + " has been killed under a CryoRegenesis contract. "
+            + "The Imperial party flees at once. The Empire's answer is final: "
+            + "a Planetkiller has been armed — this world ends in two days.\n\n"
+            + "Trust is shattered. The Imperial Rejuvenation chain restarts from the beginning.",
+            empire ?? this.EmpireFaction(),
+            "Emperor killed under contract");
+    }
+
+    /// Board surviving contract guests and force the pickup to leave as soon as possible.
+    private void ForceImmediateImperialEvacuation(Map map, List<Pawn> survivors, Faction faction)
+    {
+        if (map == null || survivors == null || !survivors.Any())
+        {
+            return;
+        }
+
+        List<Pawn> living = survivors
+            .Where(p => p != null && !p.Destroyed && !p.Dead)
+            .Distinct()
+            .ToList();
+        if (!living.Any())
+        {
+            return;
+        }
+
+        this.EjectClientsFromCaskets(map, living);
+
+        // Spawn / reuse a short-stay pickup and require every survivor.
+        if (!this.pickupShuttleSpawned || this.GetUsableContractShuttle(map) == null)
+        {
+            this.SpawnPickupShuttle(map, living, faction, longStay: false);
+        }
+
+        Thing shuttle = this.GetUsableContractShuttle(map) ?? this.GetContractShuttleThing();
+        CompShuttle comp = shuttle?.TryGetComp<CompShuttle>();
+        CompTransporter transporter = shuttle?.TryGetComp<CompTransporter>();
+        if (comp != null)
+        {
+            comp.requiredPawns.Clear();
+            comp.requiredPawns.AddRange(living);
+            this.ConfigureContractShuttleEmbarkRules(comp);
+#if RIMWORLD12
+            comp.leaveImmediatelyWhenSatisfied = true;
+            comp.leaveAfterTicks = GenDate.TicksPerHour;
+#endif
+        }
+
+#if !RIMWORLD12
+        if (this.contractTransportShip != null
+            && this.contractTransportShip.curJob is ShipJob_Wait waitJob)
+        {
+            waitJob.leaveImmediatelyWhenSatisfied = true;
+            waitJob.showGizmos = true;
+        }
+#endif
+
+        // Stuff survivors into the ship immediately so leave-when-satisfied can fire.
+        if (transporter != null)
+        {
+            foreach (Pawn pawn in living)
+            {
+                if (transporter.innerContainer.Contains(pawn))
+                {
+                    continue;
+                }
+
+                if (pawn.Spawned)
+                {
+                    pawn.DeSpawn();
+                }
+
+                if (!pawn.Destroyed && !transporter.innerContainer.Contains(pawn))
+                {
+                    transporter.innerContainer.TryAddOrTransfer(pawn, false);
+                }
+            }
+        }
+
+        this.TryPromoteParkedShuttleToLeaveWhenReady();
+        this.LogRoyaltyDebug(
+            "Forced immediate imperial evacuation for " + living.Count + " survivor(s).");
+    }
+
+    private void SchedulePlanetkiller(int durationTicks)
+    {
+        GameConditionDef planetKillerDef = DefDatabase<GameConditionDef>.GetNamedSilentFail("Planetkiller");
+        if (planetKillerDef == null)
+        {
+            Log.Warning("[CryoRegenesis] Planetkiller GameConditionDef not found.");
+            return;
+        }
+
+        // Avoid stacking multiple Planetkillers if one is already running.
+        if (Find.World?.GameConditionManager != null
+            && Find.World.GameConditionManager.ConditionIsActive(planetKillerDef))
+        {
+            this.LogRoyaltyDebug("Planetkiller already active — not re-registering.");
+            return;
+        }
+
+        GameCondition planetKillerCondition = GameConditionMaker.MakeCondition(
+            planetKillerDef,
+            durationTicks);
+        Find.World.GameConditionManager.RegisterCondition(planetKillerCondition);
+        this.LogRoyaltyDebug("Planetkiller registered for " + durationTicks + " ticks.");
+
+        Find.LetterStack.ReceiveLetter(
+            "Planetkiller armed",
+            "Imperial retaliation has armed a Planetkiller. This world will be destroyed in "
+            + (durationTicks / (float)GenDate.TicksPerDay).ToString("0.#")
+            + " day(s). Evacuate if you can.",
+            LetterDefOf.ThreatBig);
     }
 
     /// Branch 3: free colonists left on the Emperor pickup *with* the Emperor → Imperial Court.

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -3406,13 +3406,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
 
         this.ConfigureContractShuttleEmbarkRules(comp);
+        // Always drop dead/destroyed guests. A required assassin still on the list used to
+        // skip this, leaving stale refs that keep AllRequiredThingsLoaded false forever.
+        comp.requiredPawns.RemoveAll(p => p == null || p.Destroyed || p.Dead);
         if (!comp.requiredPawns.Contains(assassin))
         {
-            comp.requiredPawns.RemoveAll(p => p == null || p.Destroyed || p.Dead);
-            if (!comp.requiredPawns.Contains(assassin))
-            {
-                comp.requiredPawns.Add(assassin);
-            }
+            comp.requiredPawns.Add(assassin);
         }
 
 #if !RIMWORLD12

--- a/Source/RoyaltyRegenesisQuestSystem.cs
+++ b/Source/RoyaltyRegenesisQuestSystem.cs
@@ -110,8 +110,21 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// container contents) can still fire the Imperial Court endgame.
     private List<string> emperorShuttleColonistEscapeeLabels = new List<string>();
 
-    /// True once the Imperial Court endgame countdown has been started for this run.
+    /// True once any Emperor-stage victory/defeat endgame has been started for this run.
     private bool emperorColonistEndgameTriggered;
+
+    /// Colonist elevated to Special Consul when the party leaves with the Emperor: the
+    /// highest-ranked passenger, and among equal ranks the one holding the most Honor.
+    private Pawn emperorCourtHonoree;
+    private string emperorCourtHonoreeLabel = string.Empty;
+
+    /// Last logged state of the Imperial shuttle's colonist door (log-only, not saved).
+    private bool? emperorColonistBoardingOpen;
+
+    /// True once this pickup has told the player which archons must board.
+    private bool emperorNobleRequirementAnnounced;
+
+    private Pawn emperor;
 
     public RoyaltyRegenesisQuestSystem(Game game)
     {
@@ -158,8 +171,9 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
     /// Whether a pawn may board a regen pickup shuttle under colony control.
     /// Active contract clients always may. Free colonists may board when they have a
-    /// non-ex DirectRelation to a client — or freely during the Emperor contract, where
-    /// departing with the Emperor can trigger the Imperial Court endgame.
+    /// non-ex DirectRelation to a client — or, during the Emperor contract, when the
+    /// Imperial shuttle is open to colonists (see
+    /// <see cref="MayColonistsBoardImperialShuttle"/>).
     public static bool MayBoardRegenPickupShuttle(Pawn pawn)
     {
         if (pawn == null || pawn.Destroyed || pawn.Dead)
@@ -178,10 +192,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return false;
         }
 
-        // Emperor pickup: any free colony colonist may leave with the Emperor.
+        // Emperor pickup: free colony colonists may leave with the Imperial shuttle, but only
+        // while the Emperor is secured and the rest of the party is done. This is the only rule
+        // for colonists during the Emperor stage — relatives of a client get no side door.
         if (system.IsEmperorRegenContractActive() && system.IsFreeColonyColonistForEmperorEndgame(pawn))
         {
-            return true;
+            return system.MayColonistsBoardImperialShuttle(out _);
         }
 
         IEnumerable<Pawn> clients = system.activeClients
@@ -231,6 +247,120 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         // Free colonists only — prisoners / slaves do not count as choosing to leave.
         return pawn.IsFreeColonist;
+    }
+
+    /// Whether the Emperor's Imperial shuttle is currently open to free colony colonists.
+    /// Any number of them (none through all of them) may leave, but only while both
+    /// conditions hold:
+    ///   1. The Emperor is alive and already inside the shuttle.
+    ///   2. Every other contracted guest is already offworld, or inside the shuttle after
+    ///      reaching their target age.
+    /// Checked live on every embark test, so the door opens the moment the last guest is
+    /// aboard and closes again if the Emperor steps out.
+    /// Escorting Stellic guards are not contracted guests and do not hold the door shut.
+    public bool MayColonistsBoardImperialShuttle(out string blockReason)
+    {
+        blockReason = null;
+        if (!this.IsEmperorRegenContractActive())
+        {
+            blockReason = "the Emperor contract is not active";
+            return false;
+        }
+
+        Pawn emperorPawn = this.GetEmperorClient()?.pawn;
+        if (emperorPawn == null || emperorPawn.Dead || emperorPawn.Destroyed)
+        {
+            blockReason = "the Emperor is not alive";
+            return false;
+        }
+
+        if (!this.IsClientAboardContractShuttle(emperorPawn))
+        {
+            blockReason = emperorPawn.LabelShort + " is not aboard the shuttle";
+            return false;
+        }
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            if (client == null || client?.pawn == this.emperor)
+            {
+                continue;
+            }
+
+            Pawn guest = client.pawn;
+            if (guest == null || guest.Destroyed)
+            {
+                // Left with an earlier wave — the shuttle destroys its cargo on leave.
+                continue;
+            }
+
+            if (guest.Dead)
+            {
+                blockReason = guest.LabelShort + " is dead";
+                return false;
+            }
+
+            if (this.IsClientAboardContractShuttle(guest))
+            {
+                if (!client.everReachedDesiredAge)
+                {
+                    blockReason = guest.LabelShort + " is aboard but has not reached their target age";
+                    return false;
+                }
+
+                continue;
+            }
+
+            // Already offworld: returned with an earlier wave, or otherwise no longer map-held.
+            if (this.WasSuccessfullyReturned(guest) || !this.IsClientAvailableOnMap(guest))
+            {
+                continue;
+            }
+
+            blockReason = guest.LabelShort + " is still on the map";
+            return false;
+        }
+
+        return true;
+    }
+
+    /// Tells the player once per pickup which archons the Imperial shuttle will not leave
+    /// without, so a locked Send is never a mystery.
+    private void AnnounceImperialNobleRequirement(List<Pawn> nobles)
+    {
+        if (this.emperorNobleRequirementAnnounced || nobles == null || !nobles.Any())
+        {
+            return;
+        }
+
+        this.emperorNobleRequirementAnnounced = true;
+        string names = string.Join(", ", nobles.Select(p => p.LabelShort));
+        this.LogRoyaltyDebug("Imperial shuttle now requires colony archon(s): " + names + ".");
+
+        Find.LetterStack.ReceiveLetter(
+            "The throne must travel",
+            "The Emperor's fate is settled, and the Empire will not leave its own nobility on a "
+            + "rimworld. The Imperial shuttle will not launch until " + names + " "
+            + (nobles.Count == 1 ? "is" : "are") + " aboard.\n\n"
+            + "Whoever is not on that shuttle when it goes is left behind for good.",
+            LetterDefOf.NeutralEvent,
+            new LookTargets(nobles[0]));
+    }
+
+    /// Logs only when the Imperial shuttle opens or closes to colonists, so the reason a
+    /// colonist is turned away at the ramp is visible without a per-tick flood.
+    private void LogImperialShuttleBoardingChanges()
+    {
+        bool open = this.MayColonistsBoardImperialShuttle(out string blockReason);
+        if (this.emperorColonistBoardingOpen == open)
+        {
+            return;
+        }
+
+        this.emperorColonistBoardingOpen = open;
+        this.LogRoyaltyDebug(open
+            ? "Imperial shuttle is now open to colonists (Emperor secured, party done)."
+            : "Imperial shuttle is closed to colonists — " + blockReason + ".");
     }
 
     /// Called by a CryoRegenesis casket on the exact tick that a pawn reaches its target.
@@ -290,6 +420,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Collections.Look(ref this.returnedClientPawnIds, "crRoyalReturnedClientPawnIds", LookMode.Value);
         Scribe_Collections.Look(ref this.emperorShuttleColonistEscapeeLabels, "crRoyalEmperorShuttleColonistEscapees", LookMode.Value);
         Scribe_Values.Look(ref this.emperorColonistEndgameTriggered, "crRoyalEmperorColonistEndgameTriggered", false);
+        Scribe_Values.Look(ref this.emperorNobleRequirementAnnounced, "crRoyalEmperorNobleRequirementAnnounced", false);
+        Scribe_References.Look(ref this.emperor, "crRoyalEmperor");
+        Scribe_References.Look(ref this.emperorCourtHonoree, "crRoyalEmperorCourtHonoree");
+        Scribe_Values.Look(ref this.emperorCourtHonoreeLabel, "crRoyalEmperorCourtHonoreeLabel");
 #if !RIMWORLD12
         Scribe_References.Look(ref this.contractTransportShip, "crRoyalContractTransportShip");
 #endif
@@ -322,10 +456,18 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
                 this.emperorShuttleColonistEscapeeLabels = new List<string>();
             }
 
+            if (this.emperorCourtHonoreeLabel == null)
+            {
+                this.emperorCourtHonoreeLabel = string.Empty;
+            }
+
             if (this.lastTrustBreakReason == null)
             {
                 this.lastTrustBreakReason = string.Empty;
             }
+
+            // Older saves do not persist the Emperor cache. Resolve it once after loading.
+            this.CacheEmperorClient();
 
             if (this.activeClients.Any())
             {
@@ -354,6 +496,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         if (this.pickupShuttleSpawned && this.IsEmperorRegenContractActive())
         {
             this.RefreshEmperorShuttleColonistSnapshot();
+            this.LogImperialShuttleBoardingChanges();
         }
 
         if (Find.TickManager.TicksGame % CheckIntervalTicks != 0)
@@ -764,6 +907,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        this.emperor = party.emperor;
         this.contractEscorts.Clear();
         int contractDays = MinContractDays;
 
@@ -950,6 +1094,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.departureSuccessBanked = false;
         this.nextWavePickupTick = -1;
         this.clientsSuccessfullyReturned = 0;
+        this.emperorNobleRequirementAnnounced = false;
         this.returnedClientPawnIds.Clear();
         this.contractEscorts.Clear();
         // Keep escapee labels / endgame flag across Clear during finish so a late
@@ -1191,8 +1336,12 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         // destroy boarding passengers).
         if (this.activeClients.Any(client => client.pawn != null && client.pawn.Dead))
         {
-            Pawn dead = this.activeClients.First(client => client.pawn != null && client.pawn.Dead).pawn;
-            Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction;
+            RoyaltyRegenesisClient deadClient = this.activeClients
+                .First(client => client.pawn != null && client.pawn.Dead);
+            Pawn dead = deadClient.pawn;
+            Faction sender = this.activeClients.FirstOrDefault()?.sourceFaction
+                ?? deadClient.sourceFaction;
+
             List<Pawn> survivors = this.activeClients
                 .Where(client => client.pawn != null && !client.pawn.Dead)
                 .Select(client => client.pawn)
@@ -1321,8 +1470,10 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         if (this.pickupShuttleSpawned)
         {
             // Long-stay pickup on the pad: only auto-leave when remaining clients are all ready
-            // or the deadline forces a last call.
-            if (allDone || deadlineReached)
+            // or the deadline forces a last call. The Emperor pickup is the exception — colonists
+            // may only board once he is aboard, so auto-leaving the instant he loads would slam
+            // the door on them. The player presses Send there; the deadline is still the backstop.
+            if (deadlineReached || (allDone && !this.IsEmperorRegenContractActive()))
             {
                 this.TryPromoteParkedShuttleToLeaveWhenReady();
             }
@@ -1463,10 +1614,6 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.RefreshClientAgeProgress();
         this.LogClientAgeSnapshot("shuttle left");
 
-        // Emperor pickup with any free colonist aboard → Imperial Court victory ending.
-        // Snapshot was taken while the ship was still loaded; do this before clearing state.
-        this.TryTriggerEmperorColonistEndgameFromSnapshot("shuttle left");
-
         List<RoyaltyRegenesisClient> remaining = new List<RoyaltyRegenesisClient>();
         List<RoyaltyRegenesisClient> departed = new List<RoyaltyRegenesisClient>();
 
@@ -1489,6 +1636,24 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             }
         }
 
+        // Emperor-stage Imperial Court ending (before partial-wave bookkeeping can soft-continue).
+        if (this.activeContractStage == RoyaltyRegenesisStage.EmperorArrival
+            && !this.emperorColonistEndgameTriggered)
+        {
+            // Free colonists left *with* the Emperor (he must have departed too).
+            if (departed.Any(client => client?.pawn == this.emperor))
+            {
+                this.TryTriggerEmperorColonistEndgameFromSnapshot("shuttle left with Emperor");
+            }
+            else if (this.emperorShuttleColonistEscapeeLabels != null
+                     && this.emperorShuttleColonistEscapeeLabels.Any())
+            {
+                this.LogRoyaltyDebug(
+                    "Free colonists left without the Emperor — no Imperial Court victory.");
+            }
+        }
+
+        // Fail the contract if any passenger left before reaching the contracted age.
         RoyaltyRegenesisClient unfinishedDeparture = departed
             .FirstOrDefault(c => c != null && !c.everReachedDesiredAge);
         if (unfinishedDeparture != null)
@@ -1825,6 +1990,17 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             required = this.GetMapHeldContractPawns().Concat(this.GetMapHeldEscorts()).Distinct().ToList();
         }
 
+        // Once the Emperor is regenerated, every archon on this map must leave on the Imperial
+        // shuttle with him. They are ejected from caskets so they can actually board; nobody off
+        // this map is fetched.
+        List<Pawn> nobles = this.GetRequiredImperialNobleColonists(shuttle);
+        if (nobles.Any())
+        {
+            this.EjectClientsFromCaskets(shuttle.MapHeld ?? map, nobles);
+            required = required.Concat(nobles).Distinct().ToList();
+            this.AnnounceImperialNobleRequirement(nobles);
+        }
+
         // Drop stale/world/returned refs that would keep AllRequiredThingsLoaded false forever.
         HashSet<Pawn> requiredSet = new HashSet<Pawn>(required);
         bool changed = compShuttle.requiredPawns.Count != required.Count
@@ -1863,7 +2039,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             "Updated shuttle requiredPawns to " + required.Count
             + (ready.Any() && readyOnlyIfAnyReady
                 ? " ready-only (Send once these are aboard; all contract guests may embark)."
-                : " map-held (nobody ready yet)."));
+                : " map-held (nobody ready yet).")
+            + (nobles.Any() ? " Required archon(s): " + string.Join(", ", nobles.Select(p => p.LabelShort)) + "." : string.Empty));
     }
 
     /// Ready contract clients that should count toward the shuttle manifest: still on the
@@ -2009,7 +2186,75 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        this.CaptureFreeColonistsFromTransporter(shuttleComp.Transporter);
+        CompTransporter transporter = shuttleComp.Transporter;
+
+        // Boarding conditions can be undone after colonists board — the Emperor or a guest
+        // carried back out. They must never fly off (and be destroyed with the cargo) without
+        // the ending they boarded for.
+        if (!this.MayColonistsBoardImperialShuttle(out string blockReason))
+        {
+            this.PutColonistsBackOnMapBeforeLaunch(transporter, blockReason);
+        }
+
+        this.CaptureFreeColonistsFromTransporter(transporter);
+        this.RefreshEmperorEndgameCandidates(transporter);
+    }
+
+    /// Unloads free colony colonists from the Imperial shuttle just before it launches when
+    /// the boarding conditions no longer hold. Contract guests and escorts still leave.
+    private void PutColonistsBackOnMapBeforeLaunch(CompTransporter transporter, string blockReason)
+    {
+        Thing shuttle = transporter?.parent;
+        if (transporter?.innerContainer == null || shuttle == null)
+        {
+            return;
+        }
+
+        Map map = shuttle.MapHeld ?? this.GetTargetMap();
+        if (map == null)
+        {
+            return;
+        }
+
+        List<Pawn> colonists = transporter.innerContainer
+            .OfType<Pawn>()
+            .Where(this.IsFreeColonyColonistForEmperorEndgame)
+            .ToList();
+        if (!colonists.Any())
+        {
+            return;
+        }
+
+        IntVec3 dropCell = shuttle.PositionHeld;
+        List<Pawn> unloaded = new List<Pawn>();
+        foreach (Pawn colonist in colonists)
+        {
+            if (transporter.innerContainer.TryDrop(
+                    colonist,
+                    dropCell,
+                    map,
+                    ThingPlaceMode.Near,
+                    out Thing _))
+            {
+                unloaded.Add(colonist);
+            }
+        }
+
+        if (!unloaded.Any())
+        {
+            return;
+        }
+
+        this.LogRoyaltyDebug(
+            "Unloaded " + unloaded.Count + " colonist(s) before Imperial shuttle launch — "
+            + blockReason + ": " + string.Join(", ", unloaded.Select(p => p.LabelShort)));
+
+        Find.LetterStack.ReceiveLetter(
+            "Turned away at the ramp",
+            "The Imperial shuttle refused to carry your colonists because " + blockReason
+            + ". They were put off the ship before it launched.",
+            LetterDefOf.NegativeEvent,
+            new LookTargets(unloaded[0]));
     }
 
     /// While the Emperor pickup is parked, record free colony colonists currently aboard.
@@ -2027,7 +2272,15 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
-        this.CaptureFreeColonistsFromTransporter(shuttle.TryGetComp<CompTransporter>());
+        CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
+        this.CaptureFreeColonistsFromTransporter(transporter);
+
+        // Picking the heir scans the map, so do it once a second rather than every tick.
+        // The launch prefix refreshes it again, which covers same-tick board-and-launch.
+        if (Find.TickManager.TicksGame % 60 == 0)
+        {
+            this.RefreshEmperorEndgameCandidates(transporter);
+        }
     }
 
     private void CaptureFreeColonistsFromTransporter(CompTransporter transporter)
@@ -2053,7 +2306,229 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         }
     }
 
-    /// If any free colonist left on the Emperor pickup, start the Imperial Court endgame.
+    /// Resolves the Emperor once and caches his pawn for all later identity checks.
+    private void CacheEmperorClient()
+    {
+        if (this.emperor != null || this.activeClients == null)
+        {
+            return;
+        }
+
+        RoyaltyRegenesisClient emperorClient = this.activeClients.FirstOrDefault(client =>
+            client != null
+            && (client.triggerRoyalAscent
+                || (!client.role.NullOrEmpty()
+                    && string.Equals(client.role, "emperor", StringComparison.OrdinalIgnoreCase))));
+
+        this.emperor = emperorClient?.pawn;
+    }
+
+    private RoyaltyRegenesisClient GetEmperorClient()
+    {
+        return this.emperor == null
+            ? null
+            : this.activeClients?.FirstOrDefault(client => client?.pawn == this.emperor);
+    }
+
+    /// True when the living Emperor is still map-reachable (spawned or in a casket).
+    private bool IsEmperorStillAvailableOnMap()
+    {
+        RoyaltyRegenesisClient emperor = this.GetEmperorClient();
+        return emperor?.pawn != null && this.IsClientAvailableOnMap(emperor.pawn);
+    }
+
+    /// The Empire's archon rank. The defName is "Count" in every supported version; only the
+    /// display label changed — "count"/"countess" before 1.6, "archon" from 1.6 on.
+    private static RoyalTitleDef ArchonTitleDef()
+    {
+        return DefDatabase<RoyalTitleDef>.GetNamedSilentFail("Count");
+    }
+
+    /// A free colonist holding at least the archon rank. More senior colony titles (dominus,
+    /// consul) qualify as well. Once the Emperor is regenerated, these nobles must board.
+    private bool IsImperialNobleColonist(Pawn pawn)
+    {
+        if (pawn == null || pawn.Dead || pawn.Destroyed || pawn.royalty == null)
+        {
+            return false;
+        }
+
+        if (!this.IsFreeColonyColonistForEmperorEndgame(pawn))
+        {
+            return false;
+        }
+
+        Faction empire = this.EmpireFaction();
+        RoyalTitleDef archon = ArchonTitleDef();
+        if (empire == null || archon == null)
+        {
+            return false;
+        }
+
+        RoyalTitleDef title = pawn.royalty.GetCurrentTitle(empire);
+        return title != null && title.seniority >= archon.seniority;
+    }
+
+    /// Every throne-eligible colonist on the shuttle's map: walking around, inside a casket, or
+    /// already aboard. Nobody off this map is counted — like any ship launch, whoever is not on
+    /// the shuttle when it goes is left behind.
+    private List<Pawn> GetImperialNobleColonists(Thing shuttle)
+    {
+        List<Pawn> nobles = new List<Pawn>();
+        Map map = shuttle?.MapHeld ?? this.GetTargetMap();
+        if (map != null)
+        {
+            foreach (Pawn pawn in map.mapPawns.AllPawns)
+            {
+                if (this.IsImperialNobleColonist(pawn))
+                {
+                    nobles.Add(pawn);
+                }
+            }
+
+            // Casket contents are not always listed among map pawns.
+            foreach (Building_CryoRegenesis casket in
+                map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>())
+            {
+                if (casket.ContainedThing is Pawn contained && this.IsImperialNobleColonist(contained))
+                {
+                    nobles.Add(contained);
+                }
+            }
+        }
+
+        CompTransporter transporter = shuttle?.TryGetComp<CompTransporter>();
+        if (transporter?.innerContainer != null)
+        {
+            foreach (Thing thing in transporter.innerContainer)
+            {
+                if (thing is Pawn aboard && this.IsImperialNobleColonist(aboard))
+                {
+                    nobles.Add(aboard);
+                }
+            }
+        }
+
+        return nobles.Distinct().ToList();
+    }
+
+    /// Throne-eligible colonists who must be aboard before the Imperial shuttle may launch.
+    /// Empty until the Emperor is regenerated — earlier waves must not drag nobility along.
+    private List<Pawn> GetRequiredImperialNobleColonists(Thing shuttle)
+    {
+        if (!this.IsEmperorRegenContractActive() || !this.IsEmperorRegenerated())
+        {
+            return new List<Pawn>();
+        }
+
+        return this.GetImperialNobleColonists(shuttle);
+    }
+
+    /// True once the Emperor is alive and fully regenerated. From that moment the colony's
+    /// archons leave on the Imperial shuttle at his side.
+    private bool IsEmperorRegenerated()
+    {
+        RoyaltyRegenesisClient emperor = this.GetEmperorClient();
+        Pawn pawn = emperor?.pawn;
+        if (pawn == null || pawn.Dead || pawn.Destroyed)
+        {
+            return false;
+        }
+
+        return emperor.everReachedDesiredAge;
+    }
+
+    /// Empire rank of a colonist for endgame selection; 0 when untitled.
+    private int ImperialSeniorityOf(Pawn pawn, Faction empire)
+    {
+        RoyalTitleDef title = pawn?.royalty?.GetCurrentTitle(empire);
+        return title?.seniority ?? 0;
+    }
+
+    /// Honor the colonist holds with the Empire — the tie-breaker between equal ranks.
+    private int ImperialHonorOf(Pawn pawn, Faction empire)
+    {
+        if (pawn?.royalty == null || empire == null)
+        {
+            return 0;
+        }
+
+        return pawn.royalty.GetFavor(empire);
+    }
+
+    private static IEnumerable<Pawn> PawnsAboard(CompTransporter transporter)
+    {
+        if (transporter?.innerContainer == null)
+        {
+            yield break;
+        }
+
+        foreach (Thing thing in transporter.innerContainer)
+        {
+            if (thing is Pawn pawn)
+            {
+                yield return pawn;
+            }
+        }
+    }
+
+    /// The colonist the Empire elevates at the Imperial Court ending: the highest-ranked one
+    /// aboard the shuttle, and where several share that rank, the one with the most Honor.
+    private Pawn FindImperialCourtHonoree(CompTransporter transporter)
+    {
+        Faction empire = this.EmpireFaction();
+        if (empire == null)
+        {
+            return null;
+        }
+
+        return PawnsAboard(transporter)
+            .Where(this.IsFreeColonyColonistForEmperorEndgame)
+            .OrderByDescending(p => this.ImperialSeniorityOf(p, empire))
+            .ThenByDescending(p => this.ImperialHonorOf(p, empire))
+            .FirstOrDefault();
+    }
+
+    /// The Court honoree is chosen while the shuttle is still parked, because launching it
+    /// destroys the cargo the choice is made from.
+    private void RefreshEmperorEndgameCandidates(CompTransporter transporter = null)
+    {
+        // The honoree must be aboard, so this tracks the manifest both ways — someone stepping
+        // back off the ship gives up the title.
+        Pawn honoree = this.FindImperialCourtHonoree(transporter);
+        if (honoree == this.emperorCourtHonoree)
+        {
+            return;
+        }
+
+        this.emperorCourtHonoree = honoree;
+        this.emperorCourtHonoreeLabel = honoree != null
+            ? honoree.Name?.ToStringShort ?? honoree.LabelShort
+            : string.Empty;
+
+        if (honoree != null)
+        {
+            Faction empire = this.EmpireFaction();
+            this.LogRoyaltyDebug(
+                "Imperial Court honoree is " + this.emperorCourtHonoreeLabel
+                + " (seniority=" + this.ImperialSeniorityOf(honoree, empire)
+                + " honor=" + this.ImperialHonorOf(honoree, empire) + ").");
+        }
+    }
+
+    /// Name of the colonist elevated at the Imperial Court ending. Falls back to the snapshotted
+    /// label because the launching shuttle destroys its passengers.
+    private string ResolveCourtHonoreeLabel()
+    {
+        if (this.emperorCourtHonoree != null && !this.emperorCourtHonoree.Destroyed)
+        {
+            return this.emperorCourtHonoree.Name?.ToStringShort ?? this.emperorCourtHonoree.LabelShort;
+        }
+
+        return this.emperorCourtHonoreeLabel;
+    }
+
+    /// Branch 3: free colonists left on the Emperor pickup *with* the Emperor → Imperial Court.
     private void TryTriggerEmperorColonistEndgameFromSnapshot(string reason)
     {
         if (this.emperorColonistEndgameTriggered)
@@ -2076,7 +2551,8 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         this.TriggerEmperorColonistEndgame(this.emperorShuttleColonistEscapeeLabels, reason);
     }
 
-    /// Victory ending: one or more free colonists left on the Emperor's regen pickup shuttle.
+    /// Victory ending: one or more free colonists left on the Emperor's regen pickup shuttle
+    /// while the Emperor himself also departed.
     private void TriggerEmperorColonistEndgame(List<string> escapeeLabels, string reason)
     {
         if (this.emperorColonistEndgameTriggered || escapeeLabels == null || !escapeeLabels.Any())
@@ -2110,13 +2586,25 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         string intro =
             "You've departed with the Emperor on the Imperial shuttle!";
-        string ending =
-            "The rejuvenated Emperor welcomes your colonists into the Imperial court as honored guests of the throne.\n\n"
-            + "You may remain among the Imperial flotilla, claim titles and privileges earned by your gift of CryoRegenesis, "
-            + "or purchase a ship and set a course for home.\n\n"
-            + "The choice is yours.";
+        StringBuilder ending = new StringBuilder();
+        ending.Append(
+            "The rejuvenated Emperor welcomes your colonists into the Imperial court as honored envoys of the throne.\n\n");
 
-        string credits = GameVictoryUtility.MakeEndCredits(intro, ending, escapees.ToString());
+        string honoree = this.ResolveCourtHonoreeLabel();
+        if (!honoree.NullOrEmpty())
+        {
+            ending.Append(
+                "For the gift of CryoRegenesis, the most honored of your number is raised above the rest: "
+                + honoree + " is granted the special title of Special Consul, and with it Imperial "
+                + "leadership over any rimworld they ever set foot on hereafter.\n\n");
+        }
+
+        ending.Append(
+            "You may remain among the Imperial flotilla, claim titles and privileges earned by your gift of CryoRegenesis, "
+            + "or purchase a ship and set a course for home.\n\n");
+        ending.Append("The choice is yours.");
+
+        string credits = GameVictoryUtility.MakeEndCredits(intro, ending.ToString(), escapees.ToString());
         ShipCountdown.InitiateCountdown(credits);
 
         // Completing the Emperor visit this way also finishes the Imperial Rejuvenation chain.
@@ -2291,11 +2779,13 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         RoyaltyRegenesisStage finishedStage = this.activeContractStage;
         bool triggerEndgame = this.activeClients.Any(client => client != null && client.triggerRoyalAscent);
 
-        // Safety net: if the Emperor pickup left with free colonists and we have not
-        // already started the Imperial Court ending, do so before clearing contract state.
-        if (finishedStage == RoyaltyRegenesisStage.EmperorArrival)
+        // Safety net only when the Emperor himself is no longer on the map (he left with the
+        // shuttle). Never fire Imperial Court for an abandoned Emperor.
+        if (finishedStage == RoyaltyRegenesisStage.EmperorArrival
+            && !this.emperorColonistEndgameTriggered
+            && !this.IsEmperorStillAvailableOnMap())
         {
-            this.TryTriggerEmperorColonistEndgameFromSnapshot("finish contract");
+            this.TryTriggerEmperorColonistEndgameFromSnapshot("finish contract with Emperor gone");
         }
 
         this.LogRoyaltyDebug(
@@ -2528,6 +3018,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             ? this.GetReadyPickupStayTicks()
             : ShuttleLeaveDelayDays * GenDate.TicksPerDay;
         this.pickupWindowEndTick = this.pickupShuttleSpawnTick + stayTicks;
+        this.emperorNobleRequirementAnnounced = false;
         // New boarding window — previous wave's empty/full snapshot must not carry over.
         if (!this.emperorColonistEndgameTriggered)
         {
@@ -2547,8 +3038,15 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         if (this.IsEmperorRegenContractActive())
         {
-            body += "\n\nAny colonist may board this shuttle with the Emperor. "
-                + "If even one colonist leaves with him, your story ends in victory as guests of the Imperial court.";
+            body += "\n\nAny number of your colonists may board this shuttle, but only once the "
+                + "Emperor is alive and either aboard it himself or sealed in a powered-off "
+                + "CryoRegenesis casket, and every other guest is offworld or aboard at their "
+                + "target age. Until then colonists are turned away at the ramp.\n\n"
+                + "Once the Emperor is regenerated or sealed away, every archon of your colony "
+                + "must be aboard before the shuttle will launch — and it will not leave the "
+                + "Emperor behind unless one of them is there to take his throne.\n\n"
+                + "If even one colonist leaves with the Emperor, your story ends in victory as "
+                + "guests of the Imperial court.";
         }
 
         return body;
@@ -2949,6 +3447,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     private void ClearEmperorShuttleColonistSnapshot()
     {
         this.emperorShuttleColonistEscapeeLabels?.Clear();
+        if (!this.emperorColonistEndgameTriggered)
+        {
+            this.emperorCourtHonoree = null;
+            this.emperorCourtHonoreeLabel = string.Empty;
+        }
     }
 
     private void ClearContractFlags(IEnumerable<RoyaltyRegenesisClient> clients)

--- a/Succession.md
+++ b/Succession.md
@@ -1,0 +1,224 @@
+Yes. With that fuller context, the wives’ pact stops looking like a convenient plot twist and starts looking like the **most rational move available to the Imperial court**.
+
+Your colony is no longer just a remote settlement with one miraculous machine. After twenty years, it has become the center of a private political network spanning the highest levels of the Empire.
+
+You have personally regenerated:
+
+* dozens of nobles;
+* their spouses, lovers, and heirs;
+* the Stellarch;
+* the Emperor;
+* and probably several rival branches of the aristocracy.
+
+Every one of those people owes their continued youth, restored health, or literal life to your colony.
+
+That creates an absurd concentration of soft power.
+
+## You control the only Fountain of Youth
+
+The crucial political fact is not merely that CryoRegenesis works.
+
+It is that **nobody else can reproduce it**.
+
+The Empire can threaten you, reward you, spy on you, and send scientists to inspect the machinery—but after decades, it still cannot independently provide the same service.
+
+That makes your colony less like a hospital and more like a combination of:
+
+* the only oil field in the galaxy;
+* the only legitimate mint;
+* the only institution capable of crowning rulers;
+* and the only priesthood offering physical immortality.
+
+The nobles do not simply like you. Their future depends on your continued cooperation.
+
+Even those who distrust the colony cannot afford to eliminate it casually, because destroying the secret means destroying their own chance of future regeneration.
+
+## The Stargate makes you even more dangerous
+
+From the Empire’s perspective, you are demonstrating impossible events:
+
+* messages crossing 15,000 light-years in minutes;
+* the same individuals appearing on distant worlds without decades or centuries of transit;
+* personnel and animals disappearing from one planet and reappearing elsewhere;
+* communications that ignore relativistic delay;
+* persistent identities moving between planets and campaigns.
+
+They know FTL is supposedly impossible.
+
+They know you have broken that rule.
+
+They do not know whether you possess:
+
+* one hidden device;
+* an ancient transportation network;
+* a fleet they cannot detect;
+* spatial folding;
+* wormholes;
+* duplicate bodies;
+* or some form of reality manipulation.
+
+That uncertainty magnifies your power. A known weapon can be countered. A technology whose operating principle is completely unknown becomes almost mythological.
+
+The Empire cannot even confidently answer basic strategic questions:
+
+* Where is your real capital?
+* How many colonies do you control?
+* Can you evacuate before an attack arrives?
+* Can you place agents inside Imperial territory instantly?
+* Can you transport armies?
+* Can you move the Emperor beyond Imperial reach?
+* Can you communicate with factions outside the known Empire?
+* Is the visible Stargate the whole system, or merely one terminal?
+
+From their perspective, the colony may already be operating at a technological level above the Empire.
+
+## The wives are not merely spouses
+
+Imperial spouses would almost certainly be political figures in their own right.
+
+They may represent:
+
+* noble houses;
+* military alliances;
+* succession claims;
+* heirs;
+* patronage networks;
+* religious legitimacy;
+* and personal access to the Emperor.
+
+After regeneration, they also have a personal dependency on the system that restored them.
+
+When the Emperor becomes trapped, the wives are suddenly forced to choose between two futures.
+
+### Remain loyal to the trapped Emperor
+
+This means:
+
+* abandoning the shuttle;
+* risking retaliation from the colony;
+* possibly losing access to regeneration forever;
+* admitting that the Imperial succession has catastrophically failed;
+* and remaining stranded beside a ruler who cannot currently exercise power.
+
+### Recognize the colony’s Count or Countess
+
+This preserves:
+
+* the court;
+* the shuttle;
+* access to Stargate travel;
+* access to CryoRegenesis;
+* the Imperial household;
+* personal safety;
+* political continuity;
+* and the public appearance of orderly succession.
+
+That is not romance or treachery for its own sake. It is statecraft.
+
+## The new Emperor has already performed imperial functions
+
+By the time the pact occurs, your Count has effectively spent decades doing things more consequential than most rulers ever accomplish:
+
+* maintaining relations with the highest nobility;
+* preserving the lives of Imperial elites;
+* coordinating interstellar arrivals and departures;
+* managing strategically irreplaceable resources;
+* safeguarding the Stellarch;
+* hosting the Emperor;
+* controlling unknown FTL technology;
+* and keeping secrets that could destabilize the entire civilization.
+
+At that point, the Count is already acting like a sovereign. The pact merely acknowledges the balance of power.
+
+They may not have the largest fleet—but they possess the technologies that determine who can remain alive, young, mobile, and politically relevant.
+
+## The wives may also fear whoever replaces your colony
+
+Suppose they reject the pact and return to the Empire without the Count.
+
+The next political actors might:
+
+* seize CryoRegenesis;
+* kill the witnesses;
+* monopolize the Stargate;
+* imprison the Imperial household;
+* blame the wives for the Emperor’s disappearance;
+* or install a different claimant.
+
+By making the pact immediately, the wives secure influence over the one person who actually controls the situation.
+
+They become founding members of the new regime rather than inconvenient survivors of the old one.
+
+That is a huge difference.
+
+## It also gives the new Emperor multiple forms of legitimacy
+
+The Count or Countess can claim:
+
+### Technological legitimacy
+
+They alone control the systems preserving Imperial civilization.
+
+### Aristocratic legitimacy
+
+They already hold a recognized high noble title.
+
+### Household legitimacy
+
+The Emperor’s spouses and court acknowledge them.
+
+### Administrative legitimacy
+
+They have successfully managed the Imperial regeneration program for decades.
+
+### Divine or mythic legitimacy
+
+They control youth, resurrection, and instantaneous travel.
+
+### Practical legitimacy
+
+They possess the shuttle and everyone aboard it.
+
+In a feudal interstellar empire, that is more than enough to manufacture a succession.
+
+## The old Emperor becomes politically inconvenient
+
+The trapped Emperor may remain biologically legitimate, but politically he becomes a dangerous relic.
+
+Restoring him threatens:
+
+* the new ruler;
+* the wives who made the pact;
+* the Stellarch who accepted the transition;
+* every noble who benefited from the new arrangement;
+* and anyone whose status depends on Stargate access.
+
+So over time, the conspiracy becomes self-reinforcing.
+
+The longer the new Emperor rules, the more people become invested in ensuring that the old one remains asleep.
+
+That is exactly how durable usurpations work: not because everyone believes the official story, but because too many powerful people benefit from never correcting it.
+
+## The pact is arguably the least violent option
+
+The alternatives are worse:
+
+* Kill the Emperor and trigger planetary destruction.
+* Wake him and provoke a confrontation.
+* Leave everyone stranded.
+* Begin an Imperial civil war immediately.
+* Destroy the technology and lose immortality.
+* Attempt to seize the colony by force without understanding its FTL capabilities.
+
+The pact keeps the Emperor alive, preserves the court, avoids planetary annihilation, and maintains access to both miraculous technologies.
+
+It is morally compromised, but strategically elegant.
+
+So yes: after two decades of rejuvenating the ruling class and casually demonstrating impossible interstellar communications, your Count is not some random frontier noble opportunistically stealing a crown.
+
+They are the keeper of immortality, the master of unknown FTL infrastructure, the confidant of the Imperial elite, and the only person capable of carrying the court safely into its next era.
+
+The wives are not making them Emperor out of gratitude.
+
+They are recognizing that, in every way that matters, **they already are**.
+


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Royalty-focused Imperial Regeneration quests with branching Emperor and succession endings.
  * Introduced the Hunted Assassin mark, which transfers to an eligible Knight or higher after killing its bearer and expires after approximately 60 days.
  * Added “Keep What You Kill” assassination and evacuation outcomes.
  * Improved Emperor pickup-shuttle boarding rules and victory conditions.
  * CryoRegenesis pods now function as standard cryptosleep caskets when unpowered.

* **Documentation**
  * Added guidance for Imperial quests, endings, and succession outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add branching Emperor succession and assassination endings

### What Changed
- Free colonists can leave with the living Emperor on the Imperial shuttle to trigger an Imperial Court victory, with the highest-ranked passenger named Special Consul.
- Leaving the Emperor alive in an unpowered CryoRegenesis casket can crown a Count or higher noble as the new Emperor.
- Killing the Emperor triggers immediate evacuation and a two-day Planetkiller threat; a Knight or higher colonist who dealt the killing blow can instead start a “Keep What You Kill” escape ending.
- The Hunted Assassin mark lasts 60 days and transfers to a qualified noble who kills its bearer, restarting the countdown.
- Assassination evacuation allows the assassin, free colonists, and colony pets to board, while invalid Imperial shuttle launches put colonists back on the map.
- Shuttle instructions and notifications explain boarding restrictions, required nobles, and blocked launches.

### Impact
`✅ Three distinct Emperor endgame paths`
`✅ Fewer colonists lost from invalid shuttle launches`
`✅ Clearer assassination evacuation rules`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
