### PR TITLE
Misc. fixes for the v7.x branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,9 @@
 * **[2024-03-15 00:44:12 CST]** Majorly refactored the deploy script.
 * **[2024-03-09 11:46:39 CST]** Update README.md
 * **[2023-07-29 01:43:18 GST]** Fixed a bug that prohibited animals from being put in the cryocasket.
-* **[2023-05-22 10:37:45 GST]** Version 3.0.0.
+
+## v3.0.0
+
 * **[2023-05-22 10:31:53 GST]** Block non-colonist humans from being placed in the casket.
 * **[2023-05-22 09:47:45 GST]** Added functionality to never heal implants.
 * **[2023-05-22 09:47:24 GST]** Added an option to not try to heal anything that isn't tendable.
@@ -101,7 +103,6 @@
 * **[2023-05-22 09:30:13 GST]** Added a proper Mod class.
 * **[2023-05-21 19:41:18 GST]** Update README.md: Added info about Cargo
 * **[2023-03-26 13:41:29 CEST]** Re-added more hair colors.
-
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-31 04:08:35 EEST]** [Quests] Fixed null clients during contract deadline updates.
 * **[2026-07-31 04:07:37 EEST]** [Quests] Fixed Imperial survivors during Emperor assassination escapes.
 * **[2026-07-30 17:02:39 EEST]** [Quests] Added Stargate continuity for Emperor shuttle escapees.
 * **[2026-07-27 22:21:04 EEST]** [Quests] Fixed debug campaign waits at five days to greatly cut down system testing time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-30 17:02:39 EEST]** [Quests] Added Stargate continuity for Emperor shuttle escapees.
 * **[2026-07-27 22:21:04 EEST]** [Quests] Fixed debug campaign waits at five days to greatly cut down system testing time.
 * **[2026-07-27 16:34:16 EEST]** [Quests] Prune dead guests from the evacuation manifest in Assassin end game (found by OpenAI Codex).
 * **[2026-07-27 15:25:00 EEST]** [Quests] Hunted Assassin mark now jumps to any Knight+ who kills the Marked One.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-31 04:26:38 EEST]** [Quests] Fixed an edge case that could complete untreated contracts.
 * **[2026-07-31 04:08:35 EEST]** [Quests] Fixed null clients during contract deadline updates.
 * **[2026-07-31 04:07:37 EEST]** [Quests] Fixed Imperial survivors during Emperor assassination escapes.
 * **[2026-07-30 17:02:39 EEST]** [Quests] Added Stargate continuity for Emperor shuttle escapees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+* **[2026-07-31 04:07:37 EEST]** [Quests] Fixed Imperial survivors during Emperor assassination escapes.
 * **[2026-07-30 17:02:39 EEST]** [Quests] Added Stargate continuity for Emperor shuttle escapees.
 * **[2026-07-27 22:21:04 EEST]** [Quests] Fixed debug campaign waits at five days to greatly cut down system testing time.
 * **[2026-07-27 16:34:16 EEST]** [Quests] Prune dead guests from the evacuation manifest in Assassin end game (found by OpenAI Codex).

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -293,12 +293,9 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                     {
                         refuelable.ConsumeFuel(fuelConsumption * ((pawnAge - 10) * 0.1f));
 
-                        long ageBeforeRegression = pawn.ageTracker.AgeBiologicalTicks;
-                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(ageBeforeRegression - rate, this.regenesisCycle.TargetAgeTicks);
-                        long ageRemoved = ageBeforeRegression - pawn.ageTracker.AgeBiologicalTicks;
-                        TrueAgeTracker trueAgeTracker = pawn.health?.hediffSet?
-                            .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
-                        trueAgeTracker?.RecordCryoRegenesisDeAging(ageRemoved);
+                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(
+                            pawn.ageTracker.AgeBiologicalTicks - rate,
+                            this.regenesisCycle.TargetAgeTicks);
                     }
                 }
             }

--- a/Source/CryoRegenesis.cs
+++ b/Source/CryoRegenesis.cs
@@ -293,7 +293,12 @@ public partial class Building_CryoRegenesis : Building_CryptosleepCasket, IThing
                     {
                         refuelable.ConsumeFuel(fuelConsumption * ((pawnAge - 10) * 0.1f));
 
-                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(pawn.ageTracker.AgeBiologicalTicks - rate, this.regenesisCycle.TargetAgeTicks);
+                        long ageBeforeRegression = pawn.ageTracker.AgeBiologicalTicks;
+                        pawn.ageTracker.AgeBiologicalTicks = Math.Max(ageBeforeRegression - rate, this.regenesisCycle.TargetAgeTicks);
+                        long ageRemoved = ageBeforeRegression - pawn.ageTracker.AgeBiologicalTicks;
+                        TrueAgeTracker trueAgeTracker = pawn.health?.hediffSet?
+                            .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+                        trueAgeTracker?.RecordCryoRegenesisDeAging(ageRemoved);
                     }
                 }
             }

--- a/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
+++ b/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
@@ -63,6 +63,9 @@ internal static class Patch_CompShuttle_SendLaunchedSignals
             return;
         }
 
+        // Snapshot contract passengers before vanilla destroys or hands off cargo.
+        system.SnapshotPickupLaunchClients(__instance.Transporter);
+
         if (!system.IsEmperorRegenContractActive()
             && !system.IsEmperorAssassinationEvacuationActive())
         {

--- a/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
+++ b/Source/Quests/Patch_CompShuttle_SendLaunchedSignals.cs
@@ -7,6 +7,9 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using HarmonyLib;
 using RimWorld;
 using Verse;
@@ -16,9 +19,36 @@ namespace BetterRimworlds.CryoRegenesis;
 /// When a regen pickup launches, free colonists are still in the transporter.
 /// Snapshot them here so the Imperial Court endgame still fires if they boarded
 /// and the ship left in the same tick as the last GameComponent refresh.
-[HarmonyPatch(typeof(CompShuttle), nameof(CompShuttle.SendLaunchedSignals))]
+///
+/// Signature differs by version:
+///   1.2:     SendLaunchedSignals(List&lt;CompTransporter&gt;)
+///   1.3+:    SendLaunchedSignals()
+[HarmonyPatch]
 internal static class Patch_CompShuttle_SendLaunchedSignals
 {
+    [HarmonyTargetMethod]
+    private static MethodBase TargetMethod()
+    {
+        // Prefer the parameterless form (1.3+), then the 1.2 List form.
+        MethodInfo method = AccessTools.Method(typeof(CompShuttle), "SendLaunchedSignals", Type.EmptyTypes);
+        if (method != null)
+        {
+            return method;
+        }
+
+        method = AccessTools.Method(
+            typeof(CompShuttle),
+            "SendLaunchedSignals",
+            new[] { typeof(List<CompTransporter>) });
+        if (method != null)
+        {
+            return method;
+        }
+
+        // Last resort: any method with that name (Harmony resolves overloads).
+        return AccessTools.Method(typeof(CompShuttle), "SendLaunchedSignals");
+    }
+
     [HarmonyPrefix]
     private static void Prefix(CompShuttle __instance)
     {

--- a/Source/Quests/RoyaltyRegenesisClient.cs
+++ b/Source/Quests/RoyaltyRegenesisClient.cs
@@ -22,6 +22,10 @@ public class RoyaltyRegenesisClient : IExposable
     public bool isPrisoner;
     public Faction sourceFaction;
 
+    /// Total biological age removed by CryoRegenesis when this contract began.
+    /// Lets completion distinguish actual treatment from time merely passing.
+    public long contractStartRemovedAgeTicks = -1L;
+
     /// Records the first time this client reaches the contracted age (the casket
     /// notifies the exact tick; the periodic check forgives natural aging afterwards).
     /// Survives subsequent natural aging so pickup success is not lost.
@@ -36,6 +40,7 @@ public class RoyaltyRegenesisClient : IExposable
         Scribe_Values.Look(ref this.returnByTick, "returnByTick", 0);
         Scribe_Values.Look(ref this.isPrisoner, "isPrisoner", false);
         Scribe_References.Look(ref this.sourceFaction, "sourceFaction");
+        Scribe_Values.Look(ref this.contractStartRemovedAgeTicks, "contractStartRemovedAgeTicks", -1L);
         Scribe_Values.Look(ref this.everReachedDesiredAge, "everReachedDesiredAge", false);
     }
 }

--- a/Source/Quests/RoyaltyRegenesisClient.cs
+++ b/Source/Quests/RoyaltyRegenesisClient.cs
@@ -23,6 +23,7 @@ public class RoyaltyRegenesisClient : IExposable
     public Faction sourceFaction;
 
     /// Total biological age removed by CryoRegenesis when this contract began.
+    /// -1L means no TrueAgeTracker was available when the contract began.
     /// Lets completion distinguish actual treatment from time merely passing.
     public long contractStartRemovedAgeTicks = -1L;
 
@@ -40,6 +41,7 @@ public class RoyaltyRegenesisClient : IExposable
         Scribe_Values.Look(ref this.returnByTick, "returnByTick", 0);
         Scribe_Values.Look(ref this.isPrisoner, "isPrisoner", false);
         Scribe_References.Look(ref this.sourceFaction, "sourceFaction");
+        // -1L preserves the unset value for contracts created without a tracker.
         Scribe_Values.Look(ref this.contractStartRemovedAgeTicks, "contractStartRemovedAgeTicks", -1L);
         Scribe_Values.Look(ref this.everReachedDesiredAge, "everReachedDesiredAge", false);
     }

--- a/Source/Quests/System/ActiveClients.cs
+++ b/Source/Quests/System/ActiveClients.cs
@@ -356,9 +356,17 @@ public partial class RoyaltyRegenesisQuestSystem
                 continue;
             }
 
-            // Off-map but not destroyed: 1.2 ExitMap, world pawn, or other leave path.
-            // Treating these as "remaining" used to skip Imperial Court entirely.
-            departed.Add(client);
+            // Off-map clients are departed only when this shuttle's launch snapshot
+            // proves they were aboard. ExitMap, world-pawn, and other leave paths stay
+            // pending instead of being credited to this pickup.
+            if (this.pickupLaunchClientPawnIds.Contains(client.pawn.thingIDNumber))
+            {
+                departed.Add(client);
+            }
+            else
+            {
+                remaining.Add(client);
+            }
         }
 
         // Emperor-stage branched endings (before partial-wave bookkeeping can soft-continue).
@@ -390,6 +398,7 @@ public partial class RoyaltyRegenesisQuestSystem
             .FirstOrDefault(c => c != null && !c.everReachedDesiredAge);
         if (unfinishedDeparture != null)
         {
+            this.pickupLaunchClientPawnIds.Clear();
             this.FinishContractAfterDeparture(
                 false,
                 failLabel: "CryoRegenesis contract expired",
@@ -418,6 +427,7 @@ public partial class RoyaltyRegenesisQuestSystem
                         && !this.WasSuccessfullyReturned(c.pawn))
                     .ToList();
                 this.ClearContractShuttle();
+                this.pickupLaunchClientPawnIds.Clear();
                 this.pickupShuttleSpawned = false;
                 this.pickupShuttleSpawnTick = -1;
                 this.pickupWindowEndTick = -1;
@@ -458,6 +468,7 @@ public partial class RoyaltyRegenesisQuestSystem
             // Shuttle left or was destroyed without taking any ready client.
             // Keep the contract; free the pad and recover with a later pickup.
             this.ClearContractShuttle();
+            this.pickupLaunchClientPawnIds.Clear();
             this.pickupShuttleSpawned = false;
             this.pickupShuttleSpawnTick = -1;
             this.pickupWindowEndTick = -1;
@@ -488,6 +499,7 @@ public partial class RoyaltyRegenesisQuestSystem
             + " returned=" + this.clientsSuccessfullyReturned
             + "/" + this.completionRewardClientCount
             + " readyThisWave=" + readyDeparted);
+        this.pickupLaunchClientPawnIds.Clear();
         this.FinishContractAfterDeparture(
             success,
             failLabel: "CryoRegenesis contract expired",
@@ -914,4 +926,25 @@ public partial class RoyaltyRegenesisQuestSystem
         CompTransporter transporter = shuttle.TryGetComp<CompTransporter>();
         return transporter != null && transporter.innerContainer.Contains(pawn);
     }
+
+    /// Records active clients in the exact pickup transporter before launch destroys
+    /// or hands off its contents (notably on 1.2).
+    public void SnapshotPickupLaunchClients(CompTransporter transporter)
+    {
+        this.pickupLaunchClientPawnIds.Clear();
+        if (transporter?.innerContainer == null)
+        {
+            return;
+        }
+
+        foreach (RoyaltyRegenesisClient client in this.activeClients)
+        {
+            Pawn pawn = client?.pawn;
+            if (pawn != null && !pawn.Destroyed && transporter.innerContainer.Contains(pawn))
+            {
+                this.pickupLaunchClientPawnIds.Add(pawn.thingIDNumber);
+            }
+        }
+    }
+
 }

--- a/Source/Quests/System/ActiveClients.cs
+++ b/Source/Quests/System/ActiveClients.cs
@@ -344,13 +344,21 @@ public partial class RoyaltyRegenesisQuestSystem
 
             if (this.IsClientAboardContractShuttle(client.pawn))
             {
-                // Only passengers in this shuttle's transporter actually departed.
+                // Still inside this shuttle's transporter (leave in progress).
                 departed.Add(client);
+                continue;
             }
-            else
+
+            // Map-reachable (spawned or in a casket) → stayed behind for a later wave.
+            if (this.IsClientAvailableOnMap(client.pawn))
             {
                 remaining.Add(client);
+                continue;
             }
+
+            // Off-map but not destroyed: 1.2 ExitMap, world pawn, or other leave path.
+            // Treating these as "remaining" used to skip Imperial Court entirely.
+            departed.Add(client);
         }
 
         // Emperor-stage branched endings (before partial-wave bookkeeping can soft-continue).

--- a/Source/Quests/System/Completion.cs
+++ b/Source/Quests/System/Completion.cs
@@ -77,7 +77,7 @@ public partial class RoyaltyRegenesisQuestSystem
         bool allEver = this.activeClients.All(c => c != null && c.everReachedDesiredAge);
         if (allEver && !this.IsDepartureSuccessBanked())
         {
-            this.LogRoyaltyDebug("All clients have latched everReachedDesiredAge → banking departure success.");
+            this.LogRoyaltyDebug("All clients have recorded everReachedDesiredAge → banking departure success.");
             this.MarkContractQuestCompleted();
         }
         else if (anyNew)
@@ -135,18 +135,18 @@ public partial class RoyaltyRegenesisQuestSystem
         return false;
     }
 
-    /// Current biological age is at or below the contracted target, forgiving natural
-    /// aging since the contract began.
+    /// Current biological age is at or below the contracted target, with a short
+    /// periodic-check allowance only when the casket has recorded sufficient treatment.
     ///
     /// The casket ejects a client the same tick it clamps them at the exact target, and
     /// they age +1 tick per tick from then on — so an exact comparison can only succeed
     /// on that single tick. The casket records that instant via
     /// <see cref="NotifyRegenesisTargetReached"/>, but if it is ever missed (pawn already
     /// ejected on load, older build, power loss on the boundary tick) an exact check can
-    /// never record again and the contract is unwinnable. Since a pawn ages at most
-    /// (now - contractStart) ticks during the contract, anyone who ever reached the
-    /// target still satisfies current <= target + elapsed, while a client whose
-    /// regression was never finished remains years over the allowance.
+    /// never record again and the contract is unwinnable. The fallback permits only one
+    /// check interval of natural aging and requires the casket to have removed at least
+    /// the age needed to reach the target during this contract. Contract time by itself
+    /// is never evidence that treatment occurred.
     private bool EvaluateAgeAgainstTarget(
         RoyaltyRegenesisClient client,
         out long currentTicks,
@@ -160,15 +160,30 @@ public partial class RoyaltyRegenesisQuestSystem
             return false;
         }
 
-        long agingAllowance = CheckIntervalTicks;
-        if (this.contractStartTick >= 0)
+        currentTicks = client.pawn.ageTracker.AgeBiologicalTicks;
+        allowedTicks = client.desiredAgeTicks + CheckIntervalTicks;
+        if (currentTicks <= client.desiredAgeTicks)
         {
-            agingAllowance += Math.Max(0, Find.TickManager.TicksGame - this.contractStartTick);
+            return true;
         }
 
-        currentTicks = client.pawn.ageTracker.AgeBiologicalTicks;
-        allowedTicks = client.desiredAgeTicks + agingAllowance;
-        return currentTicks <= allowedTicks;
+        if (currentTicks > allowedTicks)
+        {
+            return false;
+        }
+
+        TrueAgeTracker tracker = client.pawn.health?.hediffSet?
+            .GetFirstHediffOfDef(TrueAgeDefOf.TrueAgeTracker) as TrueAgeTracker;
+        if (tracker == null || client.contractStartRemovedAgeTicks < 0
+            || tracker.contractStartAgeTicks <= client.desiredAgeTicks)
+        {
+            return false;
+        }
+
+        long requiredAgeRemoved = tracker.contractStartAgeTicks - client.desiredAgeTicks;
+        long ageRemovedDuringContract = tracker.cryoRegenesisRemovedAgeTicks
+            - client.contractStartRemovedAgeTicks;
+        return ageRemovedDuringContract >= requiredAgeRemoved;
     }
 
     private void LogRoyaltyDebug(string message)

--- a/Source/Quests/System/Contracts.cs
+++ b/Source/Quests/System/Contracts.cs
@@ -419,6 +419,7 @@ public partial class RoyaltyRegenesisQuestSystem
         client.returnByTick = returnByTick;
         client.isPrisoner = isPrisoner;
         client.sourceFaction = sourceFaction;
+        client.contractStartRemovedAgeTicks = tracker?.cryoRegenesisRemovedAgeTicks ?? 0L;
         this.activeClients.Add(client);
         this.completionRewardClientCount = this.activeClients.Count;
 

--- a/Source/Quests/System/Contracts.cs
+++ b/Source/Quests/System/Contracts.cs
@@ -419,7 +419,7 @@ public partial class RoyaltyRegenesisQuestSystem
         client.returnByTick = returnByTick;
         client.isPrisoner = isPrisoner;
         client.sourceFaction = sourceFaction;
-        client.contractStartRemovedAgeTicks = tracker?.cryoRegenesisRemovedAgeTicks ?? 0L;
+        client.contractStartRemovedAgeTicks = tracker?.cryoRegenesisRemovedAgeTicks ?? -1L;
         this.activeClients.Add(client);
         this.completionRewardClientCount = this.activeClients.Count;
 

--- a/Source/Quests/System/Contracts.cs
+++ b/Source/Quests/System/Contracts.cs
@@ -429,6 +429,7 @@ public partial class RoyaltyRegenesisQuestSystem
     /// Only repairs clearly invalid (≤ 0) deadlines — does not push a live timer forward.
     private void EnsureContractDeadline()
     {
+        this.activeClients.RemoveAll(client => client == null);
         if (!this.activeClients.Any())
         {
             this.ClearContractTiming();

--- a/Source/Quests/System/Core.cs
+++ b/Source/Quests/System/Core.cs
@@ -43,6 +43,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
     /// Minimum how long a "someone is ready" pickup remains parked for manual loading.
     private const int ReadyPickupMinStayDays = 15;
+    private const int InitialUraniumRequirement = 500;
 
     /// Campaign pacing is shortened to a fixed five-day wait while debug mode is enabled.
     private int RandomizedCampaignDays(int minimumDays, int maximumDays)
@@ -621,6 +622,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             return;
         }
 
+        if (this.stage == RoyaltyRegenesisStage.NotStarted && !this.HasInitialCampaignResources())
+        {
+            return;
+        }
+
         int ticksGame = Find.TickManager.TicksGame;
         if (this.stage == RoyaltyRegenesisStage.NotStarted)
         {
@@ -646,6 +652,14 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         return Find.Maps.Any(map =>
             map.IsPlayerHome &&
             map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any());
+    }
+
+    private bool HasInitialCampaignResources()
+    {
+        return Find.Maps.Any(map =>
+            map.IsPlayerHome &&
+            map.listerBuildings.AllBuildingsColonistOfClass<Building_CryoRegenesis>().Any() &&
+            map.resourceCounter.GetCount(ThingDefOf.Uranium) >= InitialUraniumRequirement);
     }
 
     private Map GetTargetMap()

--- a/Source/Quests/System/Core.cs
+++ b/Source/Quests/System/Core.cs
@@ -133,6 +133,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// thingIDNumber of pawns that already returned successfully — never re-board or re-spawn them.
     private List<int> returnedClientPawnIds = new List<int>();
 
+    /// Active contract clients found in this pickup shuttle's transporter at launch.
+    /// Kept through container destruction so departure accounting can identify only
+    /// passengers that actually boarded this shuttle.
+    private List<int> pickupLaunchClientPawnIds = new List<int>();
+
     /// Labels of free colony colonists last seen aboard the Emperor-stage pickup shuttle.
     /// Snapshotted every tick while the ship is parked so departure (which destroys
     /// container contents) can still fire the Imperial Court endgame.
@@ -488,6 +493,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.nextWavePickupTick, "crRoyalNextWavePickupTick", -1);
         Scribe_Values.Look(ref this.clientsSuccessfullyReturned, "crRoyalClientsSuccessfullyReturned", 0);
         Scribe_Collections.Look(ref this.returnedClientPawnIds, "crRoyalReturnedClientPawnIds", LookMode.Value);
+        Scribe_Collections.Look(ref this.pickupLaunchClientPawnIds, "crRoyalPickupLaunchClientPawnIds", LookMode.Value);
         Scribe_Collections.Look(ref this.emperorShuttleColonistEscapeeLabels, "crRoyalEmperorShuttleColonistEscapees", LookMode.Value);
         Scribe_Values.Look(ref this.emperorEscapeeSnapshotSealed, "crRoyalEmperorEscapeeSnapshotSealed", false);
         Scribe_Values.Look(ref this.emperorAssassinationHumanEscapeeCount, "crRoyalEmperorAssassinationHumanEscapees", 0);
@@ -527,6 +533,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
             if (this.returnedClientPawnIds == null)
             {
                 this.returnedClientPawnIds = new List<int>();
+            }
+
+            if (this.pickupLaunchClientPawnIds == null)
+            {
+                this.pickupLaunchClientPawnIds = new List<int>();
             }
 
             if (this.emperorShuttleColonistEscapeeLabels == null)

--- a/Source/Quests/System/Core.cs
+++ b/Source/Quests/System/Core.cs
@@ -452,7 +452,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
 
         client.everReachedDesiredAge = true;
         system.LogRoyaltyDebug(
-            "Client target latched directly from casket: "
+            "Client target recorded directly from casket: "
             + (pawn?.Name?.ToStringShort ?? "?")
             + " bioTicks=" + (pawn?.ageTracker?.AgeBiologicalTicks ?? -1)
             + " desired=" + client.desiredAgeTicks);

--- a/Source/Quests/System/Core.cs
+++ b/Source/Quests/System/Core.cs
@@ -138,6 +138,11 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
     /// During assassination evacuation this list also includes colony pets for credits.
     private List<string> emperorShuttleColonistEscapeeLabels = new List<string>();
 
+    /// Once the Imperial shuttle is launching, free-colonist labels must not be
+    /// recomputed from the transporter. Stargate handoff empties that container
+    /// before the ship leaves the map, and a later tick would wipe the endgame list.
+    private bool emperorEscapeeSnapshotSealed;
+
     /// Humanlike passengers recorded for the assassination shuttle launch statistic.
     /// Pets stay on the label list for credits but must not inflate colonistsLaunched.
     private int emperorAssassinationHumanEscapeeCount;
@@ -483,6 +488,7 @@ public partial class RoyaltyRegenesisQuestSystem : GameComponent
         Scribe_Values.Look(ref this.clientsSuccessfullyReturned, "crRoyalClientsSuccessfullyReturned", 0);
         Scribe_Collections.Look(ref this.returnedClientPawnIds, "crRoyalReturnedClientPawnIds", LookMode.Value);
         Scribe_Collections.Look(ref this.emperorShuttleColonistEscapeeLabels, "crRoyalEmperorShuttleColonistEscapees", LookMode.Value);
+        Scribe_Values.Look(ref this.emperorEscapeeSnapshotSealed, "crRoyalEmperorEscapeeSnapshotSealed", false);
         Scribe_Values.Look(ref this.emperorAssassinationHumanEscapeeCount, "crRoyalEmperorAssassinationHumanEscapees", 0);
         Scribe_Values.Look(ref this.emperorColonistEndgameTriggered, "crRoyalEmperorColonistEndgameTriggered", false);
         Scribe_Values.Look(ref this.emperorNobleRequirementAnnounced, "crRoyalEmperorNobleRequirementAnnounced", false);

--- a/Source/Quests/System/Emperor.cs
+++ b/Source/Quests/System/Emperor.cs
@@ -1260,7 +1260,38 @@ public partial class RoyaltyRegenesisQuestSystem
 
         this.EjectClientsFromCaskets(map, guests.Concat(new[] { assassin }).ToList());
 
-        List<Pawn> shuttleParty = guests.Concat(new[] { assassin }).Distinct().ToList();
+        // Emperor-wife clients escape with the assassin as player-faction passengers.
+        // Every other Imperial survivor remains on the map as a guaranteed hostile
+        // Empire pawn.
+        HashSet<Pawn> wives = new HashSet<Pawn>(
+            this.activeClients
+                .Where(client => client?.role != null
+                    && client.role.IndexOf("imperial wife", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Select(client => client?.pawn)
+                .Where(pawn => pawn != null));
+        foreach (Pawn guest in guests)
+        {
+            this.ReleaseFromCurrentLord(guest);
+            if (wives.Contains(guest))
+            {
+                if (guest.Faction != Faction.OfPlayer)
+                {
+                    guest.SetFaction(Faction.OfPlayer);
+                }
+            }
+            else if (faction != null && guest.Faction != faction)
+            {
+                guest.SetFaction(faction);
+            }
+        }
+
+        this.MakeFactionHostileToPlayer(faction, guests.Any(guest => !wives.Contains(guest)));
+
+        List<Pawn> shuttleParty = wives
+            .Where(pawn => pawn != null && !pawn.Destroyed && !pawn.Dead)
+            .Concat(new[] { assassin })
+            .Distinct()
+            .ToList();
         if (!this.pickupShuttleSpawned || this.GetUsableContractShuttle(map) == null)
         {
             this.SpawnPickupShuttle(map, shuttleParty, faction, longStay: true);
@@ -1272,14 +1303,15 @@ public partial class RoyaltyRegenesisQuestSystem
         if (comp != null)
         {
             this.ConfigureContractShuttleEmbarkRules(comp);
-            // Assassin is required to leave; guests should leave with the ship when possible.
+            // The assassin and every Emperor-wife client must leave. Other Imperial
+            // survivors stay on-map and are not retained in the shuttle.
             comp.requiredPawns.Clear();
             comp.requiredPawns.Add(assassin);
-            foreach (Pawn guest in guests)
+            foreach (Pawn wife in wives)
             {
-                if (!comp.requiredPawns.Contains(guest))
+                if (!wife.Destroyed && !wife.Dead && !comp.requiredPawns.Contains(wife))
                 {
-                    comp.requiredPawns.Add(guest);
+                    comp.requiredPawns.Add(wife);
                 }
             }
 
@@ -1298,11 +1330,37 @@ public partial class RoyaltyRegenesisQuestSystem
         }
 #endif
 
-        // Stuff Imperial guests only — the assassin and free colonists board themselves.
+        // Remove non-wife Imperial survivors that boarded before the assassination began,
+        // then load all wives so they cannot be left behind.
         if (transporter != null)
         {
+            foreach (Pawn pawn in guests.Where(pawn => !wives.Contains(pawn)))
+            {
+                if (!transporter.innerContainer.Contains(pawn))
+                {
+                    continue;
+                }
+
+                if (!transporter.innerContainer.TryDrop(
+                    pawn,
+                    shuttle.PositionHeld,
+                    map,
+                    ThingPlaceMode.Near,
+                    out Thing _))
+                {
+                    Log.Warning(
+                        "[CryoRegenesis] Could not unload Imperial survivor "
+                        + pawn.LabelShort + " from assassination shuttle.");
+                }
+            }
+
             foreach (Pawn pawn in guests)
             {
+                if (!wives.Contains(pawn))
+                {
+                    continue;
+                }
+
                 if (transporter.innerContainer.Contains(pawn))
                 {
                     continue;
@@ -1313,10 +1371,19 @@ public partial class RoyaltyRegenesisQuestSystem
                     pawn.DeSpawn();
                 }
 
-                if (!pawn.Destroyed && !transporter.innerContainer.Contains(pawn))
+                if (pawn.Destroyed || transporter.innerContainer.TryAddOrTransfer(pawn, false))
                 {
-                    transporter.innerContainer.TryAddOrTransfer(pawn, false);
+                    continue;
                 }
+
+                // Never leave a wife despawned/unheld if the transporter rejects her.
+                if (!pawn.Spawned && !pawn.Destroyed)
+                {
+                    GenSpawn.Spawn(pawn, shuttle.PositionHeld, map, WipeMode.Vanish);
+                }
+                Log.Warning(
+                    "[CryoRegenesis] Could not load Emperor-wife client "
+                    + pawn.LabelShort + " onto assassination shuttle.");
             }
         }
 
@@ -1324,6 +1391,32 @@ public partial class RoyaltyRegenesisQuestSystem
         this.LogRoyaltyDebug(
             "Assassination evacuation shuttle ready. Required assassin="
             + assassin.LabelShort + " imperialGuests=" + guests.Count + ".");
+    }
+
+    private void MakeFactionHostileToPlayer(Faction faction, bool required)
+    {
+        if (!required || faction == null || faction == Faction.OfPlayer)
+        {
+            return;
+        }
+
+#if RIMWORLD12
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            -1000,
+            false,
+            false,
+            "CryoRegenesis assassination",
+            null);
+#else
+        faction.TryAffectGoodwillWith(
+            Faction.OfPlayer,
+            -1000,
+            false,
+            false,
+            HistoryEventDefOf.MemberKilled,
+            null);
+#endif
     }
 
     private void ApplyAssassinationTrustBreak(Faction empire, Pawn assassin)

--- a/Source/Quests/System/Emperor.cs
+++ b/Source/Quests/System/Emperor.cs
@@ -7,6 +7,7 @@
  * This file is licensed under the MIT License.
  */
 
+using System;
 using System.Reflection;
 using System.Text;
 using HarmonyLib;
@@ -27,7 +28,23 @@ public partial class RoyaltyRegenesisQuestSystem
 {
     /// Called from CompShuttle.SendLaunchedSignals just before cargo is destroyed.
     /// Ensures same-tick board-and-launch still records free colonists for the endgame.
+    /// Must never throw: on 1.2 CompShuttle.Send sets sending=true before this runs, and an
+    /// exception leaves the shuttle permanently stuck on the pad.
     public void NotifyEmperorPickupLaunching(CompShuttle shuttleComp)
+    {
+        try
+        {
+            this.NotifyEmperorPickupLaunchingInner(shuttleComp);
+        }
+        catch (Exception e)
+        {
+            Log.Error(
+                "[CryoRegenesis] NotifyEmperorPickupLaunching failed (shuttle leave must continue): "
+                + e);
+        }
+    }
+
+    private void NotifyEmperorPickupLaunchingInner(CompShuttle shuttleComp)
     {
         if (shuttleComp?.parent == null || this.emperorColonistEndgameTriggered)
         {
@@ -48,6 +65,11 @@ public partial class RoyaltyRegenesisQuestSystem
             // Assassin is a required passenger; companions and pets may leave freely.
             this.CaptureFreeColonistsFromTransporter(transporter);
             this.CaptureAssassinationPassengers(transporter);
+            this.SealEmperorEscapeeSnapshot();
+            StargateShuttleBuffer.TryTransmitFreeColonistsFromTransporter(
+                transporter,
+                this.IsFreeColonyColonistForEmperorEndgame,
+                this.LogRoyaltyDebug);
             return;
         }
 
@@ -61,6 +83,72 @@ public partial class RoyaltyRegenesisQuestSystem
 
         this.CaptureFreeColonistsFromTransporter(transporter);
         this.RefreshEmperorEndgameCandidates(transporter);
+        // Seal before Stargate handoff: that path pulls free colonists out of the shuttle,
+        // and the per-tick snapshot would otherwise clear the endgame labels next.
+        this.SealEmperorEscapeeSnapshot();
+
+        this.CacheEmperorClient();
+        Pawn emperorPawn = this.emperor;
+        bool emperorAboard = emperorPawn != null
+            && !emperorPawn.Destroyed
+            && (this.IsClientAboardContractShuttle(emperorPawn)
+                || (transporter?.innerContainer != null
+                    && transporter.innerContainer.Contains(emperorPawn)));
+        bool freeColonistsLeaving = this.emperorShuttleColonistEscapeeLabels != null
+            && this.emperorShuttleColonistEscapeeLabels.Any();
+
+        // Fire Imperial Court at launch — do not wait for departure bookkeeping.
+        // On 1.2 guests ExitMap without being Destroyed, and older departure logic
+        // could mis-classify them as still on the map and skip the ending entirely.
+        if (freeColonistsLeaving && emperorAboard)
+        {
+            Log.Message(
+                "[CryoRegenesis Royalty] Launch endgame check: free colonists leaving with Emperor aboard — firing Imperial Court.");
+            this.TryTriggerEmperorColonistEndgameFromSnapshot("launch with Emperor aboard");
+        }
+        else if (freeColonistsLeaving && this.IsEmperorInUnpoweredCryoCasket())
+        {
+            // Usurpation path: free colonists leave while the living Emperor stays sealed.
+            Log.Message(
+                "[CryoRegenesis Royalty] Launch endgame check: free colonists leaving with Emperor sealed — firing Keep What You Kill.");
+            List<RoyaltyRegenesisClient> remaining = this.activeClients
+                .Where(c => c?.pawn != null && (c.pawn == emperorPawn || this.IsClientAvailableOnMap(c.pawn)))
+                .ToList();
+            List<RoyaltyRegenesisClient> departed = this.activeClients
+                .Where(c => c != null && !remaining.Contains(c))
+                .ToList();
+            this.TryTriggerYouKeepWhatYouKillEndgame(remaining, departed, "launch with Emperor sealed");
+        }
+        else
+        {
+            Log.Message(
+                "[CryoRegenesis Royalty] Launch endgame check: freeColonists="
+                + freeColonistsLeaving
+                + " emperorAboard=" + emperorAboard
+                + " emperorSealed=" + this.IsEmperorInUnpoweredCryoCasket()
+                + " labels=" + (this.emperorShuttleColonistEscapeeLabels?.Count ?? 0));
+        }
+
+        // Soft Stargate integration: never let file I/O abort CompShuttle.Send.
+        try
+        {
+            StargateShuttleBuffer.TryTransmitFreeColonistsFromTransporter(
+                transporter,
+                this.IsFreeColonyColonistForEmperorEndgame,
+                this.LogRoyaltyDebug);
+        }
+        catch (Exception e)
+        {
+            Log.Error(
+                "[CryoRegenesis] Stargate shuttle buffer write failed (ignored so launch continues): "
+                + e);
+        }
+    }
+
+    /// Freeze free-colonist escapee labels once launch has snapshotted them.
+    private void SealEmperorEscapeeSnapshot()
+    {
+        this.emperorEscapeeSnapshotSealed = true;
     }
 
     /// Unloads free colony colonists from the Imperial shuttle just before it launches when
@@ -124,7 +212,7 @@ public partial class RoyaltyRegenesisQuestSystem
     /// Labels are stored because the shuttle destroys container contents on launch.
     private void RefreshEmperorShuttleColonistSnapshot()
     {
-        if (this.emperorColonistEndgameTriggered)
+        if (this.emperorColonistEndgameTriggered || this.emperorEscapeeSnapshotSealed)
         {
             return;
         }
@@ -148,7 +236,7 @@ public partial class RoyaltyRegenesisQuestSystem
 
     private void CaptureFreeColonistsFromTransporter(CompTransporter transporter)
     {
-        if (transporter?.innerContainer == null)
+        if (this.emperorEscapeeSnapshotSealed || transporter?.innerContainer == null)
         {
             return;
         }
@@ -925,7 +1013,7 @@ public partial class RoyaltyRegenesisQuestSystem
 
     private void CaptureAssassinationPassengers(CompTransporter transporter)
     {
-        if (transporter?.innerContainer == null)
+        if (this.emperorEscapeeSnapshotSealed || transporter?.innerContainer == null)
         {
             return;
         }

--- a/Source/Quests/System/Pickup.cs
+++ b/Source/Quests/System/Pickup.cs
@@ -596,6 +596,10 @@ public partial class RoyaltyRegenesisQuestSystem
 
     private bool SpawnPickupShuttle(Map map, List<Pawn> living, Faction faction, bool longStay = false)
     {
+        // A new pickup gets a fresh launch manifest; the previous wave has already
+        // completed or was cleared before this method is called.
+        this.pickupLaunchClientPawnIds.Clear();
+
         // Only map-held remaining clients. Never re-import world pawns who already returned.
         List<Pawn> passengers = (living ?? new List<Pawn>())
             .Where(p => p != null && !p.Destroyed && !p.Dead
@@ -850,6 +854,7 @@ public partial class RoyaltyRegenesisQuestSystem
 #if !RIMWORLD12
         this.contractTransportShip = null;
 #endif
+        this.pickupLaunchClientPawnIds.Clear();
         // Do not clear emperorShuttleColonistEscapeeLabels here — FinishContractAfterDeparture
         // may still need them after HandleContractShuttleDeparture already nulls the ship ref.
     }

--- a/Source/Quests/System/Pickup.cs
+++ b/Source/Quests/System/Pickup.cs
@@ -174,14 +174,14 @@ public partial class RoyaltyRegenesisQuestSystem
         }
         else
         {
-            bool latchedSuccess = this.IsDepartureSuccessBanked()
+            bool recordedSuccess = this.IsDepartureSuccessBanked()
                 || (this.activeClients.Any()
                     && this.activeClients.All(c => c != null && c.everReachedDesiredAge));
-            if (latchedSuccess != success)
+            if (recordedSuccess != success)
             {
                 this.LogRoyaltyDebug(
-                    "Finish success override: arg=" + success + " → latched=" + latchedSuccess);
-                success = latchedSuccess;
+                    "Finish success override: arg=" + success + " → recorded=" + recordedSuccess);
+                success = recordedSuccess;
             }
         }
 

--- a/Source/Quests/System/Pickup.cs
+++ b/Source/Quests/System/Pickup.cs
@@ -857,6 +857,7 @@ public partial class RoyaltyRegenesisQuestSystem
     private void ClearEmperorShuttleColonistSnapshot()
     {
         this.emperorShuttleColonistEscapeeLabels?.Clear();
+        this.emperorEscapeeSnapshotSealed = false;
         if (!this.emperorColonistEndgameTriggered)
         {
             this.emperorUsurpationCountCandidate = null;

--- a/Source/Quests/System/StargateShuttleBuffer.cs
+++ b/Source/Quests/System/StargateShuttleBuffer.cs
@@ -1,0 +1,440 @@
+/*
+ * This file is part of CryoRegenesis, a Better Rimworlds Project.
+ *
+ * Copyright © 2020-2026 Theodore R. Smith
+ * Author: Theodore R. Smith <hopeseekr@gmail.com>
+ *
+ * This file is licensed under the MIT License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using RimWorld;
+using Verse;
+
+namespace BetterRimworlds.CryoRegenesis;
+
+/// Soft bridge to BetterRimworlds.Stargate: move free colonists from the Emperor
+/// pickup into a live gate buffer, write them to Shuttle.xml, then remove them from
+/// the world so they leave with the Emperor (serialized for a new-game recall).
+///
+/// Stargate is optional. Presence is detected by the unique TransdimensionalStargate def.
+internal static class StargateShuttleBuffer
+{
+    private const string StargateProbeDefName = "TransdimensionalStargate";
+
+    private static readonly string[] GateDefNames =
+    {
+        "Stargate",
+        "TransdimensionalStargate",
+        "OffWorldStargate",
+    };
+
+    private static bool? stargateModPresent;
+    private static MethodInfo saveThingsMethod;
+    private static MethodInfo transmitContentsMethod;
+    private static bool saveMethodResolved;
+    private static bool transmitMethodResolved;
+
+    /// True when the Stargate mod has loaded its defs (unique probe def).
+    public static bool IsStargateModLoaded()
+    {
+        if (stargateModPresent.HasValue)
+        {
+            return stargateModPresent.Value;
+        }
+
+        stargateModPresent = DefDatabase<ThingDef>.GetNamedSilentFail(StargateProbeDefName) != null;
+        return stargateModPresent.Value;
+    }
+
+    /// Transfer free-colonist escapees from the Imperial shuttle into a map Stargate buffer,
+    /// serialize only those pawns to …/Stargate/Shuttle.xml, then destroy them so they
+    /// leave this world (they must not remain sitting in the gate after launch).
+    /// Returns true when at least one colonist was written.
+    public static bool TryTransmitFreeColonistsFromTransporter(
+        CompTransporter transporter,
+        Func<Pawn, bool> isEscapee,
+        Action<string> log = null)
+    {
+        // Outer guard: never throw into CompShuttle.Send (1.2 sets sending=true first).
+        try
+        {
+            return TryTransmitFreeColonistsFromTransporterInner(transporter, isEscapee, log);
+        }
+        catch (Exception e)
+        {
+            Log.Error(
+                "[CryoRegenesis] StargateShuttleBuffer.TryTransmit failed (ignored): " + e);
+            return false;
+        }
+    }
+
+    private static bool TryTransmitFreeColonistsFromTransporterInner(
+        CompTransporter transporter,
+        Func<Pawn, bool> isEscapee,
+        Action<string> log)
+    {
+        if (transporter?.innerContainer == null || isEscapee == null)
+        {
+            return false;
+        }
+
+        if (!IsStargateModLoaded())
+        {
+            log?.Invoke(
+                "Stargate mod not present (no " + StargateProbeDefName
+                + " def) — skip shuttle buffer write.");
+            return false;
+        }
+
+        List<Pawn> escapees = transporter.innerContainer
+            .OfType<Pawn>()
+            .Where(p => p != null && !p.Destroyed && isEscapee(p))
+            .ToList();
+        if (!escapees.Any())
+        {
+            return false;
+        }
+
+        Map map = transporter.parent?.MapHeld;
+        if (map == null)
+        {
+            log?.Invoke("No map for Imperial shuttle — cannot find a Stargate.");
+            return false;
+        }
+
+        Thing gate = FindStargateOnMap(map);
+        if (gate == null)
+        {
+            log?.Invoke("No Stargate on map — skip shuttle buffer write for "
+                + escapees.Count + " colonist(s).");
+            return false;
+        }
+
+        if (!(gate is IThingHolder holder))
+        {
+            log?.Invoke("Stargate building is not an IThingHolder.");
+            return false;
+        }
+
+        ThingOwner buffer = holder.GetDirectlyHeldThings();
+        if (buffer == null)
+        {
+            log?.Invoke("Stargate GetDirectlyHeldThings() returned null.");
+            return false;
+        }
+
+        // Drop free colonists from requiredPawns so a failed mid-leave cannot lock Send forever.
+        CompShuttle shuttleComp = transporter.parent?.TryGetComp<CompShuttle>();
+        if (shuttleComp?.requiredPawns != null)
+        {
+            shuttleComp.requiredPawns.RemoveAll(
+                p => p == null || p.Destroyed || escapees.Contains(p));
+        }
+
+        List<Pawn> transferred = new List<Pawn>();
+        foreach (Pawn pawn in escapees)
+        {
+            // Pull out of the transporter first so the shuttle will not destroy them,
+            // then let StargateBuffer.TryAdd attach the traveler implant and hold them.
+            if (transporter.innerContainer.Contains(pawn))
+            {
+                transporter.innerContainer.Remove(pawn);
+            }
+
+            if (buffer.TryAdd(pawn, canMergeWithExistingStacks: false))
+            {
+                transferred.Add(pawn);
+                continue;
+            }
+
+            bool returnedToShuttle = !pawn.Destroyed
+                && transporter.innerContainer.TryAddOrTransfer(pawn, false);
+            if (!returnedToShuttle && !pawn.Spawned && !pawn.Destroyed)
+            {
+                GenSpawn.Spawn(pawn, transporter.parent.PositionHeld, map, WipeMode.Vanish);
+            }
+
+            log?.Invoke("Failed to add " + pawn.LabelShort + " to Stargate buffer; "
+                + (returnedToShuttle ? "returned to shuttle." : "returned to the map."));
+        }
+
+        if (!transferred.Any())
+        {
+            return false;
+        }
+
+        if (!TrySaveEscapeesToShuttleXml(buffer, transferred, log))
+        {
+            // Serialization failed — leave them in the gate buffer rather than destroy
+            // living colonists that never made it to Shuttle.xml.
+            log?.Invoke(
+                "Shuttle.xml write failed; " + transferred.Count
+                + " colonist(s) remain in the Stargate buffer.");
+            return false;
+        }
+
+        // They have been serialized for a new-game recall and must leave this world.
+        // Leaving them in the gate would strand "escaped" colonists on the map and
+        // break the Imperial Court / usurpation endgames' "they left" fiction.
+        foreach (Pawn pawn in transferred)
+        {
+            if (buffer.Contains(pawn))
+            {
+                buffer.Remove(pawn);
+            }
+
+            if (pawn != null && !pawn.Destroyed)
+            {
+                pawn.Destroy(DestroyMode.Vanish);
+            }
+        }
+
+        Find.ColonistBar?.MarkColonistsDirty();
+        log?.Invoke(
+            "Transmitted " + transferred.Count
+            + " free colonist(s) to Stargate Shuttle.xml and removed them from the world via "
+            + gate.LabelShort + ".");
+        return true;
+    }
+
+    private static bool TrySaveEscapeesToShuttleXml(
+        ThingOwner buffer,
+        List<Pawn> escapees,
+        Action<string> log)
+    {
+        string shuttlePath = ResolveShuttleBufferPath(buffer);
+        if (shuttlePath.NullOrEmpty())
+        {
+            log?.Invoke("Could not resolve Stargate Shuttle.xml path.");
+            return false;
+        }
+
+        // Prefer saving only the escapees so pre-existing gate cargo is not mixed in.
+        if (TryResolveSaveThings(buffer.GetType(), log)
+            && TryInvokeSaveThings(escapees.Cast<Thing>().ToList(), shuttlePath, log))
+        {
+            return true;
+        }
+
+        // Fallback: TransmitContents(keepContents: true) writes the whole buffer, then
+        // the caller still destroys only the escapees we transferred.
+        if (!TryResolveTransmitContents(buffer.GetType(), log))
+        {
+            return false;
+        }
+
+        try
+        {
+            transmitContentsMethod.Invoke(buffer, new object[] { true });
+            log?.Invoke(
+                "Saved Shuttle.xml via TransmitContents(keepContents: true) fallback.");
+            return true;
+        }
+        catch (Exception e)
+        {
+            Log.Error(
+                "[CryoRegenesis] Stargate TransmitContents(keepContents: true) failed: "
+                + e);
+            return false;
+        }
+    }
+
+    private static string ResolveShuttleBufferPath(ThingOwner buffer)
+    {
+        if (buffer == null)
+        {
+            return null;
+        }
+
+        // Match StargateBuffer field when present.
+        FieldInfo field = buffer.GetType().GetField(
+            "ShuttleBufferFilePath",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null)
+        {
+            string path = field.GetValue(buffer) as string;
+            if (!path.NullOrEmpty())
+            {
+                return path;
+            }
+        }
+
+        // Same layout StargateBuffer.EnsurePathsInitialized uses.
+        string baseDirectory = Path.Combine(GenFilePaths.SaveDataFolderPath, "Stargate");
+        if (!Directory.Exists(baseDirectory))
+        {
+            Directory.CreateDirectory(baseDirectory);
+        }
+
+        return Path.Combine(baseDirectory, "Shuttle.xml");
+    }
+
+    private static bool TryResolveSaveThings(Type bufferType, Action<string> log)
+    {
+        if (saveMethodResolved)
+        {
+            return saveThingsMethod != null;
+        }
+
+        saveMethodResolved = true;
+
+        // Prefer the type from the live Stargate assembly (buffer's assembly).
+        Type saveType = bufferType.Assembly.GetType(
+            "Enhanced_Development.Stargate.Saving.SaveThings");
+        if (saveType == null)
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    saveType = assembly.GetType(
+                        "Enhanced_Development.Stargate.Saving.SaveThings");
+                    if (saveType != null)
+                    {
+                        break;
+                    }
+                }
+                catch
+                {
+                    // Skip dynamic / reflection-only assemblies.
+                }
+            }
+        }
+
+        if (saveType == null)
+        {
+            log?.Invoke(
+                "SaveThings type not found — will try TransmitContents(keepContents) fallback.");
+            return false;
+        }
+
+        saveThingsMethod = saveType.GetMethod(
+            "save",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(List<Thing>), typeof(string) },
+            modifiers: null);
+
+        if (saveThingsMethod == null)
+        {
+            log?.Invoke(
+                "SaveThings.save(List<Thing>, string) not found — will try TransmitContents fallback.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryInvokeSaveThings(
+        List<Thing> things,
+        string path,
+        Action<string> log)
+    {
+        if (saveThingsMethod == null || things == null || path.NullOrEmpty())
+        {
+            return false;
+        }
+
+        try
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (!directory.NullOrEmpty() && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            saveThingsMethod.Invoke(null, new object[] { things, path });
+            return true;
+        }
+        catch (Exception e)
+        {
+            Log.Error("[CryoRegenesis] SaveThings.save for Shuttle.xml failed: " + e);
+            log?.Invoke("SaveThings.save failed: " + e.Message);
+            return false;
+        }
+    }
+
+    private static Thing FindStargateOnMap(Map map)
+    {
+        if (map == null)
+        {
+            return null;
+        }
+
+        foreach (string defName in GateDefNames)
+        {
+            ThingDef def = DefDatabase<ThingDef>.GetNamedSilentFail(defName);
+            if (def == null)
+            {
+                continue;
+            }
+
+            // Prefer player-owned buildings; fall back to any thing of that def.
+            Building colonistGate = map.listerBuildings.allBuildingsColonist
+                .FirstOrDefault(b => b.def == def);
+            if (colonistGate != null)
+            {
+                return colonistGate;
+            }
+
+            Thing any = map.listerThings.ThingsOfDef(def).FirstOrDefault();
+            if (any != null)
+            {
+                return any;
+            }
+        }
+
+        // Def names can lag a WIP build; match Stargate building classes by name.
+        foreach (Building building in map.listerBuildings.allBuildingsColonist)
+        {
+            string typeName = building.GetType().Name;
+            if (typeName == "Building_Stargate"
+                || typeName == "Building_TransdimensionalStargate"
+                || typeName == "Building_OffWorldStargate")
+            {
+                return building;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveTransmitContents(Type bufferType, Action<string> log)
+    {
+        if (transmitMethodResolved)
+        {
+            if (transmitContentsMethod == null)
+            {
+                log?.Invoke(
+                    "StargateBuffer.TransmitContents(bool) was not found earlier — "
+                    + "rebuild Stargate with the keepContents API.");
+            }
+
+            return transmitContentsMethod != null;
+        }
+
+        transmitMethodResolved = true;
+        transmitContentsMethod = bufferType.GetMethod(
+            "TransmitContents",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(bool) },
+            modifiers: null);
+
+        if (transmitContentsMethod == null)
+        {
+            log?.Invoke(
+                "StargateBuffer.TransmitContents(bool) not found on "
+                + bufferType.FullName
+                + " — rebuild Stargate with the keepContents API.");
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## **CodeAnt-AI Description**
Preserve Emperor escapees across Stargate travel and tighten Regen Quest completion rules

### What Changed
- Emperor shuttle escapees are saved to Stargate Shuttle.xml and removed from the departing world so they can continue into a new game when Stargate is available.
- Emperor wives now escape with the assassin, while surviving guards and other Imperial guests remain on the map and turn hostile.
- Regen Quests now require 500 Uranium to begin.
- Contracts no longer complete merely because time passed; clients must have received enough CryoRegenesis treatment to reach their target age.
- Shuttle departures and contract deadlines handle off-map passengers, missing clients, and edge cases without skipping endgame outcomes or incorrectly completing contracts.

### Impact
`✅ Escapees continue through Stargate recalls`
`✅ Clearer Imperial assassination outcomes`
`✅ Fewer contracts completed without treatment`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
